### PR TITLE
[dra-511] HotFix/ remove make trace_db_upgrade in worker ci dra-511

### DIFF
--- a/.github/workflows/deploy-ingestion-prod.yml
+++ b/.github/workflows/deploy-ingestion-prod.yml
@@ -36,8 +36,6 @@ jobs:
             git clean -fd
             echo "Code updated successfully."
 
-            echo "👁️ Re-setup the traces database"
-            make trace-db-upgrade
 
       - name: Restart ada-worker Service
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/deploy-ingestion-staging.yml
+++ b/.github/workflows/deploy-ingestion-staging.yml
@@ -36,9 +36,6 @@ jobs:
             git clean -fd
             echo "Code updated successfully."
 
-            echo "👁️ Re-setup the traces database"
-            make trace-db-upgrade
-
       - name: Restart ada-worker Service
         uses: appleboy/ssh-action@v1.0.3
         with:


### PR DESCRIPTION
- We use the same trace_db in worker and staging so we cannot run 2 times the same migration
- This is a HotFix, we **must eliminate dependencies between db and worker**