### PR TITLE
[dra-477] remove deprecated trace endpoints and code

### DIFF
--- a/ada_backend/routers/project_router.py
+++ b/ada_backend/routers/project_router.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, Optional
+from typing import Annotated, List
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Body
 from sqlalchemy.orm import Session
@@ -18,7 +18,6 @@ from ada_backend.schemas.project_schema import (
     ProjectUpdateSchema,
     ProjectCreateSchema,
 )
-from ada_backend.schemas.trace_schema import TraceSpan
 from ada_backend.services.agent_runner_service import run_agent, run_env_agent
 from ada_backend.routers.auth_router import (
     get_user_from_supabase_token,

--- a/ada_backend/routers/project_router.py
+++ b/ada_backend/routers/project_router.py
@@ -38,7 +38,6 @@ from ada_backend.services.project_service import (
     get_workflows_by_organization_service,
     update_project_service,
 )
-from ada_backend.services.trace_service import get_trace_by_project
 from ada_backend.repositories.env_repository import get_env_relationship_by_graph_runner_id
 
 LOGGER = logging.getLogger(__name__)
@@ -226,78 +225,6 @@ async def get_project_charts(
             "Failed to get charts for project %s (duration=%s)",
             project_id,
             duration,
-        )
-        raise HTTPException(status_code=500, detail="Internal Server Error") from e
-
-
-# TODO: Delete this endpoint
-@router.get("/{project_id}/trace", response_model=List[TraceSpan], tags=["Metrics"], deprecated=True)
-async def get_project_trace(
-    project_id: UUID,
-    duration: int,
-    user: Annotated[SupabaseUser, Depends(get_user_from_supabase_token)],
-    environment: Optional[EnvType] = None,
-    call_type: Optional[CallType] = None,
-    tag_version: Optional[str] = None,
-):
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-    try:
-        response = get_trace_by_project(
-            user.id,
-            project_id,
-            duration,
-            include_messages=False,
-            environment=environment,
-            call_type=call_type,
-            tag_version=tag_version,
-        )
-        return response
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.exception(
-            "Failed to get traces (v1) for project %s (duration=%s, env=%s, call_type=%s)",
-            project_id,
-            duration,
-            environment,
-            call_type,
-        )
-        raise HTTPException(status_code=500, detail="Internal Server Error") from e
-
-
-# TODO: Delete this endpoint
-@router.get("/{project_id}/v2/trace", response_model=List[TraceSpan], tags=["Metrics"], deprecated=True)
-async def get_project_trace_v2(
-    project_id: UUID,
-    duration: int,
-    user: Annotated[SupabaseUser, Depends(get_user_from_supabase_token)],
-    environment: Optional[EnvType] = None,
-    call_type: Optional[CallType] = None,
-    tag_version: Optional[str] = None,
-):
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-    try:
-        response = get_trace_by_project(
-            user.id,
-            project_id,
-            duration,
-            include_messages=True,
-            environment=environment,
-            call_type=call_type,
-            tag_version=tag_version,
-        )
-        return response
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.exception(
-            "Failed to get traces (v2) for project %s (duration=%s, env=%s, call_type=%s)",
-            project_id,
-            duration,
-            environment,
-            call_type,
         )
         raise HTTPException(status_code=500, detail="Internal Server Error") from e
 

--- a/ada_backend/schemas/trace_schema.py
+++ b/ada_backend/schemas/trace_schema.py
@@ -62,6 +62,9 @@ class RootTraceSpan(BaseModel):
     cumulative_llm_token_count_completion: int
     llm_token_count_prompt: int | None
     llm_token_count_completion: int | None
+    environment: EnvType | None
+    call_type: CallType | None
+    tag_version: str | None
 
 
 class TokenUsage(BaseModel):

--- a/ada_backend/services/metrics/utils.py
+++ b/ada_backend/services/metrics/utils.py
@@ -37,24 +37,6 @@ def query_trace_duration(project_id: UUID, duration_days: int) -> pd.DataFrame:
     return df
 
 
-def query_trace_messages(
-    duration_days: int,
-) -> pd.DataFrame:
-    start_time_offset_days = (datetime.now() - timedelta(days=duration_days)).isoformat()
-    LOGGER.debug(f"Querying messages for since {start_time_offset_days}")
-
-    query = (
-        "SELECT m.span_id, m.input_content, m.output_content FROM span_messages m "
-        "JOIN spans s ON m.span_id = s.span_id "
-        f"WHERE s.start_time > '{start_time_offset_days}';"
-    )
-    session = get_session_trace()
-    df = pd.read_sql_query(query, session.bind)
-    session.close()
-    df = df.replace({np.nan: None})
-    return df
-
-
 def query_root_trace_duration(project_id: UUID, duration_days: int) -> pd.DataFrame:
     start_time_offset_days = (datetime.now() - timedelta(days=duration_days)).isoformat()
 

--- a/ada_backend/services/trace_service.py
+++ b/ada_backend/services/trace_service.py
@@ -5,7 +5,6 @@ from uuid import UUID
 import logging
 
 import pandas as pd
-import numpy as np
 
 from ada_backend.schemas.trace_schema import RootTraceSpan, TraceSpan, TokenUsage
 from ada_backend.services.metrics.utils import (

--- a/ada_backend/services/trace_service.py
+++ b/ada_backend/services/trace_service.py
@@ -11,11 +11,9 @@ from ada_backend.schemas.trace_schema import RootTraceSpan, TraceSpan, TokenUsag
 from ada_backend.services.metrics.utils import (
     query_root_trace_duration,
     query_trace_by_trace_id,
-    query_trace_duration,
-    query_trace_messages,
 )
 from engine.trace import models as db
-from engine.trace.sql_exporter import get_session_trace, parse_str_or_dict
+from engine.trace.sql_exporter import get_session_trace
 from ada_backend.segment_analytics import track_project_observability_loaded, track_span_observability_loaded
 from ada_backend.database.models import EnvType, CallType
 

--- a/ada_backend/services/trace_service.py
+++ b/ada_backend/services/trace_service.py
@@ -26,70 +26,6 @@ LOGGER = logging.getLogger(__name__)
 TOKEN_LIMIT = 2000000
 
 
-# TODO: Delete this function
-def get_attributes(span_kind: str, row: pd.Series) -> dict:
-    input = []
-    output = []
-    documents = []
-    tool_info = {}
-    model_name = ""
-    try:
-        if span_kind == "AGENT" or span_kind == "CHAIN" or span_kind == "TOOL":
-            input = [row["attributes"]["input"].get("value", "")]
-            if "output" in row["attributes"]:
-                output = [row["attributes"]["output"].get("value", "")]
-            if "llm" in row["attributes"]:
-                model_name = row["attributes"]["llm"].get("model_name", "")
-        elif span_kind == "LLM":
-            if "llm" in row["attributes"]:
-                model_name = row["attributes"]["llm"].get("model_name", "")
-                if "input_messages" in row["attributes"]["llm"]:
-                    input = parse_str_or_dict(row["attributes"]["llm"]["input_messages"])
-                    input = input if isinstance(input, list) else [input]
-                if "output_messages" in row["attributes"]["llm"]:
-                    output = parse_str_or_dict(row["attributes"]["llm"]["output_messages"])
-                    output = output if isinstance(output, list) else [output]
-
-            if input is None or len(input) == 0:
-                if "input" in row["attributes"]:
-                    input = parse_str_or_dict(row["attributes"]["input"].get("value", []))
-                if not isinstance(input, list):
-                    input = [input]
-            if output is None or len(output) == 0:
-                if "output" in row["attributes"]:
-                    output = parse_str_or_dict(row["attributes"]["output"].get("value", []))
-                if not isinstance(output, list):
-                    output = [output]
-        elif span_kind == "RETRIEVER":
-            events = json.loads(row["events"])
-            if "input" in row["attributes"]:
-                input = [row["attributes"]["input"].get("value", "")]
-            if "retrieval" in row["attributes"]:
-                documents = row["attributes"]["retrieval"]["documents"]
-            elif len(events) > 0:
-                documents = [{"document": event["attributes"]} for event in events]
-        elif span_kind == "EMBEDDING":
-            if isinstance(row["attributes"]["input"]["value"], str):
-                row["attributes"]["input"]["value"] = json.loads(row["attributes"]["input"]["value"])
-            input = row["attributes"]["input"]["value"]["input"]
-            model_name = "embedding:" + row["attributes"]["embedding"]["model_name"]
-        elif span_kind == "TOOL":
-            input = [row["attributes"]["input"].get("value", "")]
-            output = [row["attributes"]["output"].get("value", "")]
-            tool_info = row["attributes"]["tool"]
-        elif span_kind == "UNKNOWN":
-            if "input" in row["attributes"]:
-                input = parse_str_or_dict(row["attributes"]["input"].get("value", ""))
-                input = input if isinstance(input, list) else [input]
-            if "output" in row["attributes"]:
-                output = parse_str_or_dict(row["attributes"]["output"].get("value", ""))
-                output = output if isinstance(output, list) else [output]
-    except Exception as e:
-        LOGGER.error(f"Error processing row {row}: {e}")
-
-    return input, output, documents, tool_info, model_name
-
-
 def get_attributes_with_messages(span_kind: str, row: pd.Series) -> dict:
     input = json.loads(row["input_content"]) if row["input_content"] else []
     output = json.loads(row["output_content"]) if row["output_content"] else []
@@ -116,7 +52,7 @@ def get_attributes_with_messages(span_kind: str, row: pd.Series) -> dict:
 
 
 # TODO: refacto this function to only handle one trace id
-def build_span_trees(df: pd.DataFrame, include_messages: bool) -> List[TraceSpan]:
+def build_span_trees(df: pd.DataFrame) -> List[TraceSpan]:
     """Convert a Pandas DataFrame containing multiple OpenTelemetry spans into a list of hierarchical JSON trees."""
     traces = defaultdict(dict)  # {trace_id: {span_id: span}}
 
@@ -126,10 +62,7 @@ def build_span_trees(df: pd.DataFrame, include_messages: bool) -> List[TraceSpan
         span_id = row["span_id"]
         parent_id = row["parent_id"]
         span_kind = row["span_kind"]
-        if include_messages:
-            input, output, documents, tool_info, model_name = get_attributes_with_messages(span_kind, row)
-        else:
-            input, output, documents, tool_info, model_name = get_attributes(span_kind, row)
+        input, output, documents, tool_info, model_name = get_attributes_with_messages(span_kind, row)
 
         traces[trace_id][span_id] = TraceSpan(
             span_id=span_id,
@@ -191,42 +124,13 @@ def build_root_spans(df: pd.DataFrame) -> List[RootTraceSpan]:
                 cumulative_llm_token_count_completion=row["cumulative_llm_token_count_completion"],
                 llm_token_count_prompt=row.get("llm_token_count_prompt", None),
                 llm_token_count_completion=row.get("llm_token_count_completion", None),
+                environment=row.get("environment", None),
+                call_type=row.get("call_type", None),
+                tag_version=row.get("tag_version", None),
             )
         )
 
     return root_spans
-
-
-# TODO: Delete this function
-def get_trace_by_project(
-    user_id: UUID,
-    project_id: UUID,
-    duration: int,
-    include_messages: bool = False,
-    environment: Optional[EnvType] = None,
-    call_type: Optional[CallType] = None,
-    tag_version: Optional[str] = None,
-) -> List[TraceSpan]:
-    df_span = query_trace_duration(project_id, duration)
-    track_project_observability_loaded(user_id, project_id)
-
-    if include_messages:
-        LOGGER.info(f"Querying messages for project {project_id} with duration {duration} days")
-        df_messages = query_trace_messages(duration)
-        df_span = df_span.merge(df_messages, on="span_id", how="left")
-
-    df_span = df_span.replace({np.nan: None})
-
-    if environment is not None:
-        df_span = df_span[df_span["environment"] == environment.value]
-
-    if call_type is not None:
-        df_span = df_span[df_span["call_type"] == call_type.value]
-
-    if tag_version is not None:
-        df_span = df_span[df_span["tag_version"] == tag_version]
-
-    return build_span_trees(df_span, include_messages=include_messages)
 
 
 def get_token_usage(organization_id: UUID) -> TokenUsage:
@@ -241,7 +145,7 @@ def get_span_trace_service(user_id: UUID, trace_id: UUID) -> TraceSpan:
     df_span = query_trace_by_trace_id(trace_id)
     track_span_observability_loaded(user_id, trace_id)
 
-    span_trees = build_span_trees(df_span, include_messages=True)
+    span_trees = build_span_trees(df_span)
     if len(span_trees) == 0:
         raise ValueError(f"No spans found for trace_id {trace_id}")
 

--- a/engine/trace/alembic/versions/3ef4828f70f9_migrate_spans_messages.py
+++ b/engine/trace/alembic/versions/3ef4828f70f9_migrate_spans_messages.py
@@ -1,0 +1,261 @@
+"""migrate spans messages
+
+Revision ID: 3ef4828f70f9
+Revises: c4814af70804
+Create Date: 2025-10-06 13:58:55.833149
+
+"""
+
+from typing import Sequence, Union
+import json
+import re
+
+import pandas as pd
+from alembic import op
+import sqlalchemy as sa
+
+from engine.trace.sql_exporter import get_session_trace
+
+
+# revision identifiers, used by Alembic.
+revision: str = "3ef4828f70f9"
+down_revision: Union[str, None] = "c4814af70804"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# detect whether a string contains an “active” \u0000
+def has_bad_u0000(s: str) -> bool:
+    for m in re.finditer(r"(\\+)[uU]0000", s):
+        if len(m.group(1)) % 2 == 1:  # nombre impair de backslashes => escape actif
+            return True
+    return False
+
+
+# 2) neutralize any sequence \u0000 with an odd number of backslashes
+def neutralize_u0000(s: str) -> str:
+    def _repl(m):
+        bs = m.group(1)
+        # if odd, add a backslash to make it even => \\\\u0000 (literal)
+        if len(bs) % 2 == 1:
+            return bs + "\\\\u0000"
+        return m.group(0)
+
+    # remove the actual NUL if it exists (U+0000), option: replace with U+FFFD
+    s = s.replace("\x00", "")  # ou '\uFFFD'
+    s = re.sub(r"(\\+)[uU]0000", _repl, s)
+    return s
+
+
+# 3) recursive JSON cleaning (handles dict/list + JSON-embedded-in-string)
+def sanitize_json(obj):
+    if isinstance(obj, dict):
+        return {sanitize_json(k): sanitize_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [sanitize_json(v) for v in obj]
+    if isinstance(obj, str):
+        s = neutralize_u0000(obj)
+        # if the string looks like JSON, we try to open it, clean it up, and then re-encode it
+        if s and s.lstrip()[:1] in "{[":
+            try:
+                inner = json.loads(s)
+                inner = sanitize_json(inner)
+                s = json.dumps(inner, ensure_ascii=False, allow_nan=False)
+                # post-dumps neutralization (in case any \u0000 were produced)
+                s = neutralize_u0000(s)
+            except Exception:
+                pass
+        return s
+    return obj
+
+
+def to_json_str_super_safe(v):
+    if v is None:
+        return None
+    if isinstance(v, str):
+        try:
+            data = json.loads(v)
+        except Exception:
+            # it's not JSON → just neutralize at the string level
+            s = neutralize_u0000(v)
+            # if it looks like a JSON-embedded, we leave it as is; otherwise we keep the string as is
+            return s
+        # data JSON → we clean it up recursively and then dumps
+        data = sanitize_json(data)
+        s = json.dumps(data, ensure_ascii=False, allow_nan=False)
+        return neutralize_u0000(s)
+    # dict/list/etc.
+    data = sanitize_json(v)
+    s = json.dumps(data, ensure_ascii=False, allow_nan=False)
+    return neutralize_u0000(s)
+
+
+def try_parse(x):
+    if not isinstance(x, str):
+        return True
+    try:
+        json.loads(x)
+        return True
+    except json.JSONDecodeError:
+        return False
+
+
+def upgrade() -> None:
+    session = get_session_trace()
+
+    print("- Adding temporary column attributes_jsonb...")
+    session.execute(
+        sa.text(
+            """
+        ALTER TABLE spans
+        ADD COLUMN IF NOT EXISTS attributes_jsonb JSONB;
+    """
+        )
+    )
+    session.commit()
+    total_updated = 0
+
+    last_id = 0
+    batch_size = 20000
+    stmt = sa.text(
+        """
+        UPDATE spans
+        SET attributes_jsonb = CAST(:cleaned AS jsonb)
+        WHERE id = :id
+    """
+    )
+
+    while True:
+        df = pd.read_sql_query(
+            sa.text("SELECT id, attributes FROM spans WHERE id > :last_id ORDER BY id ASC LIMIT :lim"),
+            session.bind,
+            params={"last_id": last_id, "lim": batch_size},
+        )
+        if df.empty:
+            break
+        print(f"- Processing batch starting from id={last_id} ({len(df)} lines...)")
+        df["cleaned"] = df["attributes"].apply(lambda x: json.loads(x) if isinstance(x, str) else x)
+
+        df["valid"] = df["cleaned"].apply(try_parse)
+        invalid_after = df[~df["valid"]]
+        print(f"→ {len(invalid_after)} lines still invalid after cleaning")
+
+        changed = df.loc[df["attributes"] != df["cleaned"], ["id", "cleaned"]].copy()
+        changed["cleaned"] = changed["cleaned"].map(to_json_str_super_safe)
+        still_bad = changed["cleaned"].map(lambda s: isinstance(s, str) and has_bad_u0000(s))
+        if still_bad.any():
+            bad_ids = changed.loc[still_bad, "id"].head(5).tolist()
+            raise ValueError(f"Still active '\\u0000' after neutralization. Example ids: {bad_ids}")
+
+        print(f"→ {len(changed)} lines to be updated")
+        if not changed.empty:
+            # Conversion en liste de dictionnaires pour executemany
+            rows = changed.to_dict(orient="records")
+
+            print("- Updating rows in the database (executemany)...")
+            session.execute(
+                stmt,
+                rows,
+            )
+            session.commit()
+            total_updated += len(changed)
+            last_id = int(df["id"].iloc[-1])
+            print(f"→ Batch up to id={last_id}, casted: {len(changed)} lines (total: {total_updated})")
+    session.execute(
+        sa.text(
+            """
+        UPDATE spans
+        SET attributes_jsonb =
+            (
+              (
+                (
+                  (attributes_jsonb #- '{llm,input_messages}')
+                  #- '{llm,output_messages}'
+                )
+                - 'input'
+                - 'output'
+              )
+            )
+        WHERE
+              (attributes_jsonb ? 'llm')
+           OR (attributes_jsonb ? 'input')
+           OR (attributes_jsonb ? 'output');
+        """
+        )
+    )
+    session.commit()
+    print("- Converting attributes (TEXT) -> JSONB using attributes_jsonb...")
+    session.execute(
+        sa.text(
+            """
+            ALTER TABLE spans
+            ALTER COLUMN attributes TYPE JSONB
+            USING attributes_jsonb;
+            """
+        )
+    )
+    session.commit()
+
+    print("- Dropping temporary column attributes_jsonb...")
+    session.execute(sa.text("ALTER TABLE spans DROP COLUMN IF EXISTS attributes_jsonb;"))
+    session.commit()
+
+    print(f"✓ Done. Total rows updated: {total_updated}")
+
+
+def downgrade() -> None:
+    # Step 1) Rebuild "input" and "output" keys in the attributes JSONB
+    # ----------------------------------------------------------------
+    # For each span that has a matching row in span_messages:
+    #   - Merge the existing attributes JSONB with:
+    #       input:  {"value": input_content or ""}
+    #       output: {"value": output_content or ""}
+    # If no matching row exists, we still ensure empty values are present.
+    print("- Rebuilding input/output in attributes from span_messages...")
+
+    # Case 1: spans with a matching row in span_messages
+    op.execute(
+        """
+            UPDATE spans AS s
+            SET attributes =
+                COALESCE(s.attributes, '{}'::jsonb)
+                || jsonb_build_object(
+                     'input',  jsonb_build_object('value', COALESCE(sm.input_content, ''))
+                   )
+                || jsonb_build_object(
+                     'output', jsonb_build_object('value', COALESCE(sm.output_content, ''))
+                   )
+            FROM span_messages sm
+            WHERE sm.span_id = s.span_id;
+            """
+    )
+
+    # Case 2: spans without any matching span_messages row
+    # We still create empty "input" and "output" fields for consistency.
+    op.execute(
+        """
+            UPDATE spans AS s
+            SET attributes =
+                COALESCE(s.attributes, '{}'::jsonb)
+                || jsonb_build_object('input',  jsonb_build_object('value', ''))
+                || jsonb_build_object('output', jsonb_build_object('value', ''))
+            WHERE NOT EXISTS (
+                SELECT 1 FROM span_messages sm WHERE sm.span_id = s.span_id
+            );
+            """
+    )
+
+    # Step 2) Convert attributes back from JSONB → TEXT
+    # -------------------------------------------------
+    # After re-injecting the input/output data, we turn the column back to text
+    # to restore the previous schema.
+    print("- Converting attributes (JSONB) -> TEXT...")
+    op.execute(
+        """
+            ALTER TABLE spans
+            ALTER COLUMN attributes TYPE TEXT
+            USING attributes::text;
+            """
+    )
+
+    print("✓ Downgrade complete (attributes now contains input/output with value strings).")

--- a/engine/trace/alembic/versions/3ef4828f70f9_migrate_spans_messages.py
+++ b/engine/trace/alembic/versions/3ef4828f70f9_migrate_spans_messages.py
@@ -14,8 +14,6 @@ import pandas as pd
 from alembic import op
 import sqlalchemy as sa
 
-from engine.trace.sql_exporter import get_session_trace
-
 
 # revision identifiers, used by Alembic.
 revision: str = "3ef4828f70f9"

--- a/engine/trace/alembic/versions/f6dfd93b8baf_add_messages_table.py
+++ b/engine/trace/alembic/versions/f6dfd93b8baf_add_messages_table.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 from engine.trace.nested_utils import split_nested_keys
-from engine.trace.sql_exporter import get_messages_from_span
+from engine.trace.sql_exporter import extract_messages_from_attributes
 
 
 # revision identifiers, used by Alembic.
@@ -49,7 +49,7 @@ def upgrade() -> None:
     spans = session.execute(sa.select(spans_table)).mappings().all()
     for span in spans:
         formatted_attributes = split_nested_keys(json.loads(span["attributes"]))
-        input, output = get_messages_from_span(formatted_attributes)
+        input, output, _ = extract_messages_from_attributes(formatted_attributes)
         session.execute(
             messages_table.insert().values(
                 span_id=span["span_id"],

--- a/engine/trace/models.py
+++ b/engine/trace/models.py
@@ -5,6 +5,7 @@ from sqlalchemy import Text, Column, Integer, String, TIMESTAMP, Enum as SQLAlch
 from sqlalchemy.orm import declarative_base, mapped_column
 from opentelemetry.trace.status import StatusCode
 from openinference.semconv.trace import OpenInferenceSpanKindValues
+from sqlalchemy.dialects.postgresql import JSONB
 
 from ada_backend.database.models import EnvType, CallType
 
@@ -52,7 +53,7 @@ class Span(Base):
     start_time = Column(TIMESTAMP(timezone=True), nullable=False, index=True)
     end_time = Column(TIMESTAMP(timezone=True), nullable=False)
 
-    attributes = Column(Text, nullable=False)
+    attributes = Column(JSONB, nullable=False)
     events = Column(Text, nullable=False)
 
     status_code = mapped_column(

--- a/engine/trace/sql_exporter.py
+++ b/engine/trace/sql_exporter.py
@@ -150,7 +150,6 @@ class SQLSpanExporter(SpanExporter):
             formatted_attributes = (
                 split_nested_keys(json_span["attributes"]) if isinstance(json_span["attributes"], dict) else {}
             )
-            print(formatted_attributes)
 
             environment = formatted_attributes.pop("environment", None)
             call_type = formatted_attributes.pop("call_type", None)
@@ -167,7 +166,7 @@ class SQLSpanExporter(SpanExporter):
                 name=span.name,
                 start_time=datetime.fromtimestamp(span.start_time / 1e9, tz=timezone.utc),
                 end_time=datetime.fromtimestamp(span.end_time / 1e9, tz=timezone.utc),
-                attributes=json.dumps(formatted_attributes),
+                attributes=formatted_attributes,
                 events=json.dumps([event_to_dict(event) for event in span.events]),
                 status_code=span.status.status_code,
                 status_message=span.status.description or "",

--- a/engine/trace/sql_exporter.py
+++ b/engine/trace/sql_exporter.py
@@ -69,32 +69,34 @@ def parse_str_or_dict(input_str: str | list) -> str | dict | list:
         return input_str
 
 
-def get_messages_from_span(attributes: dict) -> tuple[list[dict], list[dict]]:
+def extract_messages_from_attributes(attributes: dict) -> tuple[list[dict], list[dict], dict]:
     try:
         input = []
         output = []
         if "llm" in attributes:
             if "input_messages" in attributes["llm"]:
-                input = parse_str_or_dict(attributes["llm"]["input_messages"])
+                input_messages = attributes["llm"].pop("input_messages")
+                input = parse_str_or_dict(input_messages)
                 input = input if isinstance(input, list) else [input]
             if "output_messages" in attributes["llm"]:
-                output = parse_str_or_dict(attributes["llm"]["output_messages"])
+                output_messages = attributes["llm"].pop("output_messages")
+                output = parse_str_or_dict(output_messages)
                 output = output if isinstance(output, list) else [output]
 
-        if input is None or len(input) == 0:
-            if "input" in attributes:
-                input = parse_str_or_dict(attributes["input"].get("value", []))
-            if not isinstance(input, list):
-                input = [input]
-        if output is None or len(output) == 0:
-            if "output" in attributes:
-                output = parse_str_or_dict(attributes["output"].get("value", []))
-            if not isinstance(output, list):
-                output = [output]
-        return input, output
+        if "input" in attributes:
+            input_attributes = attributes.pop("input")
+            if input is None or len(input) == 0:
+                input = parse_str_or_dict(input_attributes.get("value", []))
+                input = input if isinstance(input, list) else [input]
+        if "output" in attributes:
+            output_attributes = attributes.pop("output")
+            if output is None or len(output) == 0:
+                output = parse_str_or_dict(output_attributes.get("value", []))
+                output = output if isinstance(output, list) else [output]
+        return input, output, attributes
     except Exception as e:
         LOGGER.error(f"Error processing span attributes {attributes}: {e}")
-        return [], []
+        return [], [], attributes
 
 
 class SQLSpanExporter(SpanExporter):
@@ -148,11 +150,13 @@ class SQLSpanExporter(SpanExporter):
             formatted_attributes = (
                 split_nested_keys(json_span["attributes"]) if isinstance(json_span["attributes"], dict) else {}
             )
+            print(formatted_attributes)
 
             environment = formatted_attributes.pop("environment", None)
             call_type = formatted_attributes.pop("call_type", None)
             project_id = formatted_attributes.pop("project_id", None)
             tag_version = formatted_attributes.pop("tag_version", None)
+            input, output, formatted_attributes = extract_messages_from_attributes(formatted_attributes)
 
             openinference_span_kind = json_span["attributes"].get(SpanAttributes.OPENINFERENCE_SPAN_KIND, "UNKNOWN")
             span_row = models.Span(
@@ -199,7 +203,6 @@ class SQLSpanExporter(SpanExporter):
             )
             self.session.add(span_row)
 
-            input, output = get_messages_from_span(formatted_attributes)
             self.session.add(
                 models.SpanMessage(
                     span_id=span_row.span_id,

--- a/tests/ada_backend/test_monitor_endpoints.py
+++ b/tests/ada_backend/test_monitor_endpoints.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 from ada_backend.main import app
 
 from ada_backend.schemas.project_schema import ChatResponse
-from ada_backend.schemas.trace_schema import TraceSpan
+from ada_backend.schemas.trace_schema import RootTraceSpan
 from ada_backend.scripts.get_supabase_token import get_user_jwt
 from engine.trace.trace_context import set_trace_manager
 from engine.trace.trace_manager import TraceManager
@@ -34,10 +34,10 @@ def test_monitor_endpoint():
     trace_manager.force_flush()
 
     duration = 7
-    url = f"/projects/{project_id}/trace?duration={duration}"
+    url = f"/projects/{project_id}/traces?duration={duration}"
     response = client.get(url, headers=headers)
     results = response.json()
-    keys_trace_span = [field_name[0] for field_name in TraceSpan.model_fields.items()]
+    keys_trace_span = [field_name[0] for field_name in RootTraceSpan.model_fields.items()]
 
     assert response.status_code == 200
     assert len(results) > 0


### PR DESCRIPTION
# Summary
This PR removes deprecated **trace and span endpoints** and adds a **migration** that converts `spans.attributes` from `TEXT` to `JSONB`, removing **message data** from attributes stored exclusively in the `span_messages` table. 

## Details
- Added migration to :
    - Safely cast `attributes` to `JSONB` with data cleanup.
    - Remove deprecated keys: `llm.input_messages`, `llm.output_messages`, `input`, `output`.
    - Ensure all trace message content is kept only in `span_messages`.

## To test : 
- `make db-trace-upgrade`
- Verify that observability is still loading.
- Run an agent, then verify observability.
- You can also check your database to see the changes made to your table.

- At checkout, `make trace-db-downgrade`