### PR TITLE
docs: fix environment variables typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Here are two important variables that you get in the terminal when running supab
 - **anon key**: `ey_...`
 - **service_role key**: `eyJ...`
 
-You need to use them to to fill those environnement variables:
+You need to use them to fill those environment variables:
 
 ```env
 SUPABASE_PROJECT_KEY=*anon-key*


### PR DESCRIPTION
## Summary
- fix README wording regarding environment variables

## Testing
- `make test` *(fails: ADA_DB_URL is required for SQLite)*

------
https://chatgpt.com/codex/tasks/task_b_68aeafb88e60832c8dfa91cfe4cd382f