### PR TITLE
AIT-451 Project Reference Block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .coverage
 .pytest_cache
 .idea
+.cursor
 
 # virtual-env
 venv

--- a/ada_backend/context.py
+++ b/ada_backend/context.py
@@ -1,0 +1,83 @@
+"""
+Request context management for user authentication and permissions.
+
+This module provides a thread-safe way to access user information throughout
+the request lifecycle using Python's contextvars.
+"""
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Optional
+from uuid import UUID
+
+from ada_backend.schemas.auth_schema import SupabaseUser
+
+
+@dataclass
+class RequestContext:
+    """
+    Request-scoped context containing user authentication information.
+
+    Every request gets a unique request_id for tracing. User authentication
+    is optional and set when available.
+    """
+
+    request_id: UUID
+    _user: Optional[SupabaseUser] = None
+
+    def has_user(self) -> bool:
+        """Check if user context is available."""
+        return self._user is not None
+
+    def set_user(self, user: SupabaseUser) -> None:
+        """Set the user for the current request context."""
+        self._user = user
+
+    def require_user(self) -> SupabaseUser:
+        """
+        Get the user, raising an error if no user is authenticated.
+
+        Returns:
+            SupabaseUser: The authenticated user
+
+        Raises:
+            ValueError: If no user is authenticated
+        """
+        if not self._user:
+            raise ValueError("Authentication required for this operation")
+        return self._user
+
+
+# Thread-safe context variable for storing request context
+request_context: ContextVar[RequestContext] = ContextVar("request_context")
+
+
+def set_request_context(context: RequestContext) -> None:
+    """
+    Set the request context.
+
+    This should be called by middleware for every request to make request
+    information available throughout the request lifecycle.
+
+    Args:
+        context: The RequestContext object to set
+    """
+    request_context.set(context)
+
+
+def get_request_context() -> RequestContext:
+    """
+    Get the current request context.
+
+    Returns:
+        RequestContext: The current request context
+
+    Raises:
+        ValueError: If no context is available (endpoint didn't set context)
+    """
+    try:
+        return request_context.get()
+    except LookupError as exc:
+        raise ValueError(
+            "No request context available. This operation requires authentication.",
+        ) from exc

--- a/ada_backend/database/demo/demo_graph_test.py
+++ b/ada_backend/database/demo/demo_graph_test.py
@@ -10,7 +10,7 @@ from ada_backend.schemas.pipeline.base import (
 from ada_backend.schemas.pipeline.graph_schema import EdgeSchema, GraphUpdateSchema
 from engine.agent.types import ToolDescription
 from engine.agent.rag.rag import format_rag_tool_description
-from ada_backend.services.registry import COMPLETION_MODEL_IN_DB
+from ada_backend.database.seed.constants import COMPLETION_MODEL_IN_DB
 
 
 GRAPH_TEST_TOOL_DESCRIPTION = ToolDescription(

--- a/ada_backend/database/demo/demo_react_sql_tool.py
+++ b/ada_backend/database/demo/demo_react_sql_tool.py
@@ -6,7 +6,7 @@ from ada_backend.schemas.pipeline.base import (
     ComponentInstanceSchema,
 )
 from ada_backend.schemas.pipeline.graph_schema import GraphUpdateSchema
-from ada_backend.services.registry import COMPLETION_MODEL_IN_DB
+from ada_backend.database.seed.constants import COMPLETION_MODEL_IN_DB
 
 ADDITIONAL_DB_DESCRIPTION = (
     "Pour les tables, voici une explication des données: \n"

--- a/ada_backend/database/seed/constants.py
+++ b/ada_backend/database/seed/constants.py
@@ -1,0 +1,6 @@
+COMPLETION_MODEL_IN_DB = "completion_model"
+EMBEDDING_MODEL_IN_DB = "embedding_model"
+WEB_SERVICE_IN_DB = "web_service"
+TEMPERATURE_IN_DB = "default_temperature"
+VERBOSITY_IN_DB = "verbosity"
+REASONING_IN_DB = "reasoning"

--- a/ada_backend/database/seed/seed_ai_agent.py
+++ b/ada_backend/database/seed/seed_ai_agent.py
@@ -18,7 +18,10 @@ from ada_backend.database.seed.utils import (
     ParameterLLMConfig,
     build_function_calling_service_config_definitions,
 )
-from ada_backend.services.registry import COMPLETION_MODEL_IN_DB, TEMPERATURE_IN_DB
+from ada_backend.database.seed.constants import (
+    COMPLETION_MODEL_IN_DB,
+    TEMPERATURE_IN_DB,
+)
 
 
 def seed_ai_agent_components(session: Session):

--- a/ada_backend/database/seed/seed_llm_call.py
+++ b/ada_backend/database/seed/seed_llm_call.py
@@ -19,11 +19,11 @@ from ada_backend.database.seed.utils import (
     ParameterLLMConfig,
     build_completion_service_config_definitions,
 )
-from ada_backend.services.registry import (
+from ada_backend.database.seed.constants import (
     COMPLETION_MODEL_IN_DB,
     TEMPERATURE_IN_DB,
-    REASONING_IN_DB,
     VERBOSITY_IN_DB,
+    REASONING_IN_DB,
 )
 
 

--- a/ada_backend/database/seed/seed_ocr_call.py
+++ b/ada_backend/database/seed/seed_ocr_call.py
@@ -14,7 +14,7 @@ from ada_backend.database.seed.utils import (
     ParameterLLMConfig,
     build_ocr_service_config_definitions,
 )
-from ada_backend.services.registry import COMPLETION_MODEL_IN_DB
+from ada_backend.database.seed.constants import COMPLETION_MODEL_IN_DB
 
 
 def seed_ocr_call_components(session: Session):

--- a/ada_backend/database/seed/seed_project_reference.py
+++ b/ada_backend/database/seed/seed_project_reference.py
@@ -1,0 +1,53 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ada_backend.database import models as db
+from ada_backend.database.models import ParameterType, UIComponent, UIComponentProperties
+from ada_backend.database.component_definition_seeding import (
+    upsert_components,
+    upsert_components_parameter_definitions,
+)
+from ada_backend.database.seed.utils import COMPONENT_UUIDS
+
+
+def seed_project_reference_components(session: Session):
+    """Seed the ProjectReference component definition."""
+
+    project_reference = db.Component(
+        id=COMPONENT_UUIDS["project_reference"],
+        name="ProjectReference",
+        description="Execute another project's graph workflow as a component.",
+        is_agent=True,
+        function_callable=False,
+        release_stage=db.ReleaseStage.INTERNAL,
+    )
+
+    upsert_components(
+        session=session,
+        components=[project_reference],
+    )
+
+    upsert_components_parameter_definitions(
+        session=session,
+        component_parameter_definitions=[
+            db.ComponentParameterDefinition(
+                id=UUID("47d2e1f5-8c39-4a6b-9f15-3e8a7c2d1b90"),
+                component_id=project_reference.id,
+                name="project_id",
+                type=ParameterType.STRING,
+                nullable=False,
+                # TODO: Dropdown to choose among existing projects (that are accessible to the user)
+                ui_component=UIComponent.TEXTFIELD,
+                ui_component_properties=UIComponentProperties(
+                    label="Project ID",
+                    placeholder="Enter the UUID of the project to reference",
+                    description=(
+                        "The UUID of the project whose graph workflow will be executed. "
+                        "The project must be published to production."
+                    ),
+                ).model_dump(exclude_unset=True, exclude_none=True),
+            ),
+            # TODO: Add version, now it can only reference the latest "production" version
+        ],
+    )

--- a/ada_backend/database/seed/seed_rag.py
+++ b/ada_backend/database/seed/seed_rag.py
@@ -23,11 +23,11 @@ from ada_backend.database.seed.utils import (
     ParameterLLMConfig,
     build_completion_service_config_definitions,
 )
-from ada_backend.services.registry import (
+from ada_backend.database.seed.constants import (
     COMPLETION_MODEL_IN_DB,
     TEMPERATURE_IN_DB,
-    REASONING_IN_DB,
     VERBOSITY_IN_DB,
+    REASONING_IN_DB,
 )
 from engine.agent.synthesizer_prompts import (
     get_base_synthetizer_prompt_template,

--- a/ada_backend/database/seed/seed_react_sql.py
+++ b/ada_backend/database/seed/seed_react_sql.py
@@ -21,7 +21,7 @@ from ada_backend.database.seed.utils import (
     ParameterLLMConfig,
     build_function_calling_service_config_definitions,
 )
-from ada_backend.services.registry import COMPLETION_MODEL_IN_DB
+from ada_backend.database.seed.constants import COMPLETION_MODEL_IN_DB
 from engine.agent.sql.react_sql_tool import DEFAULT_REACT_SQL_TOOL_PROMPT
 
 

--- a/ada_backend/database/seed/seed_smart_rag.py
+++ b/ada_backend/database/seed/seed_smart_rag.py
@@ -19,7 +19,7 @@ from ada_backend.database.seed.utils import (
     ParameterLLMConfig,
     build_function_calling_service_config_definitions,
 )
-from ada_backend.services.registry import COMPLETION_MODEL_IN_DB
+from ada_backend.database.seed.constants import COMPLETION_MODEL_IN_DB
 from engine.agent.document_react_loader import INITIAL_PROMPT as DEFAULT_DOCUMENT_REACT_LOADER_PROMPT
 
 

--- a/ada_backend/database/seed/seed_sql_tool.py
+++ b/ada_backend/database/seed/seed_sql_tool.py
@@ -15,7 +15,7 @@ from ada_backend.database.seed.utils import (
     ParameterLLMConfig,
     build_completion_service_config_definitions,
 )
-from ada_backend.services.registry import COMPLETION_MODEL_IN_DB
+from ada_backend.database.seed.constants import COMPLETION_MODEL_IN_DB
 
 
 def seed_sql_tool_components(session: Session):

--- a/ada_backend/database/seed/seed_tavily.py
+++ b/ada_backend/database/seed/seed_tavily.py
@@ -15,7 +15,7 @@ from ada_backend.database.seed.utils import (
     ParameterLLMConfig,
     build_completion_service_config_definitions,
 )
-from ada_backend.services.registry import COMPLETION_MODEL_IN_DB
+from ada_backend.database.seed.constants import COMPLETION_MODEL_IN_DB
 
 
 def seed_tavily_components(session: Session):

--- a/ada_backend/database/seed/seed_web_search.py
+++ b/ada_backend/database/seed/seed_web_search.py
@@ -15,7 +15,9 @@ from ada_backend.database.seed.utils import (
     ParameterLLMConfig,
     build_web_service_config_definitions,
 )
-from ada_backend.services.registry import COMPLETION_MODEL_IN_DB
+from ada_backend.database.seed.constants import (
+    COMPLETION_MODEL_IN_DB,
+)
 
 
 def seed_web_search_components(session: Session):

--- a/ada_backend/database/seed/utils.py
+++ b/ada_backend/database/seed/utils.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 from ada_backend.database.models import ParameterType, SelectOption, UIComponent, UIComponentProperties
 from ada_backend.database import models as db
-from ada_backend.services.registry import (
+from ada_backend.database.seed.constants import (
     COMPLETION_MODEL_IN_DB,
     EMBEDDING_MODEL_IN_DB,
     TEMPERATURE_IN_DB,
@@ -49,6 +49,7 @@ def add_custom_llm_model(
     return list_model_options
 
 
+# TODO: Move to constants.py
 # Define UUIDs for components and instances
 COMPONENT_UUIDS: dict[str, UUID] = {
     "synthesizer": UUID("6f790dd1-06f6-4489-a655-1a618763a114"),
@@ -80,6 +81,7 @@ COMPONENT_UUIDS: dict[str, UUID] = {
     "python_code_runner": UUID("e2b00000-0000-1111-2222-333333333333"),
     "terminal_command_runner": UUID("e2b10000-1111-2222-3333-444444444444"),
     "pdf_generation": UUID("428baac0-0c5f-4374-b2de-8075218082b4"),
+    "project_reference": UUID("4c8f9e2d-1a3b-4567-8901-234567890abc"),
 }
 
 DEFAULT_MODEL = "openai:gpt-5-mini"

--- a/ada_backend/database/seed_db.py
+++ b/ada_backend/database/seed_db.py
@@ -30,6 +30,7 @@ from ada_backend.database.seed.seed_terminal_command_runner import seed_terminal
 from ada_backend.database.seed.seed_web_search import seed_web_search_components
 from ada_backend.database.seed.seed_ocr_call import seed_ocr_call_components
 from ada_backend.database.seed.seed_pdf_generation import seed_pdf_generation_components
+from ada_backend.database.seed.seed_project_reference import seed_project_reference_components
 from ada_backend.database.seed.seed_tool_description import seed_tool_description
 from ada_backend.database.seed.utils import COMPONENT_UUIDS
 
@@ -62,6 +63,7 @@ def seed_db(session: Session):
         seed_input_components(session)
         seed_filter_components(session)
         seed_gmail_components(session)
+        seed_project_reference_components(session)
 
         # Verify components exist
         for name, uuid_value in COMPONENT_UUIDS.items():

--- a/ada_backend/main.py
+++ b/ada_backend/main.py
@@ -6,6 +6,7 @@ from prometheus_fastapi_instrumentator import PrometheusFastApiInstrumentator
 
 from ada_backend.admin.admin import setup_admin
 from ada_backend.instrumentation import setup_performance_instrumentation
+from ada_backend.middleware.request_context import RequestContextMiddleware
 from ada_backend.routers.project_router import router as project_router
 from ada_backend.routers.template_router import router as template_router
 from ada_backend.routers.integration_router import router as integration_router
@@ -104,6 +105,7 @@ app.include_router(components_router)
 app.include_router(graph_router)
 app.include_router(graphql_router, prefix="/graphql")
 
+app.add_middleware(RequestContextMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ALLOW_ORIGINS.split(","),

--- a/ada_backend/middleware/request_context.py
+++ b/ada_backend/middleware/request_context.py
@@ -1,0 +1,23 @@
+from uuid import uuid4
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from ada_backend.context import RequestContext, set_request_context
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware that sets up RequestContext for every request.
+
+    This middleware creates a new RequestContext with a unique request_id
+    for every request. User authentication is handled separately by
+    authenticated endpoints after JWT validation.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        context = RequestContext(request_id=uuid4())
+        set_request_context(context)
+
+        response = await call_next(request)
+        return response

--- a/ada_backend/repositories/graph_runner_repository.py
+++ b/ada_backend/repositories/graph_runner_repository.py
@@ -28,7 +28,11 @@ def get_graph_runners_by_project(session: Session, project_id: UUID) -> list[db.
     )
 
 
-def get_graph_runner_for_env(session: Session, project_id: UUID, env: db.EnvType) -> db.GraphRunner:
+def get_graph_runner_for_env(
+    session: Session,
+    project_id: UUID,
+    env: db.EnvType,
+) -> Optional[db.GraphRunner]:
     """Returns the GraphRunner bound to the given project and environment."""
     return (
         session.query(db.GraphRunner)

--- a/ada_backend/routers/auth_router.py
+++ b/ada_backend/routers/auth_router.py
@@ -9,6 +9,7 @@ from supabase import Client, create_client
 from sqlalchemy.orm import Session
 
 from ada_backend.repositories.project_repository import get_project
+from ada_backend.context import get_request_context
 from settings import settings
 from ada_backend.database.setup_db import get_db
 from ada_backend.services.api_key_service import (
@@ -53,6 +54,7 @@ async def get_user_from_supabase_token(
 ) -> SupabaseUser:
     """
     Validate Supabase JWT from Authorization header and return user info.
+    Also sets the user in the request context.
 
     Args:
         authorization (Optional[str]): Supabase JWT in the 'Authorization' header.
@@ -67,11 +69,18 @@ async def get_user_from_supabase_token(
         if not user_response or not user_response.user:
             raise HTTPException(status_code=401, detail="Invalid Supabase token")
 
-        return SupabaseUser(
+        user = SupabaseUser(
             id=user_response.user.id,
             email=user_response.user.email,
             token=supabase_token,
         )
+
+        context = get_request_context()
+        context.set_user(user)
+
+        return user
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=401, detail="Failed to validate Supabase token") from e
 

--- a/ada_backend/services/agent_runner_service.py
+++ b/ada_backend/services/agent_runner_service.py
@@ -16,7 +16,6 @@ from ada_backend.repositories.graph_runner_repository import (
     graph_runner_exists,
     delete_temp_folder,
 )
-from engine.agent.agent import Agent
 from ada_backend.repositories.project_repository import get_project, get_project_with_details
 from ada_backend.repositories.organization_repository import get_organization_secrets
 from engine.graph_runner.runnable import Runnable
@@ -78,7 +77,7 @@ async def get_agent_for_project(
     session: Session,
     graph_runner_id: UUID,
     project_id: UUID,
-) -> Agent | GraphRunner:
+) -> GraphRunner:
     project = get_project(session, project_id=project_id)
     if not project:
         raise ValueError(f"Project {project_id} not found.")

--- a/ada_backend/services/graph/update_graph_service.py
+++ b/ada_backend/services/graph/update_graph_service.py
@@ -28,6 +28,7 @@ from ada_backend.segment_analytics import track_project_saved
 LOGGER = logging.getLogger(__name__)
 
 
+# TODO: Refactor to rollback if instantiation failed.
 async def update_graph_service(
     session: Session,
     graph_runner_id: UUID,

--- a/ada_backend/services/pipeline/update_pipeline_service.py
+++ b/ada_backend/services/pipeline/update_pipeline_service.py
@@ -19,7 +19,7 @@ from ada_backend.repositories.component_repository import (
     delete_component_instance_parameters,
 )
 from ada_backend.services.entity_factory import get_llm_provider_and_model
-from ada_backend.services.registry import COMPLETION_MODEL_IN_DB
+from ada_backend.database.seed.constants import COMPLETION_MODEL_IN_DB
 
 LOGGER = getLogger(__name__)
 

--- a/ada_backend/services/registry.py
+++ b/ada_backend/services/registry.py
@@ -27,12 +27,14 @@ from engine.agent.document_enhanced_llm_call import DocumentEnhancedLLMCallAgent
 from engine.agent.document_react_loader import DocumentReactLoaderAgent
 from engine.agent.ocr_call import OCRCall
 from engine.agent.rag.document_search import DocumentSearch
+from engine.agent.graph_runner_block import GraphRunnerBlock
 from engine.integrations.gmail_sender import GmailSender
 from engine.storage_service.local_service import SQLLocalService
 from engine.storage_service.snowflake_service.snowflake_service import SnowflakeService
 from ada_backend.services.entity_factory import (
     EntityFactory,
     AgentFactory,
+    NonToolCallableBlockFactory,
     detect_and_convert_dataclasses,
     build_trace_manager_processor,
     build_completion_service_processor,
@@ -41,14 +43,15 @@ from ada_backend.services.entity_factory import (
     compose_processors,
     build_web_service_processor,
     build_ocr_service_processor,
+    build_project_reference_processor,
 )
-
-COMPLETION_MODEL_IN_DB = "completion_model"
-EMBEDDING_MODEL_IN_DB = "embedding_model"
-WEB_SERVICE_IN_DB = "web_service"
-TEMPERATURE_IN_DB = "default_temperature"
-VERBOSITY_IN_DB = "verbosity"
-REASONING_IN_DB = "reasoning"
+from ada_backend.database.seed.constants import (
+    COMPLETION_MODEL_IN_DB,
+    EMBEDDING_MODEL_IN_DB,
+    TEMPERATURE_IN_DB,
+    VERBOSITY_IN_DB,
+    REASONING_IN_DB,
+)
 
 
 class SupportedEntityType(StrEnum):
@@ -88,6 +91,7 @@ class SupportedEntityType(StrEnum):
     OCR_CALL = "OCR Call"
     INPUT = "API Input"
     FILTER = "Filter"
+    PROJECT_REFERENCE = "ProjectReference"
 
     # Integrations
     GMAIL_SENDER = "Gmail Sender"
@@ -311,6 +315,15 @@ def create_factory_registry() -> FactoryRegistry:
             entity_class=LLMCallAgent,
             parameter_processors=[
                 completion_service_processor,
+            ],
+        ),
+    )
+    registry.register(
+        name=SupportedEntityType.PROJECT_REFERENCE,
+        factory=NonToolCallableBlockFactory(
+            entity_class=GraphRunnerBlock,
+            parameter_processors=[
+                build_project_reference_processor(),
             ],
         ),
     )

--- a/engine/agent/graph_runner_block.py
+++ b/engine/agent/graph_runner_block.py
@@ -1,0 +1,39 @@
+from engine.agent.agent import Agent
+from engine.agent.types import AgentPayload, ToolDescription, ComponentAttributes
+from engine.graph_runner.graph_runner import GraphRunner
+from engine.trace.trace_manager import TraceManager
+
+
+DEFAULT_GRAPH_RUNNER_BLOCK_TOOL_DESCRIPTION = ToolDescription(
+    name="Graph Runner",
+    description="Execute a graph workflow",
+    tool_properties={},
+    required_tool_properties=[],
+)
+
+
+class GraphRunnerBlock(Agent):
+    def __init__(
+        self,
+        trace_manager: TraceManager,
+        graph_runner: GraphRunner,
+        component_attributes: ComponentAttributes,
+        tool_description: ToolDescription = DEFAULT_GRAPH_RUNNER_BLOCK_TOOL_DESCRIPTION,
+    ):
+        super().__init__(
+            trace_manager=trace_manager,
+            tool_description=tool_description,
+            component_attributes=component_attributes,
+        )
+        self._graph_runner = graph_runner
+
+    async def _run_without_io_trace(self, *inputs: AgentPayload, **kwargs) -> AgentPayload:
+        input_data: AgentPayload = inputs[0]
+
+        result = await self._graph_runner.run(input_data)
+
+        # TODO: This should be enforced on the GraphRunner level
+        if not isinstance(result, AgentPayload):
+            raise ValueError("GraphRunnerBlock must return an AgentPayload")
+
+        return result

--- a/tests/agent/test_api_call_tool.py
+++ b/tests/agent/test_api_call_tool.py
@@ -1,7 +1,8 @@
+import asyncio
 from unittest.mock import MagicMock, patch, AsyncMock
 import json
 import pytest
-import asyncio
+import pytest_asyncio
 from httpx import HTTPError
 
 from engine.agent.tools.api_call_tool import APICallTool, API_CALL_TOOL_DESCRIPTION
@@ -14,10 +15,10 @@ def mock_trace_manager():
     return MagicMock(spec=TraceManager)
 
 
-@pytest.fixture
-def api_tool(mock_trace_manager):
-    """Create an API call tool instance."""
-    return APICallTool(
+@pytest_asyncio.fixture
+async def api_tool(mock_trace_manager):
+    """Create an API call tool instance with proper async cleanup."""
+    tool = APICallTool(
         trace_manager=mock_trace_manager,
         component_attributes=ComponentAttributes(component_instance_name="test_api_tool"),
         endpoint="https://api.example.com/test",
@@ -26,6 +27,10 @@ def api_tool(mock_trace_manager):
         timeout=30,
         fixed_parameters={"api_version": "v2", "format": "json", "language": "en"},
     )
+    yield tool
+    # Cleanup: ensure any lingering HTTP connections are closed
+
+    await asyncio.sleep(0.1)
 
 
 @pytest.fixture
@@ -49,18 +54,14 @@ def test_api_tool_initialization(api_tool):
 
 @patch("httpx.AsyncClient")
 def test_make_api_call_with_fixed_and_dynamic_params(mock_client_class, api_tool, mock_response):
-    async def run_test():
-        # Dynamic parameters provided by LLM
-        dynamic_params = {"query": "test", "page": 1, "limit": 10, "filter": "active", "sort": "date"}
+    # Dynamic parameters provided by LLM
+    dynamic_params = {"query": "test", "page": 1, "limit": 10, "filter": "active", "sort": "date"}
 
-        mock_client = AsyncMock()
-        mock_client.request.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client = AsyncMock()
+    mock_client.request.return_value = mock_response
+    mock_client_class.return_value.__aenter__.return_value = mock_client
 
-        result = await api_tool.make_api_call(**dynamic_params)
-        return result, mock_client
-
-    result, mock_client = asyncio.run(run_test())
+    result = asyncio.run(api_tool.make_api_call(**dynamic_params))
 
     # Verify all parameters are included
     expected_params = {
@@ -89,21 +90,17 @@ def test_make_api_call_with_fixed_and_dynamic_params(mock_client_class, api_tool
 
 @patch("httpx.AsyncClient")
 def test_make_api_call_post_with_fixed_and_dynamic_params(mock_client_class, api_tool, mock_response):
-    async def run_test():
-        # Change method to POST
-        api_tool.method = "POST"
+    # Change method to POST
+    api_tool.method = "POST"
 
-        # Dynamic parameters provided by LLM
-        dynamic_params = {"data": {"name": "test", "value": 123}}
+    # Dynamic parameters provided by LLM
+    dynamic_params = {"data": {"name": "test", "value": 123}}
 
-        mock_client = AsyncMock()
-        mock_client.request.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client = AsyncMock()
+    mock_client.request.return_value = mock_response
+    mock_client_class.return_value.__aenter__.return_value = mock_client
 
-        result = await api_tool.make_api_call(**dynamic_params)
-        return result, mock_client
-
-    result, mock_client = asyncio.run(run_test())
+    result = asyncio.run(api_tool.make_api_call(**dynamic_params))
 
     # Verify all parameters are included
     expected_params = {
@@ -128,17 +125,13 @@ def test_make_api_call_post_with_fixed_and_dynamic_params(mock_client_class, api
 
 @patch("httpx.AsyncClient")
 def test_make_api_call_with_only_fixed_params(mock_client_class, api_tool, mock_response):
-    async def run_test():
-        # Test with only fixed parameters
+    # Test with only fixed parameters
 
-        mock_client = AsyncMock()
-        mock_client.request.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client = AsyncMock()
+    mock_client.request.return_value = mock_response
+    mock_client_class.return_value.__aenter__.return_value = mock_client
 
-        result = await api_tool.make_api_call()
-        return result, mock_client
-
-    result, mock_client = asyncio.run(run_test())
+    result = asyncio.run(api_tool.make_api_call())
 
     expected_params = {"api_version": "v2", "format": "json", "language": "en"}
 
@@ -157,26 +150,22 @@ def test_make_api_call_with_only_fixed_params(mock_client_class, api_tool, mock_
 
 @patch("httpx.AsyncClient")
 def test_make_api_call_post_with_empty_params(mock_client_class, mock_trace_manager, mock_response):
-    async def run_test():
-        # Test POST with no parameters (should still send empty JSON)
-        api_tool = APICallTool(
-            trace_manager=mock_trace_manager,
-            component_attributes=ComponentAttributes(
-                component_instance_name="test_api_tool",
-            ),
-            endpoint="https://api.example.com/test",
-            method="POST",
-            headers={"Content-Type": "application/json"},
-        )
+    # Test POST with no parameters (should still send empty JSON)
+    api_tool = APICallTool(
+        trace_manager=mock_trace_manager,
+        component_attributes=ComponentAttributes(
+            component_instance_name="test_api_tool",
+        ),
+        endpoint="https://api.example.com/test",
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
 
-        mock_client = AsyncMock()
-        mock_client.request.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client = AsyncMock()
+    mock_client.request.return_value = mock_response
+    mock_client_class.return_value.__aenter__.return_value = mock_client
 
-        result = await api_tool.make_api_call()
-        return result, mock_client
-
-    result, mock_client = asyncio.run(run_test())
+    result = asyncio.run(api_tool.make_api_call())
 
     mock_client.request.assert_called_once_with(
         url="https://api.example.com/test",
@@ -192,26 +181,22 @@ def test_make_api_call_post_with_empty_params(mock_client_class, mock_trace_mana
 
 @patch("httpx.AsyncClient")
 def test_make_api_call_get_with_empty_params(mock_client_class, mock_trace_manager, mock_response):
-    async def run_test():
-        # Test GET with no parameters (should not send params)
-        api_tool = APICallTool(
-            trace_manager=mock_trace_manager,
-            component_attributes=ComponentAttributes(
-                component_instance_name="test_api_tool",
-            ),
-            endpoint="https://api.example.com/test",
-            method="GET",
-            headers={"Content-Type": "application/json"},
-        )
+    # Test GET with no parameters (should not send params)
+    api_tool = APICallTool(
+        trace_manager=mock_trace_manager,
+        component_attributes=ComponentAttributes(
+            component_instance_name="test_api_tool",
+        ),
+        endpoint="https://api.example.com/test",
+        method="GET",
+        headers={"Content-Type": "application/json"},
+    )
 
-        mock_client = AsyncMock()
-        mock_client.request.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client = AsyncMock()
+    mock_client.request.return_value = mock_response
+    mock_client_class.return_value.__aenter__.return_value = mock_client
 
-        result = await api_tool.make_api_call()
-        return result, mock_client
-
-    result, mock_client = asyncio.run(run_test())
+    result = asyncio.run(api_tool.make_api_call())
 
     mock_client.request.assert_called_once_with(
         url="https://api.example.com/test",
@@ -227,15 +212,11 @@ def test_make_api_call_get_with_empty_params(mock_client_class, mock_trace_manag
 
 @patch("httpx.AsyncClient")
 def test_make_api_call_error_handling(mock_client_class, api_tool):
-    async def run_test():
-        mock_client = AsyncMock()
-        mock_client.request.side_effect = HTTPError("API Error")
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client = AsyncMock()
+    mock_client.request.side_effect = HTTPError("API Error")
+    mock_client_class.return_value.__aenter__.return_value = mock_client
 
-        result = await api_tool.make_api_call()
-        return result, mock_client
-
-    result, mock_client = asyncio.run(run_test())
+    result = asyncio.run(api_tool.make_api_call())
 
     assert result["success"] is False
     assert result["error"] == "API Error"
@@ -244,21 +225,17 @@ def test_make_api_call_error_handling(mock_client_class, api_tool):
 
 @patch("httpx.AsyncClient")
 def test_make_api_call_non_json_response(mock_client_class, api_tool):
-    async def run_test():
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.text = "plain text response"
-        mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
-        mock_response.headers = {"Content-Type": "text/plain"}
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "plain text response"
+    mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+    mock_response.headers = {"Content-Type": "text/plain"}
 
-        mock_client = AsyncMock()
-        mock_client.request.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client = AsyncMock()
+    mock_client.request.return_value = mock_response
+    mock_client_class.return_value.__aenter__.return_value = mock_client
 
-        result = await api_tool.make_api_call()
-        return result, mock_client
-
-    result, mock_client = asyncio.run(run_test())
+    result = asyncio.run(api_tool.make_api_call())
 
     assert result["status_code"] == 200
     assert result["data"] == {"text": "plain text response"}
@@ -266,44 +243,37 @@ def test_make_api_call_non_json_response(mock_client_class, api_tool):
 
 
 def test_run_without_io_trace_with_dynamic_params(api_tool):
-    async def run_test():
-        agent_input = AgentPayload(messages=[ChatMessage(role="user", content="test")])
-        dynamic_params = {"query": "test", "page": 1, "filter": "active"}
+    agent_input = AgentPayload(messages=[ChatMessage(role="user", content="test")])
+    dynamic_params = {"query": "test", "page": 1, "filter": "active"}
 
-        with patch.object(api_tool, "make_api_call") as mock_make_api_call:
-            mock_make_api_call.return_value = {
-                "status_code": 200,
-                "data": {"result": "success"},
-                "headers": {"Content-Type": "application/json"},
-                "success": True,
-            }
+    with patch.object(api_tool, "make_api_call") as mock_make_api_call:
+        mock_make_api_call.return_value = {
+            "status_code": 200,
+            "data": {"result": "success"},
+            "headers": {"Content-Type": "application/json"},
+            "success": True,
+        }
 
-            result = await api_tool._run_without_io_trace(agent_input, **dynamic_params)
-            return result, mock_make_api_call
+        result = asyncio.run(api_tool._run_without_io_trace(agent_input, **dynamic_params))
 
-    result, mock_make_api_call = asyncio.run(run_test())
-
-    assert isinstance(result, AgentPayload)
-    assert len(result.messages) == 1
-    assert result.messages[0].role == "assistant"
-    assert "result" in result.messages[0].content
-    assert result.artifacts["api_response"]["success"] is True
-    mock_make_api_call.assert_called_once_with(query="test", page=1, filter="active")
+        assert isinstance(result, AgentPayload)
+        assert len(result.messages) == 1
+        assert result.messages[0].role == "assistant"
+        assert "result" in result.messages[0].content
+        assert result.artifacts["api_response"]["success"] is True
+        mock_make_api_call.assert_called_once_with(**dynamic_params)
 
 
 def test_run_without_io_trace_error(api_tool):
-    async def run_test():
-        agent_input = AgentPayload(messages=[ChatMessage(role="user", content="test")])
+    agent_input = AgentPayload(messages=[ChatMessage(role="user", content="test")])
 
-        with patch.object(api_tool, "make_api_call") as mock_make_api_call:
-            mock_make_api_call.return_value = {"status_code": 500, "error": "Internal Server Error", "success": False}
+    with patch.object(api_tool, "make_api_call") as mock_make_api_call:
+        mock_make_api_call.return_value = {"status_code": 500, "error": "Internal Server Error", "success": False}
 
-            return await api_tool._run_without_io_trace(agent_input)
+        result = asyncio.run(api_tool._run_without_io_trace(agent_input))
 
-    result = asyncio.run(run_test())
-
-    assert isinstance(result, AgentPayload)
-    assert len(result.messages) == 1
-    assert result.messages[0].role == "assistant"
-    assert "API call failed" in result.messages[0].content
-    assert result.artifacts["api_response"]["success"] is False
+        assert isinstance(result, AgentPayload)
+        assert len(result.messages) == 1
+        assert result.messages[0].role == "assistant"
+        assert "API call failed" in result.messages[0].content
+        assert result.artifacts["api_response"]["success"] is False

--- a/tests/agent/test_graph_runner_block.py
+++ b/tests/agent/test_graph_runner_block.py
@@ -1,0 +1,217 @@
+"""
+Test module for GraphRunnerBlock functionality.
+Tests the ability to wrap a GraphRunner as an Agent and use it in another GraphRunner.
+"""
+
+import uuid
+import asyncio
+from unittest.mock import patch, MagicMock
+
+import pytest
+import networkx as nx
+
+from engine.agent.types import AgentPayload, ChatMessage, ComponentAttributes
+from engine.agent.graph_runner_block import GraphRunnerBlock, DEFAULT_GRAPH_RUNNER_BLOCK_TOOL_DESCRIPTION
+from engine.graph_runner.graph_runner import GraphRunner
+from tests.mocks.dummy_agent import DummyAgent
+
+
+@pytest.fixture
+def mock_trace_manager():
+    """Mock trace manager that returns a context manager."""
+    trace_manager = MagicMock()
+
+    # Create a mock context manager for start_span
+    mock_span = MagicMock()
+    mock_span.__enter__ = MagicMock(return_value=mock_span)
+    mock_span.__exit__ = MagicMock(return_value=None)
+
+    trace_manager.start_span.return_value = mock_span
+    return trace_manager
+
+
+@pytest.fixture
+def simple_graph_runner(mock_trace_manager):
+    """Create a simple graph runner with 3 dummy agents in sequence."""
+    # Create dummy agents
+    agent1 = DummyAgent(mock_trace_manager, "Step1", "a")
+    agent2 = DummyAgent(mock_trace_manager, "Step2", "b")
+    agent3 = DummyAgent(mock_trace_manager, "Step3", "c")
+
+    # Create graph structure: agent1 -> agent2 -> agent3
+    graph = nx.DiGraph()
+    graph.add_edge("agent1", "agent2")
+    graph.add_edge("agent2", "agent3")
+
+    # Create runnables dict
+    runnables = {
+        "agent1": agent1,
+        "agent2": agent2,
+        "agent3": agent3,
+    }
+
+    # Start nodes (only agent1)
+    start_nodes = ["agent1"]
+
+    return GraphRunner(
+        graph=graph,
+        runnables=runnables,
+        start_nodes=start_nodes,
+        trace_manager=mock_trace_manager,
+    )
+
+
+@pytest.fixture
+def nested_graph_runner(mock_trace_manager, simple_graph_runner):
+    """Create a graph runner that uses the GraphRunnerBlock to wrap another graph runner."""
+    # Create a GraphRunnerBlock that wraps the inner graph runner
+    graph_runner_block = GraphRunnerBlock(
+        trace_manager=mock_trace_manager,
+        graph_runner=simple_graph_runner,
+        tool_description=DEFAULT_GRAPH_RUNNER_BLOCK_TOOL_DESCRIPTION,
+        component_attributes=ComponentAttributes(
+            component_instance_id=uuid.uuid4(),
+            component_instance_name="wrapped_inner_graph",
+        ),
+    )
+
+    # Create additional dummy agents for the outer graph
+    pre_agent = DummyAgent(mock_trace_manager, "PRE", "pre")
+    post_agent = DummyAgent(mock_trace_manager, "POST", "post")
+
+    # Create graph structure: pre_agent -> graph_runner_block -> post_agent
+    graph = nx.DiGraph()
+    graph.add_edge("pre_agent", "wrapped_graph")
+    graph.add_edge("wrapped_graph", "post_agent")
+
+    # Create runnables dict
+    runnables = {
+        "pre_agent": pre_agent,
+        "wrapped_graph": graph_runner_block,  # Using GraphRunnerBlock as a runnable
+        "post_agent": post_agent,
+    }
+
+    # Start nodes (only pre_agent)
+    start_nodes = ["pre_agent"]
+
+    return GraphRunner(
+        graph=graph,
+        runnables=runnables,
+        start_nodes=start_nodes,
+        trace_manager=mock_trace_manager,
+    )
+
+
+@patch("engine.prometheus_metric.get_tracing_span")
+@patch("engine.prometheus_metric.agent_calls")
+def test_simple_graph_runner(mock_agent_calls, mock_get_tracing_span, simple_graph_runner):
+    """Test that a simple graph runner works as expected."""
+    # Setup prometheus mocks
+    mock_get_tracing_span.return_value = MagicMock(project_id="test_project")
+    mock_agent_calls.labels.return_value.inc = MagicMock()
+
+    input_payload = AgentPayload(messages=[ChatMessage(role="user", content="Hello World!")])
+
+    result = asyncio.run(simple_graph_runner.run(input_payload))
+
+    # Should apply Step1, Step2, Step3 prefixes in sequence
+    expected = "[Step3] [Step2] [Step1] Hello World!"
+    assert result.messages[-1].content == expected
+
+
+@patch("engine.prometheus_metric.get_tracing_span")
+@patch("engine.prometheus_metric.agent_calls")
+def test_graph_runner_block_direct(mock_agent_calls, mock_get_tracing_span, mock_trace_manager, simple_graph_runner):
+    """Test GraphRunnerBlock directly as an agent."""
+    # Setup prometheus mocks
+    mock_get_tracing_span.return_value = MagicMock(project_id="test_project")
+    mock_agent_calls.labels.return_value.inc = MagicMock()
+
+    # Create GraphRunnerBlock
+    graph_runner_block = GraphRunnerBlock(
+        trace_manager=mock_trace_manager,
+        graph_runner=simple_graph_runner,
+        tool_description=DEFAULT_GRAPH_RUNNER_BLOCK_TOOL_DESCRIPTION,
+        component_attributes=ComponentAttributes(
+            component_instance_id=uuid.uuid4(),
+            component_instance_name="direct_test",
+        ),
+    )
+
+    input_payload = AgentPayload(messages=[ChatMessage(role="user", content="Direct test!")])
+
+    result = asyncio.run(graph_runner_block.run(input_payload))
+
+    # Should apply Step1, Step2, Step3 prefixes in sequence
+    expected = "[Step3] [Step2] [Step1] Direct test!"
+    assert result.messages[-1].content == expected
+
+
+@patch("engine.prometheus_metric.get_tracing_span")
+@patch("engine.prometheus_metric.agent_calls")
+def test_nested_graph_runner(mock_agent_calls, mock_get_tracing_span, nested_graph_runner):
+    """Test the key functionality: a GraphRunner that contains a GraphRunnerBlock wrapping another GraphRunner."""
+    # Setup prometheus mocks
+    mock_get_tracing_span.return_value = MagicMock(project_id="test_project")
+    mock_agent_calls.labels.return_value.inc = MagicMock()
+
+    input_payload = AgentPayload(messages=[ChatMessage(role="user", content="Nested test!")])
+
+    result = asyncio.run(nested_graph_runner.run(input_payload))
+
+    # Should apply PRE, then the inner graph (Step1->Step2->Step3), then POST
+    expected = "[POST] [Step3] [Step2] [Step1] [PRE] Nested test!"
+    assert result.messages[-1].content == expected
+
+
+@patch("engine.prometheus_metric.get_tracing_span")
+@patch("engine.prometheus_metric.agent_calls")
+def test_graph_runner_block_tool_description(
+    mock_agent_calls, mock_get_tracing_span, mock_trace_manager, simple_graph_runner
+):
+    """Test that GraphRunnerBlock has the correct tool description."""
+    # Setup prometheus mocks
+    mock_get_tracing_span.return_value = MagicMock(project_id="test_project")
+    mock_agent_calls.labels.return_value.inc = MagicMock()
+
+    graph_runner_block = GraphRunnerBlock(
+        trace_manager=mock_trace_manager,
+        graph_runner=simple_graph_runner,
+        tool_description=DEFAULT_GRAPH_RUNNER_BLOCK_TOOL_DESCRIPTION,
+        component_attributes=ComponentAttributes(
+            component_instance_id=uuid.uuid4(),
+            component_instance_name="test_tool_desc",
+        ),
+    )
+
+    assert graph_runner_block.tool_description.name == "Graph Runner"
+    assert graph_runner_block.tool_description.description == "Execute a graph workflow"
+
+
+@patch("engine.prometheus_metric.get_tracing_span")
+@patch("engine.prometheus_metric.agent_calls")
+def test_graph_runner_block_empty_input(
+    mock_agent_calls, mock_get_tracing_span, mock_trace_manager, simple_graph_runner
+):
+    """Test GraphRunnerBlock with empty input."""
+    # Setup prometheus mocks
+    mock_get_tracing_span.return_value = MagicMock(project_id="test_project")
+    mock_agent_calls.labels.return_value.inc = MagicMock()
+
+    graph_runner_block = GraphRunnerBlock(
+        trace_manager=mock_trace_manager,
+        graph_runner=simple_graph_runner,
+        tool_description=DEFAULT_GRAPH_RUNNER_BLOCK_TOOL_DESCRIPTION,
+        component_attributes=ComponentAttributes(
+            component_instance_id=uuid.uuid4(),
+            component_instance_name="empty_test",
+        ),
+    )
+
+    input_payload = AgentPayload(messages=[])
+
+    result = asyncio.run(graph_runner_block.run(input_payload))
+
+    # Should apply Step1, Step2, Step3 prefixes to "empty input"
+    expected = "[Step3] [Step2] [Step1] empty input"
+    assert result.messages[-1].content == expected

--- a/tests/agent/test_python_code_runner.py
+++ b/tests/agent/test_python_code_runner.py
@@ -63,12 +63,11 @@ def test_tool_description_structure():
     assert "python_code" in desc.required_tool_properties
 
 
-@pytest.mark.anyio
-async def test_execute_simple_python_code(e2b_tool, e2b_api_key):
+def test_execute_simple_python_code(e2b_tool, e2b_api_key):
     """Test executing simple Python code that returns a value."""
     python_code = "print('Hello, World!'); x = 42; x"
 
-    result_data = await e2b_tool.execute_python_code(python_code)
+    result_data = asyncio.run(e2b_tool.execute_python_code(python_code))
 
     # Check that the execution was successful
     assert "error" in result_data
@@ -87,8 +86,7 @@ async def test_execute_simple_python_code(e2b_tool, e2b_api_key):
     assert result_data["results"][0].text == "42"
 
 
-@pytest.mark.anyio
-async def test_execute_python_code_with_imports(e2b_tool, e2b_api_key):
+def test_execute_python_code_with_imports(e2b_tool, e2b_api_key):
     """Test executing Python code that uses standard library imports."""
     python_code = """
 import math
@@ -105,7 +103,7 @@ result = {"area": area, "date": current_time}
 result
 """
 
-    result_data = await e2b_tool.execute_python_code(python_code)
+    result_data = asyncio.run(e2b_tool.execute_python_code(python_code))
 
     assert "error" in result_data
     assert "stdout" in result_data
@@ -125,8 +123,7 @@ result
     assert "date" in result_obj.json
 
 
-@pytest.mark.anyio
-async def test_execute_python_code_with_error(e2b_tool, e2b_api_key):
+def test_execute_python_code_with_error(e2b_tool, e2b_api_key):
     """Test executing Python code that raises an error."""
     python_code = """
 x = 10
@@ -134,7 +131,7 @@ y = 0
 result = x / y  # This will raise a ZeroDivisionError
 """
 
-    result_data = await e2b_tool.execute_python_code(python_code)
+    result_data = asyncio.run(e2b_tool.execute_python_code(python_code))
 
     assert "error" in result_data
     assert "stdout" in result_data
@@ -149,8 +146,7 @@ result = x / y  # This will raise a ZeroDivisionError
     assert "ZeroDivisionError" in result_data["error"] or "division by zero" in result_data["error"]
 
 
-@pytest.mark.anyio
-async def test_execute_python_code_with_file_operations(e2b_tool, e2b_api_key):
+def test_execute_python_code_with_file_operations(e2b_tool, e2b_api_key):
     """Test executing Python code that performs file operations."""
     python_code = """
 # Create a file and write to it
@@ -170,7 +166,7 @@ files = os.listdir('.')
 {"content": content, "files": files}
 """
 
-    result_data = await e2b_tool.execute_python_code(python_code)
+    result_data = asyncio.run(e2b_tool.execute_python_code(python_code))
 
     assert "error" in result_data
     assert "stdout" in result_data
@@ -189,8 +185,7 @@ files = os.listdir('.')
     assert "test_file.txt" in result_obj.json["files"]
 
 
-@pytest.mark.anyio
-async def test_execute_python_code_with_data_processing(e2b_tool, e2b_api_key):
+def test_execute_python_code_with_data_processing(e2b_tool, e2b_api_key):
     """Test executing Python code that processes data."""
     python_code = """
 # Create some sample data
@@ -215,7 +210,7 @@ print(f"Even numbers: {even_numbers}")
 }
 """
 
-    result_data = await e2b_tool.execute_python_code(python_code)
+    result_data = asyncio.run(e2b_tool.execute_python_code(python_code))
 
     assert "error" in result_data
     assert "stdout" in result_data
@@ -239,8 +234,7 @@ print(f"Even numbers: {even_numbers}")
     assert result_data_obj["even_numbers"] == [2, 4, 6, 8, 10]
 
 
-@pytest.mark.anyio
-async def test_execute_python_code_with_single_image(e2b_tool, e2b_api_key):
+def test_execute_python_code_with_single_image(e2b_tool, e2b_api_key):
     """Test executing Python code that generates a single matplotlib plot."""
     python_code = """
 import matplotlib.pyplot as plt
@@ -261,7 +255,7 @@ plt.show()
 print("Single plot generated!")
 """
 
-    result_data = await e2b_tool.execute_python_code(python_code)
+    result_data = asyncio.run(e2b_tool.execute_python_code(python_code))
 
     # Check that execution was successful
     assert result_data["error"] is None
@@ -285,8 +279,7 @@ print("Single plot generated!")
         pytest.fail("Image data is not valid base64")
 
 
-@pytest.mark.anyio
-async def test_execute_python_code_with_multiple_images(e2b_tool, e2b_api_key):
+def test_execute_python_code_with_multiple_images(e2b_tool, e2b_api_key):
     """Test executing Python code that generates multiple matplotlib plots."""
     python_code = """
 import matplotlib.pyplot as plt
@@ -319,7 +312,7 @@ plt.show()
 print("Three plots generated!")
 """
 
-    result_data = await e2b_tool.execute_python_code(python_code)
+    result_data = asyncio.run(e2b_tool.execute_python_code(python_code))
 
     # Check that execution was successful
     assert result_data["error"] is None
@@ -343,8 +336,7 @@ print("Three plots generated!")
             pytest.fail(f"Image {i+1} data is not valid base64")
 
 
-@pytest.mark.anyio
-async def test_execute_python_code_with_no_images(e2b_tool, e2b_api_key):
+def test_execute_python_code_with_no_images(e2b_tool, e2b_api_key):
     """Test executing Python code that doesn't generate any images."""
     python_code = """
 import numpy as np
@@ -362,7 +354,7 @@ print("Calculations completed!")
 result
 """
 
-    result_data = await e2b_tool.execute_python_code(python_code)
+    result_data = asyncio.run(e2b_tool.execute_python_code(python_code))
 
     # Check that execution was successful
     assert result_data["error"] is None
@@ -374,8 +366,7 @@ result
     assert len(images) == 0
 
 
-@pytest.mark.anyio
-async def test_run_without_io_trace_with_single_image(e2b_tool, e2b_api_key):
+def test_run_without_io_trace_with_single_image(e2b_tool, e2b_api_key):
     """Test the async _run_without_io_trace method with image generation."""
     python_code = """
 import matplotlib.pyplot as plt
@@ -393,7 +384,7 @@ plt.show()
 print("Async image test completed!")
 """
 
-    result = await e2b_tool._run_without_io_trace(python_code=python_code)
+    result = asyncio.run(e2b_tool._run_without_io_trace(python_code=python_code))
 
     assert isinstance(result, AgentPayload)
     assert len(result.messages) == 1
@@ -425,8 +416,7 @@ print("Async image test completed!")
     assert "[1 image(s) generated and included in artifacts]" in content
 
 
-@pytest.mark.anyio
-async def test_run_without_io_trace_with_multiple_images(e2b_tool, e2b_api_key):
+def test_run_without_io_trace_with_multiple_images(e2b_tool, e2b_api_key):
     """Test the async _run_without_io_trace method with multiple image generation."""
     python_code = """
 import matplotlib.pyplot as plt
@@ -444,7 +434,7 @@ for i, func in enumerate([np.sin, np.cos]):
 print("Two async plots generated!")
 """
 
-    result = await e2b_tool._run_without_io_trace(python_code=python_code)
+    result = asyncio.run(e2b_tool._run_without_io_trace(python_code=python_code))
 
     assert isinstance(result, AgentPayload)
     assert len(result.messages) == 1
@@ -471,12 +461,11 @@ print("Two async plots generated!")
     assert "[2 image(s) generated and included in artifacts]" in content
 
 
-@pytest.mark.anyio
-async def test_run_without_io_trace_no_images(e2b_tool, e2b_api_key):
+def test_run_without_io_trace_no_images(e2b_tool, e2b_api_key):
     """Test the async _run_without_io_trace method with no image generation."""
     python_code = "print('No images here!'); result = {'value': 42}; result"
 
-    result = await e2b_tool._run_without_io_trace(python_code=python_code)
+    result = asyncio.run(e2b_tool._run_without_io_trace(python_code=python_code))
 
     assert isinstance(result, AgentPayload)
     assert len(result.messages) == 1
@@ -492,12 +481,11 @@ async def test_run_without_io_trace_no_images(e2b_tool, e2b_api_key):
     assert "image(s) generated" not in content
 
 
-@pytest.mark.anyio
-async def test_run_without_io_trace_simple_code(e2b_tool, e2b_api_key):
+def test_run_without_io_trace_simple_code(e2b_tool, e2b_api_key):
     """Test the async _run_without_io_trace method with simple code."""
     python_code = "print('Async test'); 2 + 2"
 
-    result = await e2b_tool._run_without_io_trace(python_code=python_code)
+    result = asyncio.run(e2b_tool._run_without_io_trace(python_code=python_code))
 
     assert isinstance(result, AgentPayload)
     assert len(result.messages) == 1
@@ -533,8 +521,7 @@ async def test_run_without_io_trace_simple_code(e2b_tool, e2b_api_key):
     # Note: artifacts has Result objects while execution_data has serialized strings
 
 
-@pytest.mark.anyio
-async def test_run_without_io_trace_complex_code(e2b_tool, e2b_api_key):
+def test_run_without_io_trace_complex_code(e2b_tool, e2b_api_key):
     """Test the async _run_without_io_trace method with complex code."""
     python_code = """
 import json
@@ -564,7 +551,7 @@ print(f"Processed {len(data['numbers'])} numbers")
 json.dumps(result)
 """
 
-    result = await e2b_tool._run_without_io_trace(python_code=python_code)
+    result = asyncio.run(e2b_tool._run_without_io_trace(python_code=python_code))
 
     assert isinstance(result, AgentPayload)
     assert len(result.messages) == 1
@@ -597,8 +584,7 @@ json.dumps(result)
     assert '"count": 5' in result_obj
 
 
-@pytest.mark.anyio
-async def test_missing_api_key():
+def test_missing_api_key():
     """Test that the tool raises an error when E2B API key is not configured."""
     with pytest.MonkeyPatch().context() as m:
         m.setattr("settings.settings.E2B_API_KEY", None)
@@ -610,7 +596,7 @@ async def test_missing_api_key():
             ),
         )
         with pytest.raises(ValueError, match="E2B API key not configured"):
-            await tool.execute_python_code("print('test')")
+            asyncio.run(tool.execute_python_code("print('test')"))
 
 
 def test_sandbox_timeout_configuration():

--- a/tests/mocks/dummy_agent.py
+++ b/tests/mocks/dummy_agent.py
@@ -1,0 +1,47 @@
+"""
+Reusable dummy agent for testing purposes.
+This agent simply adds a prefix to input messages, useful for testing graph flows.
+"""
+
+import uuid
+from engine.agent.agent import Agent
+from engine.agent.types import AgentPayload, ChatMessage, ToolDescription, ComponentAttributes
+
+
+class DummyAgent(Agent):
+    """A reusable dummy agent for testing that adds a prefix to the input message"""
+
+    def __init__(self, trace_manager, prefix: str, agent_id: str = None):
+        if agent_id is None:
+            agent_id = prefix.lower()
+
+        tool_description = ToolDescription(
+            name=f"Dummy Agent {prefix}",
+            description=f"Adds '{prefix}' prefix to messages",
+            tool_properties={},
+            required_tool_properties=[],
+        )
+        component_attributes = ComponentAttributes(
+            component_instance_id=uuid.uuid4(),
+            component_instance_name=f"dummy_{prefix}_{agent_id}",
+        )
+        super().__init__(
+            trace_manager=trace_manager,
+            tool_description=tool_description,
+            component_attributes=component_attributes,
+        )
+        self.prefix = prefix
+
+    async def _run_without_io_trace(self, *inputs: AgentPayload, **kwargs) -> AgentPayload:
+        input_payload = inputs[0] if inputs else AgentPayload(messages=[])
+
+        # Get the last message content or use default
+        if input_payload.messages:
+            last_content = input_payload.messages[-1].content or ""
+        else:
+            last_content = "empty input"
+
+        # Add prefix
+        new_content = f"[{self.prefix}] {last_content}"
+
+        return AgentPayload(messages=[ChatMessage(role="assistant", content=new_content)])


### PR DESCRIPTION
# PR: Secure Project Referencing (ProjectReference / GraphRunnerBlock)

## Why

This PR lays the groundwork for the upcoming **Chunk Processor**. The main challenges were not in splitting/merging data, but in **secure project referencing**: how to run another project’s graph as a component, ensure the user has permission, and handle sync/async safely. Once this is solid, the Chunk Processor can reuse the same parameter processor and focus only on chunking logic.

## What’s in this PR

* **GraphRunnerBlock** agent to run a graph as a single node (supports nested graphs).
* **ProjectReference** component (UI-facing) with `project_id`.
* **RequestContext** via `ContextVar` for Supabase user per request.
* **Permission validation** in parameter processor using Supabase + `anyio.from_thread.run`.
* **Entity factory/registry wiring** for ProjectReference → GraphRunnerBlock.
* **Seeding**: component, tool description, constants; registry entries.
* **Fixes**: circular imports (lazy imports, constants refactor) (**edits on seed files**).
* **Tests**: GraphRunnerBlock incl. nested graphs & IO handling.

## Tested Flow

Built a flow on the frontend:
`API Input → AI Agent (internet search) → ProjectReference (child project: simple LLM call that translates to sarcastic French`
Input: “tell me the current conversion rate of the dollar.”
Result: worked end-to-end — internet search produced rates, ProjectReference invoked the child project, and the final output was the sarcastic French translation.
**NOTE: Referenced project needs to be _deployed_ to make it work, ProjectReference uses the latest _production_  project referenced. Choosing the version will come soon**).

## Debug note

When running a ProjectReference, the output from the upstream block was being lost upon entering the child project’s **Input** component, which defaulted to `"Hello"`. This happened because the Input logic overwrote incoming values with defaults and only worked with `dict`, while the ProjectReference passed an `AgentPayload`. The fix was to update the Input block to handle both `AgentPayload` and `dict`, preserving runtime values instead of replacing them. With this change, inputs now flow correctly into child graphs, and ProjectReference produces the expected output.

