### PR TITLE
feat(BugFix): Fix the image bug display after python coder tool

### DIFF
--- a/ada_backend/database/seed/utils.py
+++ b/ada_backend/database/seed/utils.py
@@ -104,9 +104,7 @@ OCR_MODELS = [
 COMPLETION_MODELS.extend(
     add_custom_llm_model(settings.custom_models, "completion_models", "constrained_completion_with_pydantic")
 )
-FUNCTION_CALLING_MODELS.extend(
-    add_custom_llm_model(settings.custom_models, "completion_models", "function_calling")
-)
+FUNCTION_CALLING_MODELS.extend(add_custom_llm_model(settings.custom_models, "completion_models", "function_calling"))
 
 EMBEDDING_MODELS.extend(add_custom_llm_model(settings.custom_models, "embedding_models"))
 

--- a/engine/agent/agent.py
+++ b/engine/agent/agent.py
@@ -179,7 +179,7 @@ class Agent(ABC):
             span.set_attributes(
                 {
                     SpanAttributes.OPENINFERENCE_SPAN_KIND: self.TRACE_SPAN_KIND,
-                    SpanAttributes.INPUT_VALUE: serialize_to_json(inputs[0]),
+                    SpanAttributes.INPUT_VALUE: serialize_to_json(inputs[0], shorten_string=True),
                     "component_instance_id": str(self.component_attributes.component_instance_id),
                 }
             )
@@ -188,7 +188,7 @@ class Agent(ABC):
                     {
                         SpanAttributes.TOOL_NAME: self.tool_description.name,
                         SpanAttributes.TOOL_DESCRIPTION: self.tool_description.description,
-                        SpanAttributes.TOOL_PARAMETERS: serialize_to_json(kwargs),
+                        SpanAttributes.TOOL_PARAMETERS: serialize_to_json(kwargs, shorten_string=True),
                     }
                 )
             try:

--- a/engine/agent/inputs_outputs/input.py
+++ b/engine/agent/inputs_outputs/input.py
@@ -43,8 +43,8 @@ class Input:
             span.set_attributes(
                 {
                     SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.UNKNOWN.value,
-                    SpanAttributes.INPUT_VALUE: serialize_to_json(input_data),
-                    SpanAttributes.OUTPUT_VALUE: serialize_to_json(filtered_input),
+                    SpanAttributes.INPUT_VALUE: serialize_to_json(input_data, shorten_string=True),
+                    SpanAttributes.OUTPUT_VALUE: serialize_to_json(filtered_input, shorten_string=True),
                     "component_instance_id": str(self.component_attributes.component_instance_id),
                 }
             )

--- a/engine/agent/llm_call_agent.py
+++ b/engine/agent/llm_call_agent.py
@@ -162,7 +162,9 @@ class LLMCallAgent(Agent):
         span = get_current_span()
         span.set_attributes(
             {
-                SpanAttributes.INPUT_VALUE: serialize_to_json([{"role": "user", "content": content}]),
+                SpanAttributes.INPUT_VALUE: serialize_to_json(
+                    [{"role": "user", "content": content}], shorten_string=True
+                ),
                 SpanAttributes.LLM_MODEL_NAME: self._completion_service._model_name,
             }
         )

--- a/engine/agent/ocr_call.py
+++ b/engine/agent/ocr_call.py
@@ -38,7 +38,7 @@ class OCRCall(Agent):
             span = get_current_span()
             span.set_attributes(
                 {
-                    SpanAttributes.INPUT_VALUE: serialize_to_json(payload_json),
+                    SpanAttributes.INPUT_VALUE: serialize_to_json(payload_json, shorten_string=True),
                     SpanAttributes.LLM_MODEL_NAME: self._ocr_service._model_name,
                 }
             )

--- a/engine/agent/tools/python_code_runner.py
+++ b/engine/agent/tools/python_code_runner.py
@@ -120,7 +120,7 @@ class PythonCodeRunner(Agent):
         shared_sandbox = kwargs.get("shared_sandbox")
 
         execution_result_dict = await self.execute_python_code(python_code=python_code, shared_sandbox=shared_sandbox)
-        content = serialize_to_json(execution_result_dict, shorten_string=True)
+        content = serialize_to_json(execution_result_dict)
 
         images = self._extract_images_from_results(execution_result_dict)
         artifacts = {"execution_result": execution_result_dict}

--- a/engine/agent/tools/python_code_runner.py
+++ b/engine/agent/tools/python_code_runner.py
@@ -120,7 +120,7 @@ class PythonCodeRunner(Agent):
         shared_sandbox = kwargs.get("shared_sandbox")
 
         execution_result_dict = await self.execute_python_code(python_code=python_code, shared_sandbox=shared_sandbox)
-        content = serialize_to_json(execution_result_dict)
+        content = serialize_to_json(execution_result_dict, shorten_string=True)
 
         images = self._extract_images_from_results(execution_result_dict)
         artifacts = {"execution_result": execution_result_dict}

--- a/engine/graph_runner/graph_runner.py
+++ b/engine/graph_runner/graph_runner.py
@@ -119,7 +119,7 @@ class GraphRunner:
         is_root_execution = kwargs.pop("is_root_execution", False)
 
         with self.trace_manager.start_span("Workflow", isolate_context=is_root_execution) as span:
-            trace_input = serialize_to_json(input_data)
+            trace_input = serialize_to_json(input_data, shorten_string=True)
             span.set_attributes(
                 {
                     SpanAttributes.OPENINFERENCE_SPAN_KIND: self.TRACE_SPAN_KIND,
@@ -128,7 +128,7 @@ class GraphRunner:
             )
             final_output = await self._run_without_trace(input_data, **kwargs)
             # TODO: Update trace when AgentInput/Output is refactored
-            trace_output = serialize_to_json(final_output)
+            trace_output = serialize_to_json(final_output, shorten_string=True)
             span.set_attributes(
                 {
                     SpanAttributes.OUTPUT_VALUE: trace_output,


### PR DESCRIPTION
 Fix the image bug display after python coder tool generate an image.
It was caused by the shortening base64 of the serialize function called on the payload passed in the react agent.

Now by default, serialize does not shorten the string base64 unless explicitely told to do so.
 Hence tracing uses it with shorten_string=True, as well as the python coder. Otherwise we do not shorten it.