### PR TITLE
feat(Code quality) : deduplicate qdrant code to avoid having same code twice on async and sync

### DIFF
--- a/ingestion_script/ingest_folder_source.py
+++ b/ingestion_script/ingest_folder_source.py
@@ -94,7 +94,7 @@ def sync_chunks_to_qdrant(
             collection_name=collection_name,
             query_filter_qdrant=query_filter_qdrant,
         )
-    
+
     return asyncio.run(_sync_chunks())
 
 

--- a/tests/qdrant/test_qdrant_service.py
+++ b/tests/qdrant/test_qdrant_service.py
@@ -46,6 +46,7 @@ def test_qdrant_service():
     qdrant_agentic_service = QdrantService.from_defaults(
         embedding_service=embedding_service,
         default_collection_schema=qdrant_schema,
+        timeout=60.0,  # Increased timeout for tests
     )
 
     # Ensure a clean state
@@ -134,129 +135,6 @@ def test_qdrant_service():
     assert not qdrant_agentic_service.collection_exists(TEST_COLLECTION_NAME)
 
 
-@pytest.mark.asyncio
-async def test_qdrant_service_async():
-    mock_trace_manager = MockTraceManager(project_name="test")
-    embedding_service = EmbeddingService(
-        trace_manager=mock_trace_manager,
-        provider="openai",
-        model_name="text-embedding-3-large",
-    )
-
-    qdrant_schema = QdrantCollectionSchema(
-        chunk_id_field="chunk_id",
-        content_field="content",
-        file_id_field="file_id",
-        url_id_field="url",
-        last_edited_ts_field="last_edited_ts",
-    )
-    chunks = [
-        {
-            "chunk_id": "1",
-            "content": "chunk1",
-            "file_id": "file_id1",
-            "url": "https//www.dummy1.com",
-            "last_edited_ts": "2024-11-26 10:40:40",
-        },
-        {
-            "chunk_id": "2",
-            "content": "chunk2",
-            "file_id": "file_id2",
-            "url": "https//www.dummy2.com",
-            "last_edited_ts": "2024-11-26 10:40:40",
-        },
-    ]
-    qdrant_agentic_service = QdrantService.from_defaults(
-        embedding_service=embedding_service,
-        default_collection_schema=qdrant_schema,
-    )
-
-    # Ensure a clean state
-    if await qdrant_agentic_service.collection_exists_async(TEST_COLLECTION_NAME):
-        await qdrant_agentic_service.delete_collection_async(TEST_COLLECTION_NAME)
-    assert not await qdrant_agentic_service.collection_exists_async(TEST_COLLECTION_NAME)
-
-    await qdrant_agentic_service.create_collection_async(collection_name=TEST_COLLECTION_NAME)
-    assert await qdrant_agentic_service.collection_exists_async(TEST_COLLECTION_NAME)
-    assert await qdrant_agentic_service.count_points_async(TEST_COLLECTION_NAME) == 0
-    await qdrant_agentic_service.add_chunks_async(
-        list_chunks=chunks,
-        collection_name=TEST_COLLECTION_NAME,
-    )
-    assert await qdrant_agentic_service.count_points_async(TEST_COLLECTION_NAME) == 2
-    assert await qdrant_agentic_service.delete_chunks_async(
-        point_ids=["1"],
-        id_field="chunk_id",
-        collection_name=TEST_COLLECTION_NAME,
-    )
-    assert await qdrant_agentic_service.count_points_async(TEST_COLLECTION_NAME) == 1
-    retrieved_chunks = await qdrant_agentic_service.retrieve_similar_chunks_async(
-        query_text="chunk2",
-        collection_name=TEST_COLLECTION_NAME,
-    )
-    correct_chunk = SourceChunk(
-        name="2",
-        content="chunk2",
-        document_name="file_id2",
-        url="https//www.dummy2.com",
-        metadata={},
-    )
-    assert retrieved_chunks[0] == correct_chunk
-
-    new_df_1 = pd.DataFrame(
-        [
-            {
-                "chunk_id": "1",
-                "content": "chunk1",
-                "file_id": "file_id1",
-                "url": "https//www.dummy1.com",
-                "last_edited_ts": "2025-01-2 10:40:40",
-            },
-            {
-                "chunk_id": "2",
-                "content": "chunk2",
-                "url": "https//www.dummy2.com",
-                "file_id": "file_id2",
-                "last_edited_ts": "2025-01-2 10:40:40",
-            },
-        ]
-    )
-    await qdrant_agentic_service.sync_df_with_collection_async(new_df_1, TEST_COLLECTION_NAME)
-    assert await qdrant_agentic_service.count_points_async(TEST_COLLECTION_NAME) == 2
-    synced_df = await qdrant_agentic_service.get_collection_data_async(TEST_COLLECTION_NAME)
-    synced_df.sort_values(by="chunk_id", inplace=True)
-    synced_df.reset_index(drop=True, inplace=True)
-    assert synced_df.equals(new_df_1)
-
-    new_df_2 = pd.DataFrame(
-        [
-            {
-                "chunk_id": "1",
-                "content": "chunk1",
-                "file_id": "file_id1",
-                "url": "https//www.dummy1.com",
-                "last_edited_ts": "2025-01-2 10:40:40",
-            },
-            {
-                "chunk_id": "3",
-                "content": "chunk3",
-                "file_id": "file_id3",
-                "url": "https//www.dummy3.com",
-                "last_edited_ts": "2025-01-2 10:40:40",
-            },
-        ]
-    )
-    await qdrant_agentic_service.sync_df_with_collection_async(new_df_2, TEST_COLLECTION_NAME)
-    assert await qdrant_agentic_service.count_points_async(TEST_COLLECTION_NAME) == 2
-    synced_df = await qdrant_agentic_service.get_collection_data_async(TEST_COLLECTION_NAME)
-    synced_df.sort_values(by="chunk_id", inplace=True)
-    synced_df.reset_index(drop=True, inplace=True)
-    assert synced_df.equals(new_df_2)
-
-    assert await qdrant_agentic_service.delete_collection_async(TEST_COLLECTION_NAME)
-    assert not await qdrant_agentic_service.collection_exists_async(TEST_COLLECTION_NAME)
-
-
 @pytest.mark.parametrize(
     "filter_dict, filtering_condition, expected_chunk",
     [
@@ -321,6 +199,7 @@ def test_qdrant_filtering(
     qdrant_agentic_service = QdrantService.from_defaults(
         embedding_service=embedding_service,
         default_collection_schema=qdrant_schema,
+        timeout=60.0,  # Increased timeout for tests
     )
 
     # Ensure a clean state before testing
@@ -350,99 +229,3 @@ def test_qdrant_filtering(
     assert expected_chunk == set_chunks
     assert qdrant_agentic_service.delete_collection(TEST_COLLECTION_NAME)
     assert not qdrant_agentic_service.collection_exists(TEST_COLLECTION_NAME)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "filter_dict, filtering_condition, expected_chunk",
-    [
-        ({"metadata_1": ["a"]}, "OR", {"1"}),
-        ({"metadata_2": ["cc"]}, "OR", {"2"}),
-        ({"metadata_1": ["a"], "metadata_2": ["cc"]}, "OR", {"1", "2"}),
-        ({"metadata_1": ["f", "g"]}, "OR", set()),
-        ({"metadata_2": ["cc", "dd"]}, "OR", {"2"}),
-        ({"metadata_1": ["a", "c"], "metadata_2": ["aa", "dd"]}, "AND", {"1", "2"}),
-        ({"metadata_1": ["a"], "metadata_2": ["aa"]}, "AND", {"1"}),
-    ],
-)
-async def test_qdrant_filtering_async(
-    filter_dict: dict[str, Union[list[str], str]], filtering_condition: str, expected_chunk: str
-):
-    """Tests the async Qdrant filtering functionality using different filter conditions.
-
-    Args:
-        filter_dict (dict[str, Union[list[str], str]]): The filter dictionary to apply.
-        filtering_condition (str): The filtering condition, either "AND" or "OR".
-        expected_chunk (str): The expected chunk name to be retrieved.
-    """
-    mock_trace_manager = MockTraceManager(project_name="test")
-    embedding_service = EmbeddingService(
-        trace_manager=mock_trace_manager,
-        provider="openai",
-        model_name="text-embedding-3-large",
-    )
-    # Define the Qdrant schema
-    qdrant_schema = QdrantCollectionSchema(
-        chunk_id_field="chunk_id",
-        content_field="content",
-        file_id_field="file_id",
-        url_id_field="url",
-        last_edited_ts_field="last_edited_ts",
-        metadata_fields_to_keep=["metadata_1", "metadata_2"],
-    )
-
-    # Define test data
-    chunks = [
-        {
-            "chunk_id": "1",
-            "content": "chunk1",
-            "file_id": "file_id1",
-            "url": "https//www.dummy1.com",
-            "last_edited_ts": "2024-11-26 10:40:40",
-            "metadata_1": ["a", "b"],
-            "metadata_2": ["aa", "bb"],
-        },
-        {
-            "chunk_id": "2",
-            "content": "chunk2",
-            "file_id": "file_id2",
-            "url": "https//www.dummy2.com",
-            "last_edited_ts": "2024-11-26 10:40:40",
-            "metadata_1": ["c", "d"],
-            "metadata_2": ["cc", "dd"],
-        },
-    ]
-
-    # Initialize Qdrant service
-    qdrant_agentic_service = QdrantService.from_defaults(
-        embedding_service=embedding_service,
-        default_collection_schema=qdrant_schema,
-    )
-
-    # Ensure a clean state before testing
-    if await qdrant_agentic_service.collection_exists_async(TEST_COLLECTION_NAME):
-        await qdrant_agentic_service.delete_collection_async(TEST_COLLECTION_NAME)
-    assert not await qdrant_agentic_service.collection_exists_async(TEST_COLLECTION_NAME)
-
-    # Create the collection and add chunks
-    await qdrant_agentic_service.create_collection_async(collection_name=TEST_COLLECTION_NAME)
-    assert await qdrant_agentic_service.collection_exists_async(TEST_COLLECTION_NAME)
-    assert await qdrant_agentic_service.count_points_async(TEST_COLLECTION_NAME) == 0
-
-    await qdrant_agentic_service.add_chunks_async(
-        list_chunks=chunks,
-        collection_name=TEST_COLLECTION_NAME,
-    )
-    assert await qdrant_agentic_service.count_points_async(TEST_COLLECTION_NAME) == 2
-
-    formatted_filter = format_qdrant_filter(filter_dict, filtering_condition)
-
-    retrieved_chunks = await qdrant_agentic_service.retrieve_similar_chunks_async(
-        query_text="chunk1",
-        collection_name=TEST_COLLECTION_NAME,
-        filter=formatted_filter,
-    )
-    set_chunks = set([chunk.name for chunk in retrieved_chunks])
-    assert expected_chunk == set_chunks
-    assert await qdrant_agentic_service.delete_collection_async(TEST_COLLECTION_NAME)
-    assert not await qdrant_agentic_service.collection_exists_async(TEST_COLLECTION_NAME)


### PR DESCRIPTION
- Pass every sync function as asyncio.run(async_version)
- Remove async test in testing as sync test are already running asyncio.run(async_version)
- at ingestion, a logging error happens at the end of the ingestion. It does not concern our script but the cleaning of httpx. Fixing this would involve refactoring all the ingestion code to make it async. Hence I keep it as it is now. It will only output an Event Close looped error log on the redis queue of the ingestion, but will not affect how the ingestion performs