### PR TITLE
Add now or current timestamp detection in query filter

### DIFF
--- a/engine/qdrant_service.py
+++ b/engine/qdrant_service.py
@@ -610,6 +610,7 @@ class QdrantService:
         )
         if schema.metadata_fields_to_keep:
             for metadata_field in schema.metadata_fields_to_keep:
+                field_type = FieldSchema.KEYWORD  # Default type
                 if schema.metadata_field_types and metadata_field in schema.metadata_field_types:
                     internal_type = schema.metadata_field_types[metadata_field]
                     field_type = map_internal_type_to_qdrant_field_schema(internal_type)
@@ -617,7 +618,7 @@ class QdrantService:
             await self.create_index_if_needed_async(
                 collection_name=collection_name,
                 field_name=metadata_field,
-                field_schema_type=field_type if field_type else FieldSchema.KEYWORD,
+                field_schema_type=field_type,
             )
         if schema.last_edited_ts_field:
             await self.create_index_if_needed_async(
@@ -1103,6 +1104,7 @@ class QdrantService:
         )
         if schema.metadata_fields_to_keep:
             for metadata_field in schema.metadata_fields_to_keep:
+                field_type = FieldSchema.KEYWORD  # Default type
                 if schema.metadata_field_types and metadata_field in schema.metadata_field_types:
                     internal_type = schema.metadata_field_types[metadata_field]
                     field_type = map_internal_type_to_qdrant_field_schema(internal_type)
@@ -1110,7 +1112,7 @@ class QdrantService:
             await self.create_index_if_needed_async(
                 collection_name=collection_name,
                 field_name=metadata_field,
-                field_schema_type=field_type if field_type else FieldSchema.KEYWORD,
+                field_schema_type=field_type,
             )
         if schema.last_edited_ts_field:
             await self.create_index_if_needed_async(

--- a/ingestion_script/ingest_db_source.py
+++ b/ingestion_script/ingest_db_source.py
@@ -23,7 +23,7 @@ from ingestion_script.utils import (
     CHUNK_COLUMN_NAME,
     FILE_ID_COLUMN_NAME,
     URL_COLUMN_NAME,
-    normalize_timestamp_functions,
+    resolve_sql_timestamp_filter,
 )
 from ada_backend.schemas.ingestion_task_schema import SourceAttributes
 
@@ -210,7 +210,7 @@ async def upload_db_source(
     )
     combined_filter_qdrant = qdrant_service._build_combined_filter(
         query_filter=query_filter,
-        timestamp_filter=normalize_timestamp_functions(timestamp_filter),
+        timestamp_filter=resolve_sql_timestamp_filter(timestamp_filter),
         timestamp_column_name=timestamp_column_name,
     )
 

--- a/ingestion_script/utils.py
+++ b/ingestion_script/utils.py
@@ -2,7 +2,6 @@ import logging
 import inspect
 from typing import Optional
 from uuid import UUID
-import pandas as pd
 
 import requests
 
@@ -226,17 +225,7 @@ def build_combined_sql_filter(
     """Combine query_filter and timestamp_filter into a single SQL WHERE clause."""
     filters = []
     if query_filter:
-        # Replace NOW() and other timestamp functions with current date string in query_filter
-        current_date_string = pd.Timestamp.now().strftime("%Y-%m-%d %H:%M:%S")
-        modified_query_filter = query_filter
-
-        # Replace common timestamp functions with current date string
-        timestamp_functions = ["NOW()", "now()", "CURRENT_TIMESTAMP", "current_timestamp"]
-        for func in timestamp_functions:
-            if func in modified_query_filter:
-                modified_query_filter = modified_query_filter.replace(func, f"'{current_date_string}'")
-
-        filters.append(f"({modified_query_filter})")
+        filters.append(f"({query_filter})")
     if timestamp_filter and timestamp_column_name:
         filters.append(f"({timestamp_column_name} IS NOT NULL AND {timestamp_column_name} {timestamp_filter})")
     if filters:

--- a/ingestion_script/utils.py
+++ b/ingestion_script/utils.py
@@ -2,7 +2,7 @@ import logging
 import inspect
 from typing import Optional
 from uuid import UUID
-
+from datetime import datetime
 import requests
 
 from ada_backend.schemas.ingestion_task_schema import IngestionTaskUpdate
@@ -262,3 +262,22 @@ def get_first_available_embeddings_custom_llm() -> EmbeddingService | None:
                 trace_manager=TraceManager(project_name="ingestion"),
                 embedding_size=model_config.get("embedding_size"),
             )
+
+
+def normalize_timestamp_functions(timestamp_filter: Optional[str]) -> Optional[str]:
+    if not timestamp_filter:
+        return timestamp_filter
+
+    normalized = timestamp_filter.strip()
+    current_date_string = str(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+    for func in [
+        "NOW()",
+        "now()",
+        "CURRENT_TIMESTAMP",
+        "current_timestamp",
+        "CURRENT_TIMESTAMP()",
+        "current_timestamp()",
+    ]:
+        if func in normalized:
+            normalized = normalized.replace(func, f"'{current_date_string}'")
+    return normalized

--- a/ingestion_script/utils.py
+++ b/ingestion_script/utils.py
@@ -2,6 +2,7 @@ import logging
 import inspect
 from typing import Optional
 from uuid import UUID
+import pandas as pd
 
 import requests
 
@@ -225,7 +226,17 @@ def build_combined_sql_filter(
     """Combine query_filter and timestamp_filter into a single SQL WHERE clause."""
     filters = []
     if query_filter:
-        filters.append(f"({query_filter})")
+        # Replace NOW() and other timestamp functions with current date string in query_filter
+        current_date_string = pd.Timestamp.now().strftime("%Y-%m-%d %H:%M:%S")
+        modified_query_filter = query_filter
+
+        # Replace common timestamp functions with current date string
+        timestamp_functions = ["NOW()", "now()", "CURRENT_TIMESTAMP", "current_timestamp"]
+        for func in timestamp_functions:
+            if func in modified_query_filter:
+                modified_query_filter = modified_query_filter.replace(func, f"'{current_date_string}'")
+
+        filters.append(f"({modified_query_filter})")
     if timestamp_filter and timestamp_column_name:
         filters.append(f"({timestamp_column_name} IS NOT NULL AND {timestamp_column_name} {timestamp_filter})")
     if filters:

--- a/ingestion_script/utils.py
+++ b/ingestion_script/utils.py
@@ -264,12 +264,12 @@ def get_first_available_embeddings_custom_llm() -> EmbeddingService | None:
             )
 
 
-def normalize_timestamp_functions(timestamp_filter: Optional[str]) -> Optional[str]:
+def resolve_sql_timestamp_filter(timestamp_filter: Optional[str]) -> Optional[str]:
     if not timestamp_filter:
         return timestamp_filter
 
-    normalized = timestamp_filter.strip()
-    current_date_string = str(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+    filter_with_resolved_functions = timestamp_filter.strip()
+    current_date_string = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     for func in [
         "NOW()",
         "now()",
@@ -278,6 +278,6 @@ def normalize_timestamp_functions(timestamp_filter: Optional[str]) -> Optional[s
         "CURRENT_TIMESTAMP()",
         "current_timestamp()",
     ]:
-        if func in normalized:
-            normalized = normalized.replace(func, f"'{current_date_string}'")
-    return normalized
+        if func in filter_with_resolved_functions:
+            filter_with_resolved_functions = filter_with_resolved_functions.replace(func, f"'{current_date_string}'")
+    return filter_with_resolved_functions


### PR DESCRIPTION
## Context
Enhance metadata type detection for SQL and Qdrant by automatically mapping data to the correct indexes and ensuring proper serialization. Centralize SQL function handling to cleanly separate timestamp resolution from Qdrant filtering.

## Goal

1. Implement proper metadata type detection for SQL database
2. Implement proper metadata type detection for Qdrant metadatas - Automatically detect and create appropriate Qdrant indexes based on actual data types (INTEGER, FLOAT, BOOLEAN, DATETIME, KEYWORD)
3. Centralize SQL function handling - Establish a clean separation between SQL timestamp function resolution and Qdrant filtering
4. Fix JSON serialization issues - Ensure pandas Timestamp objects are properly serialized for Qdrant ingestion

