### PR TITLE
Add cerebras llama model and provider

### DIFF
--- a/ada_backend/database/seed/utils.py
+++ b/ada_backend/database/seed/utils.py
@@ -59,6 +59,8 @@ OPTIONS_COMPLETION_MODELS = [
     # SelectOption(value="anthropic:claude-3.7-sonnet", label="Claude 3.7 Sonnet"),
     # SelectOption(value="anthropic:claude-3.5-sonnet", label="Claude 3.5 Sonnet"),
     # SelectOption(value="anthropic:claude-3.5-haiku", label="Claude 3.5 Haiku"),
+    # Cerebras
+    SelectOption(value="cerebras:llama-3.3-70b", label="Llama 3.3 70B (Cerebras)"),
 ]
 
 OPTIONS_EMBEDDING_MODELS = [

--- a/engine/llm_services/llm_service.py
+++ b/engine/llm_services/llm_service.py
@@ -156,6 +156,33 @@ class CompletionService(LLMService):
                 )
                 return response.output_text
 
+            case "cerebras":
+                import openai
+
+                if self._api_key is None:
+                    raise ValueError("API key is required for Cerebras provider")
+                
+                if self._base_url is None:
+                    self._base_url = "https://api.cerebras.ai/v1"
+
+                client = openai.OpenAI(
+                    api_key=self._api_key,
+                    base_url=self._base_url,
+                )
+                response = client.chat.completions.create(
+                    model=self._model_name,
+                    messages=messages,
+                    temperature=self._temperature,
+                )
+                span.set_attributes(
+                    {
+                        SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: response.usage.completion_tokens,
+                        SpanAttributes.LLM_TOKEN_COUNT_PROMPT: response.usage.prompt_tokens,
+                        SpanAttributes.LLM_TOKEN_COUNT_TOTAL: response.usage.total_tokens,
+                    }
+                )
+                return response.choices[0].message.content
+
             case _:
                 import openai
 
@@ -287,6 +314,35 @@ class CompletionService(LLMService):
                 if self._api_key is None:
                     self._api_key = settings.OPENAI_API_KEY
                 client = openai.OpenAI(api_key=self._api_key)
+                response = client.chat.completions.create(
+                    model=self._model_name,
+                    messages=messages,
+                    tools=openai_tools,
+                    temperature=self._temperature,
+                    stream=stream,
+                    tool_choice=tool_choice,
+                )
+                span.set_attributes(
+                    {
+                        SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: response.usage.completion_tokens,
+                        SpanAttributes.LLM_TOKEN_COUNT_PROMPT: response.usage.prompt_tokens,
+                        SpanAttributes.LLM_TOKEN_COUNT_TOTAL: response.usage.total_tokens,
+                    }
+                )
+                return response
+            case "cerebras":
+                import openai
+
+                if self._api_key is None:
+                    raise ValueError("API key is required for Cerebras provider")
+                
+                if self._base_url is None:
+                    self._base_url = "https://api.cerebras.ai/v1"
+
+                client = openai.OpenAI(
+                    api_key=self._api_key,
+                    base_url=self._base_url,
+                )
                 response = client.chat.completions.create(
                     model=self._model_name,
                     messages=messages,

--- a/engine/llm_services/llm_service.py
+++ b/engine/llm_services/llm_service.py
@@ -157,22 +157,17 @@ class CompletionService(LLMService):
                 return response.output_text
 
             case "cerebras":
-                import openai
+                from cerebras.cloud.sdk import Cerebras
 
                 if self._api_key is None:
                     raise ValueError("API key is required for Cerebras provider")
-                
-                if self._base_url is None:
-                    self._base_url = "https://api.cerebras.ai/v1"
 
-                client = openai.OpenAI(
-                    api_key=self._api_key,
-                    base_url=self._base_url,
-                )
+                client = Cerebras(api_key=self._api_key)
                 response = client.chat.completions.create(
                     model=self._model_name,
                     messages=messages,
                     temperature=self._temperature,
+                    stream=stream,
                 )
                 span.set_attributes(
                     {
@@ -245,6 +240,35 @@ class CompletionService(LLMService):
                 )
                 return response.output_parsed
 
+            case "cerebras":
+                from cerebras.cloud.sdk import Cerebras
+
+                if self._api_key is None:
+                    raise ValueError("API key is required for Cerebras provider")
+
+                client = Cerebras(api_key=self._api_key)
+                response = client.chat.completions.create(
+                    model=self._model_name,
+                    messages=messages,
+                    temperature=self._temperature,
+                    stream=stream,
+                    response_format={
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": response_format.__name__,
+                            "schema": response_format.model_json_schema()
+                        }
+                    }
+                )
+                span.set_attributes(
+                    {
+                        SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: response.usage.completion_tokens,
+                        SpanAttributes.LLM_TOKEN_COUNT_PROMPT: response.usage.prompt_tokens,
+                        SpanAttributes.LLM_TOKEN_COUNT_TOTAL: response.usage.total_tokens,
+                    }
+                )
+                return response_format.model_validate_json(response.choices[0].message.content)
+
             case _:
                 raise ValueError(f"Invalid provider: {self._provider}")
 
@@ -289,6 +313,28 @@ class CompletionService(LLMService):
                     }
                 )
                 return response.output_text
+            case "cerebras":
+                from cerebras.cloud.sdk import Cerebras
+
+                if self._api_key is None:
+                    raise ValueError("API key is required for Cerebras provider")
+
+                client = Cerebras(api_key=self._api_key)
+                response = client.chat.completions.create(
+                    model=self._model_name,
+                    messages=messages,
+                    temperature=self._temperature,
+                    stream=stream,
+                    response_format=response_format
+                )
+                span.set_attributes(
+                    {
+                        SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: response.usage.completion_tokens,
+                        SpanAttributes.LLM_TOKEN_COUNT_PROMPT: response.usage.prompt_tokens,
+                        SpanAttributes.LLM_TOKEN_COUNT_TOTAL: response.usage.total_tokens,
+                    }
+                )
+                return response.choices[0].message.content
             case _:
                 raise ValueError(f"Invalid provider: {self._provider}")
 
@@ -331,18 +377,12 @@ class CompletionService(LLMService):
                 )
                 return response
             case "cerebras":
-                import openai
+                from cerebras.cloud.sdk import Cerebras
 
                 if self._api_key is None:
                     raise ValueError("API key is required for Cerebras provider")
-                
-                if self._base_url is None:
-                    self._base_url = "https://api.cerebras.ai/v1"
 
-                client = openai.OpenAI(
-                    api_key=self._api_key,
-                    base_url=self._base_url,
-                )
+                client = Cerebras(api_key=self._api_key)
                 response = client.chat.completions.create(
                     model=self._model_name,
                     messages=messages,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "python-levenshtein>=0.27.1",
     "openpyxl==3.1.5",
     "tabulate==0.9.0",
+    "cerebras_cloud_sdk>=1.3.0,<2",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Add Cerebras Llama 3.3 70B model and integrate Cerebras provider for LLM completion and function calling.
This integration expands the available LLM options, providing access to Cerebras's high-speed inference for Llama 3.3 70B.

---

[Slack Thread](https://scopeogroupe.slack.com/archives/D091L1J9N87/p1752066672675809?thread_ts=1752066672.675809&cid=D091L1J9N87)