### PR TITLE
Fix test_react_function_calling after recent commits

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -129,14 +129,14 @@ class BaseConfig(BaseSettings):
 
         if values.ADA_DB_DRIVER == "sqlite":
             if not url:
-                raise ValidationError("ADA_DB_URL is required for SQLite")
+                raise ValueError("ADA_DB_URL is required for SQLite")
             return values
 
         has_url = bool(url)
         has_components = any([values.ADA_DB_HOST, values.ADA_DB_USER, values.ADA_DB_PASSWORD, values.ADA_DB_NAME])
 
         if has_url and has_components and values.ADA_DB_DRIVER != "sqlite":
-            raise ValidationError("You cannot define ADA_DB_URL and individual components simultaneously")
+            raise ValueError("You cannot define ADA_DB_URL and individual components simultaneously")
 
         if url:
             parsed = urlparse(url)

--- a/tests/agent/test_react_function_calling.py
+++ b/tests/agent/test_react_function_calling.py
@@ -161,7 +161,7 @@ def test_max_iterations(agent_calls_mock, get_span_mock, react_agent, agent_inpu
 
     output = react_agent.run_sync(agent_input)
 
-    assert output.last_message.content == "I'm sorry, I couldn't find a solution to your problem."
+    assert output.last_message.content == "I couldn't find a solution to your problem."
     assert not output.is_final
 
 


### PR DESCRIPTION
Fix `test_react_function_calling` and `settings.py` for Pydantic v2 compatibility and updated fallback message.

The `ValidationError` in `settings.py` was updated to `ValueError` to be compatible with Pydantic v2, as `ValidationError` is now specifically for schema validation errors and not general value errors.