### PR TITLE
[dra-374] add update endpoint for source

### DIFF
--- a/ada_backend/database/alembic/versions/8b393d7c2c4b_update_api_keys_table.py
+++ b/ada_backend/database/alembic/versions/8b393d7c2c4b_update_api_keys_table.py
@@ -1,0 +1,148 @@
+"""update api keys table
+
+Revision ID: 8b393d7c2c4b
+Revises: d4a5151de832
+Create Date: 2025-09-04 18:01:58.754696
+
+"""
+
+# alembic revision: introduce polymorphic api_keys without legacy org table
+from __future__ import annotations
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as psql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8b393d7c2c4b"
+down_revision: Union[str, None] = "d4a5151de832"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    scope_enum = psql.ENUM("project", "organization", name="api_key_scope")
+    scope_enum.create(conn, checkfirst=True)
+
+    # 1) Add discriminator column to base api_keys
+    op.add_column(
+        "api_keys",
+        sa.Column("type", scope_enum, nullable=False, server_default="project"),
+    )
+
+    # 2) Create child table for project keys
+    op.create_table(
+        "project_api_keys",
+        sa.Column(
+            "id",
+            psql.UUID(as_uuid=True),
+            sa.ForeignKey("api_keys.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "project_id",
+            psql.UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_project_api_keys_project_id",
+        "project_api_keys",
+        ["project_id"],
+        unique=False,
+    )
+
+    # 3) Move existing project_id links into child table
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO project_api_keys (id, project_id)
+            SELECT id, project_id
+            FROM api_keys
+            WHERE project_id IS NOT NULL
+            """
+        )
+    )
+
+    # 4) Drop project_id from base table now that link is in child
+    with op.batch_alter_table("api_keys") as batch:
+        batch.drop_column("project_id")
+
+    # 5) Create (empty) child table for org keys — no data migration
+    op.create_table(
+        "org_api_keys",
+        sa.Column(
+            "id",
+            psql.UUID(as_uuid=True),
+            sa.ForeignKey("api_keys.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "organization_id",
+            psql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_org_api_keys_organization_id",
+        "org_api_keys",
+        ["organization_id"],
+        unique=False,
+    )
+
+    # 6) Remove server default on discriminator after backfill
+    with op.batch_alter_table("api_keys") as batch:
+        batch.alter_column("type", server_default=None)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # 1) Add project_id back to base (nullable for backfill)
+    with op.batch_alter_table("api_keys") as batch:
+        batch.add_column(sa.Column("project_id", psql.UUID(as_uuid=True), nullable=True))
+
+    # 2) Restore project_id from child table
+    conn.execute(
+        sa.text(
+            """
+            UPDATE api_keys a
+            SET project_id = p.project_id
+            FROM project_api_keys p
+            WHERE p.id = a.id
+            """
+        )
+    )
+    conn.execute(
+        sa.text(
+            """
+        DELETE FROM api_keys
+        WHERE "type"::text = 'organization'
+           OR "type" = 'organization'
+    """
+        )
+    )
+
+    # 3) Make project_id NOT NULL again (match original schema)
+    with op.batch_alter_table("api_keys") as batch:
+        batch.alter_column("project_id", existing_type=psql.UUID(as_uuid=True), nullable=False)
+
+    # 4) Drop child tables + their indexes
+    op.drop_index("ix_project_api_keys_project_id", table_name="project_api_keys")
+    op.drop_table("project_api_keys")
+
+    op.drop_index("ix_org_api_keys_organization_id", table_name="org_api_keys")
+    op.drop_table("org_api_keys")
+
+    # 5) Drop discriminator column
+    with op.batch_alter_table("api_keys") as batch:
+        batch.drop_column("type")
+
+    # 6) Drop enum type
+    scope_enum = psql.ENUM("project", "organization", name="api_key_scope")
+    scope_enum.drop(conn, checkfirst=True)

--- a/ada_backend/repositories/api_key_repository.py
+++ b/ada_backend/repositories/api_key_repository.py
@@ -8,25 +8,6 @@ from ada_backend.database import models as db
 
 def create_api_key(
     session: Session,
-    project_id: UUID,
-    key_name: str,
-    hashed_key: str,
-    creator_user_id: UUID,
-) -> UUID:
-    """Creates a new API key for the given user, returns the key id."""
-    new_api_key = db.ApiKey(
-        project_id=project_id,
-        public_key=hashed_key,
-        name=key_name,
-        creator_user_id=creator_user_id,
-    )
-    session.add(new_api_key)
-    session.commit()
-    return new_api_key.id
-
-
-def create_api_key(
-    session: Session,
     scope_type: db.ApiKeyType,
     scope_id: UUID,
     key_name: str,
@@ -76,6 +57,14 @@ def get_api_keys_by_project_id(session: Session, project_id: UUID) -> list[db.Ap
             db.ProjectApiKey.project_id == project_id,
             db.ProjectApiKey.is_active.is_(True),
         )
+        .all()
+    )
+
+
+def get_api_keys_by_org_id(session: Session, org_id: UUID) -> list[db.OrgApiKey]:
+    return (
+        session.query(db.OrgApiKey)
+        .filter(db.OrgApiKey.organization_id == org_id, db.OrgApiKey.is_active.is_(True))
         .all()
     )
 

--- a/ada_backend/routers/auth_router.py
+++ b/ada_backend/routers/auth_router.py
@@ -8,18 +8,20 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from supabase import Client, create_client
 from sqlalchemy.orm import Session
 
+from ada_backend.database.models import ApiKeyType
 from ada_backend.repositories.project_repository import get_project
 from settings import settings
 from ada_backend.database.setup_db import get_db
 from ada_backend.services.api_key_service import (
+    generate_scoped_api_key,
     get_api_keys_service,
-    generate_api_key,
     deactivate_api_key_service,
     verify_api_key,
     verify_ingestion_api_key,
 )
 from ada_backend.services.user_roles_service import get_user_access_to_organization
 from ada_backend.schemas.auth_schema import (
+    OrgApiKeyCreateRequest,
     SupabaseUser,
     ApiKeyGetResponse,
     ApiKeyCreateRequest,
@@ -195,10 +197,53 @@ async def create_api_key(
     user = await _is_user(project_id=api_key_create.project_id, user=user, session=session)
 
     try:
-        return generate_api_key(
+        return generate_scoped_api_key(
             session=session,
-            project_id=api_key_create.project_id,
+            scope_type=ApiKeyType.PROJECT.value,
+            scope_id=api_key_create.project_id,
             key_name=api_key_create.key_name,
+            creator_user_id=user.id,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Failed to create API key") from e
+
+
+@router.post("/org-api-key", summary="Create Organization API Key")
+async def create_org_api_key(
+    user: Annotated[SupabaseUser, Depends(get_user_from_supabase_token)],
+    session: Session = Depends(get_db),
+    org_api_key_create: OrgApiKeyCreateRequest = Body(...),
+) -> ApiKeyCreatedResponse:
+    """
+    Generate and store a new organization API key for the authenticated user.
+    This API key gives users access to run inferences using an any Agent or Pipeline
+    that they have access to (i.e. they are a member of the organization that
+    the Agent or Pipeline belongs to)
+
+    Args:
+        user (SupabaseUser): User information from Supabase.
+        db (Session): Database session.
+
+    Returns:
+        ApiKeyCreatedResponse: Generated API key.
+
+    Raises:
+        HTTPException: If the API key cannot be created.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    _is_user = user_has_access_to_organization_dependency(
+        allowed_roles=set(UserRights.USER.value),
+    )
+    user = await _is_user(organization_id=org_api_key_create.org_id, user=user)
+
+    try:
+        return generate_scoped_api_key(
+            session=session,
+            scope_type=ApiKeyType.ORGANIZATION.value,
+            scope_id=org_api_key_create.org_id,
+            key_name=org_api_key_create.key_name,
             creator_user_id=user.id,
         )
     except Exception as e:

--- a/ada_backend/routers/auth_router.py
+++ b/ada_backend/routers/auth_router.py
@@ -267,7 +267,7 @@ async def create_org_api_key(
             creator_user_id=user.id,
         )
     except Exception as e:
-        raise HTTPException(status_code=500, detail="Failed to create API key") from e
+        raise HTTPException(status_code=500, detail="Failed to create Organization API key") from e
 
 
 @router.delete("/api-key", summary="Delete API Key")

--- a/ada_backend/routers/auth_router.py
+++ b/ada_backend/routers/auth_router.py
@@ -160,7 +160,7 @@ async def get_api_keys(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
     try:
-        return get_api_keys_service(session, project_id)
+        return get_api_keys_service(session, project_id=project_id)
     except Exception as e:
         raise HTTPException(status_code=500, detail="Failed to get API keys") from e
 
@@ -206,6 +206,26 @@ async def create_api_key(
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail="Failed to create API key") from e
+
+
+@router.get("/org-api-key", summary="Get Organization API Keys")
+async def get_org_api_keys(
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.USER.value)),
+    ],
+    session: Session = Depends(get_db),
+    organization_id: UUID = Query(..., description="The ID of the organization to retrieve API keys for"),
+) -> ApiKeyGetResponse:
+    """
+    Get all active API keys for the authenticated user.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+    try:
+        return get_api_keys_service(session, organization_id=organization_id)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Failed to get API keys") from e
 
 
 @router.post("/org-api-key", summary="Create Organization API Key")

--- a/ada_backend/routers/ingestion_task_router.py
+++ b/ada_backend/routers/ingestion_task_router.py
@@ -56,8 +56,9 @@ def create_organization_task(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
     try:
-        # Create the ingestion task
-        task_id = create_ingestion_task_by_organization(session, organization_id, ingestion_task_data, user_id=user.id)
+        task_id = create_ingestion_task_by_organization(
+            session, organization_id=organization_id, ingestion_task_data=ingestion_task_data, user_id=user.id
+        )
         return task_id
     except Exception as e:
         raise HTTPException(status_code=500, detail="Internal Server Error") from e
@@ -71,7 +72,9 @@ def update_organization_task(
     session: Session = Depends(get_db),
 ):
     try:
-        upsert_ingestion_task_by_organization_id(session, organization_id, ingestion_task_data)
+        upsert_ingestion_task_by_organization_id(
+            session, organization_id=organization_id, ingestion_task_data=ingestion_task_data
+        )
         return None
     except Exception as e:
         raise HTTPException(status_code=500, detail="Internal Server Error") from e
@@ -89,7 +92,7 @@ def delete_organization_task(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
     try:
-        delete_ingestion_task_by_id(session, organization_id, source_id)
+        delete_ingestion_task_by_id(session, organization_id=organization_id, id=source_id)
         return None
     except Exception as e:
         raise HTTPException(status_code=500, detail="Internal Server Error") from e

--- a/ada_backend/routers/ingestion_task_router.py
+++ b/ada_backend/routers/ingestion_task_router.py
@@ -57,7 +57,7 @@ def create_organization_task(
         raise HTTPException(status_code=400, detail="User ID not found")
     try:
         # Create the ingestion task
-        task_id = create_ingestion_task_by_organization(session, user.id, organization_id, ingestion_task_data)
+        task_id = create_ingestion_task_by_organization(session, organization_id, ingestion_task_data, user_id=user.id)
         return task_id
     except Exception as e:
         raise HTTPException(status_code=500, detail="Internal Server Error") from e

--- a/ada_backend/routers/source_router.py
+++ b/ada_backend/routers/source_router.py
@@ -4,11 +4,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from ada_backend.database.setup_db import get_db
-from ada_backend.schemas.auth_schema import SupabaseUser
+from ada_backend.schemas.auth_schema import SupabaseUser, VerifiedApiKey
 from ada_backend.schemas.source_schema import DataSourceSchema, DataSourceSchemaResponse
 from ada_backend.routers.auth_router import (
     user_has_access_to_organization_dependency,
     UserRights,
+    verify_api_key_dependency,
     verify_ingestion_api_key_dependency,
 )
 from ada_backend.services.source_service import (
@@ -65,6 +66,22 @@ def update_organization_source(
         raise HTTPException(status_code=400, detail="User ID not found")
     try:
         updated_source = update_source_by_source_id(session, organization_id, source_id, user.id)
+        return upsert_source_by_organization(session, organization_id, updated_source)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Internal Server Error") from e
+
+
+@router.post("/{organization_id}/{source_id}", status_code=status.HTTP_200_OK)
+def update_organization_source_by_org_api_key(
+    organization_id: UUID,
+    source_id: UUID,
+    session: Session = Depends(get_db),
+    verified_api_key: VerifiedApiKey = Depends(verify_api_key_dependency),
+):
+    if verified_api_key.organization_id != organization_id:
+        raise HTTPException(status_code=403, detail="You don't have access to this organization")
+    try:
+        updated_source = update_source_by_source_id(session, organization_id, source_id, verified_api_key.user_id)
         return upsert_source_by_organization(session, organization_id, updated_source)
     except Exception as e:
         raise HTTPException(status_code=500, detail="Internal Server Error") from e

--- a/ada_backend/routers/source_router.py
+++ b/ada_backend/routers/source_router.py
@@ -65,14 +65,14 @@ def update_organization_source(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
     try:
-        updated_source = update_source_by_source_id(session, organization_id, source_id, user.id)
+        updated_source = update_source_by_source_id(session, organization_id, source_id, user_id=user.id)
         return upsert_source_by_organization(session, organization_id, updated_source)
     except Exception as e:
         raise HTTPException(status_code=500, detail="Internal Server Error") from e
 
 
-@router.post("/{organization_id}/{source_id}", status_code=status.HTTP_200_OK)
-def update_organization_source_by_org_api_key(
+@router.post("/{organization_id}/{source_id}/api-key", status_code=status.HTTP_200_OK)
+def update_organization_source_api_key(
     organization_id: UUID,
     source_id: UUID,
     session: Session = Depends(get_db),
@@ -81,7 +81,9 @@ def update_organization_source_by_org_api_key(
     if verified_api_key.organization_id != organization_id:
         raise HTTPException(status_code=403, detail="You don't have access to this organization")
     try:
-        updated_source = update_source_by_source_id(session, organization_id, source_id, verified_api_key.user_id)
+        updated_source = update_source_by_source_id(
+            session, organization_id, source_id, api_key_id=verified_api_key.api_key_id
+        )
         return upsert_source_by_organization(session, organization_id, updated_source)
     except Exception as e:
         raise HTTPException(status_code=500, detail="Internal Server Error") from e

--- a/ada_backend/schemas/auth_schema.py
+++ b/ada_backend/schemas/auth_schema.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -29,6 +30,11 @@ class ApiKeyCreateRequest(BaseModel):
     project_id: UUID
 
 
+class OrgApiKeyCreateRequest(BaseModel):
+    key_name: str
+    org_id: UUID
+
+
 class ApiKeyCreatedResponse(BaseModel):
     private_key: str
     key_id: UUID
@@ -45,4 +51,6 @@ class ApiKeyDeleteResponse(BaseModel):
 
 class VerifiedApiKey(BaseModel):
     api_key_id: UUID
-    project_id: UUID
+    scope_type: str
+    project_id: Optional[UUID]
+    organization_id: Optional[UUID]

--- a/ada_backend/schemas/auth_schema.py
+++ b/ada_backend/schemas/auth_schema.py
@@ -21,7 +21,8 @@ class ApiKeyData(BaseModel):
 
 
 class ApiKeyGetResponse(BaseModel):
-    project_id: UUID
+    project_id: Optional[UUID]
+    organization_id: Optional[UUID]
     api_keys: list[ApiKeyData]
 
 

--- a/ada_backend/segment_analytics.py
+++ b/ada_backend/segment_analytics.py
@@ -110,13 +110,34 @@ def track_project_observability_loaded(user_id: UUID, project_id: UUID):
 
 
 @non_breaking_track
-def track_ingestion_task_created(user_id: UUID, organization_id: UUID, task_id: UUID):
-    analytics.track(
-        user_id=str(user_id),
-        event="Ingestion Task Created",
-        properties={
-            "env": settings.ENV,
-            "organization_id": str(organization_id),
-            "task_id": str(task_id),
-        },
-    )
+def track_ingestion_task_created(
+    task_id: UUID,
+    organization_id: UUID,
+    user_id: UUID | None = None,
+    api_key_id: UUID | None = None,
+):
+    properties = {
+        "env": settings.ENV,
+        "organization_id": str(organization_id),
+        "task_id": str(task_id),
+    }
+
+    if api_key_id:
+        properties["api_key_name"] = api_key_id
+        analytics.track(
+            user_id="api_key:" + api_key_id,
+            event="Ingestion Task Created",
+            properties=properties,
+        )
+    elif user_id:
+        analytics.track(
+            user_id=str(user_id),
+            event="Ingestion Task Created",
+            properties=properties,
+        )
+    else:
+        analytics.track(
+            user_id="unknown",
+            event="Ingestion Task Created",
+            properties=properties,
+        )

--- a/ada_backend/segment_analytics.py
+++ b/ada_backend/segment_analytics.py
@@ -123,9 +123,9 @@ def track_ingestion_task_created(
     }
 
     if api_key_id:
-        properties["api_key_name"] = api_key_id
+        properties["api_key_id"] = api_key_id
         analytics.track(
-            user_id="api_key:" + api_key_id,
+            anonymous_id=str(organization_id),
             event="Ingestion Task Created",
             properties=properties,
         )
@@ -137,7 +137,7 @@ def track_ingestion_task_created(
         )
     else:
         analytics.track(
-            user_id="unknown",
+            anonymous_id=str(organization_id),
             event="Ingestion Task Created",
             properties=properties,
         )

--- a/ada_backend/services/api_key_service.py
+++ b/ada_backend/services/api_key_service.py
@@ -132,7 +132,7 @@ def verify_api_key(session: Session, private_key: str) -> VerifiedApiKey:
             raise ValueError("Organization not found for the given API key")
         return VerifiedApiKey(
             api_key_id=api_key.id,
-            scope_type=api_key.type,  # l’enum tel quel
+            scope_type=api_key.type,
             project_id=None,
             organization_id=api_key.organization_id,
         )

--- a/ada_backend/services/ingestion_task_service.py
+++ b/ada_backend/services/ingestion_task_service.py
@@ -48,9 +48,10 @@ def get_ingestion_task_by_organization_id(
 
 def create_ingestion_task_by_organization(
     session: Session,
-    user_id: UUID,
     organization_id: UUID,
     ingestion_task_data: IngestionTaskQueue,
+    user_id: UUID | None = None,
+    api_key_id: UUID | None = None,
 ) -> UUID:
     """Create a new source for an organization."""
     try:
@@ -61,7 +62,7 @@ def create_ingestion_task_by_organization(
             ingestion_task_data.source_type,
             ingestion_task_data.status,
         )
-        track_ingestion_task_created(user_id, organization_id, task_id)
+        track_ingestion_task_created(task_id, organization_id, user_id=user_id, api_key_id=api_key_id)
 
         LOGGER.info(f"Task created in database with ID {task_id}")
 

--- a/ada_backend/services/source_service.py
+++ b/ada_backend/services/source_service.py
@@ -193,7 +193,8 @@ def update_source_by_source_id(
     session: Session,
     organization_id: UUID,
     source_id: UUID,
-    user_id: UUID,
+    user_id: UUID | None = None,
+    api_key_id: UUID | None = None,
 ) -> DataSourceUpdateSchema:
 
     source_attributes = get_source_attributes_by_org_id(session, organization_id, source_id)
@@ -204,7 +205,9 @@ def update_source_by_source_id(
         status=db.TaskStatus.PENDING,
         source_attributes=source_attributes,
     )
-    create_ingestion_task_by_organization(session, user_id, organization_id, ingestion_task_data)
+    create_ingestion_task_by_organization(
+        session, organization_id, ingestion_task_data, user_id=user_id, api_key_id=api_key_id
+    )
     updated_source = DataSourceUpdateSchema(
         id=source_data.id,
         name=source_data.name,


### PR DESCRIPTION
## Refactor API key storage to enable organization-level API keys

- Introduce `ApiKey` base model using _polymorphic inheritance_
- Add `project_api_keys` and `org_api_keys` child tables
- Update services and repositories accordingly with migration support
- Add 2 endpoints to handle organization api keys : get and post

## Create an update source endpoint that use this organization-level api key
- `/sources/{organization_id}/{source_id}/api-key`


# To test the PR 
You can test the PR by:
- creating an org-api-key
- getting the org-api-key
- and here is a piece of code to test the update with the endpoint
    ```
    import requests
    
    ORGANIZATION_ID = "01b6554c-4884-409f-a0e1-22e394bee989" #SCOPEO
    SOURCE_ID=XXX
    API_KEY= XXX
    
    URL = f"http://localhost:8000/sources/{ORGANIZATION_ID}/{SOURCE_ID}/api-key"
    
    headers = {
        "X-API-Key": API_KEY,
    }
    
    response = requests.post(URL, headers=headers)
    if response.status_code == 200:
        print("Success")
    else:
        print("Error:", response.status_code, response.text)
    ```