### PR TITLE
feat(qa): datasets and evaluators to org level dra-952

### DIFF
--- a/ada_backend/admin/admin.py
+++ b/ada_backend/admin/admin.py
@@ -611,11 +611,53 @@ class PortMappingAdmin(EnhancedModelView, model=db.PortMapping):
     ]
 
 
+class DatasetProjectAdmin(EnhancedModelView, model=db.DatasetProject):
+    category = AdminCategory.QUALITY_ASSURANCE
+    icon = "fas fa-database"
+    column_list = [
+        "id",
+        "organization_id",
+        "project_id",
+        "dataset_name",
+        "created_at",
+        "updated_at",
+    ]
+    column_searchable_list = ["dataset_name"]
+    column_filters = ["organization_id", "project_id"]
+    form_columns = [
+        "organization_id",
+        "project_id",
+        "dataset_name",
+    ]
+
+
+class InputGroundtruthAdmin(EnhancedModelView, model=db.InputGroundtruth):
+    category = AdminCategory.QUALITY_ASSURANCE
+    icon = "fas fa-list-check"
+    column_list = [
+        "id",
+        "dataset_id",
+        "position",
+        "input",
+        "groundtruth",
+        "created_at",
+        "updated_at",
+    ]
+    column_filters = ["dataset_id"]
+    form_columns = [
+        "dataset_id",
+        "position",
+        "input",
+        "groundtruth",
+    ]
+
+
 class LLMJudgeAdmin(EnhancedModelView, model=db.LLMJudge):
     category = AdminCategory.QUALITY_ASSURANCE
     icon = "fas fa-balance-scale"
     column_list = [
         "id",
+        "organization_id",
         "project_id",
         "name",
         "description",
@@ -627,7 +669,9 @@ class LLMJudgeAdmin(EnhancedModelView, model=db.LLMJudge):
         "updated_at",
     ]
     column_searchable_list = ["name", "description", "llm_model_reference"]
+    column_filters = ["organization_id", "project_id"]
     form_columns = [
+        "organization_id",
         "project_id",
         "name",
         "description",
@@ -794,6 +838,8 @@ def setup_admin(app: FastAPI):
     admin.add_view(CronJobAdmin)
     admin.add_view(CronRunAdmin)
     admin.add_view(EndpointPollingHistoryAdmin)
+    admin.add_view(DatasetProjectAdmin)
+    admin.add_view(InputGroundtruthAdmin)
     admin.add_view(LLMJudgeAdmin)
     admin.add_view(JudgeEvaluationAdmin)
     admin.add_view(LLMModelsAdmin)

--- a/ada_backend/database/alembic/versions/a1b2c3d4e5f7_add_organization_id_to_qa_tables.py
+++ b/ada_backend/database/alembic/versions/a1b2c3d4e5f7_add_organization_id_to_qa_tables.py
@@ -1,0 +1,129 @@
+"""add organization_id to qa tables
+
+Revision ID: a1b2c3d4e5f8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-02-09 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Step 1: Add organization_id columns (nullable initially for data migration)
+    op.add_column(
+        "dataset_project",
+        sa.Column("organization_id", sa.UUID(), nullable=True),
+        schema="quality_assurance",
+    )
+    op.add_column(
+        "llm_judges",
+        sa.Column("organization_id", sa.UUID(), nullable=True),
+        schema="quality_assurance",
+    )
+
+    # Step 2: Populate organization_id from project's organization
+    op.execute("""
+        UPDATE quality_assurance.dataset_project
+        SET organization_id = (
+            SELECT organization_id FROM projects WHERE id = dataset_project.project_id
+        )
+        WHERE project_id IS NOT NULL
+    """)
+
+    op.execute("""
+        UPDATE quality_assurance.llm_judges
+        SET organization_id = (
+            SELECT organization_id FROM projects WHERE id = llm_judges.project_id
+        )
+        WHERE project_id IS NOT NULL
+    """)
+
+    # Step 3: Make organization_id NOT NULL
+    op.alter_column(
+        "dataset_project",
+        "organization_id",
+        nullable=False,
+        schema="quality_assurance",
+    )
+    op.alter_column(
+        "llm_judges",
+        "organization_id",
+        nullable=False,
+        schema="quality_assurance",
+    )
+
+    # Step 4: Make project_id nullable (for backward compatibility)
+    op.alter_column(
+        "dataset_project",
+        "project_id",
+        nullable=True,
+        schema="quality_assurance",
+    )
+    op.alter_column(
+        "llm_judges",
+        "project_id",
+        nullable=True,
+        schema="quality_assurance",
+    )
+
+    # Step 5: Add indexes on organization_id
+    op.create_index(
+        op.f("ix_quality_assurance_dataset_project_organization_id"),
+        "dataset_project",
+        ["organization_id"],
+        unique=False,
+        schema="quality_assurance",
+    )
+    op.create_index(
+        op.f("ix_quality_assurance_llm_judges_organization_id"),
+        "llm_judges",
+        ["organization_id"],
+        unique=False,
+        schema="quality_assurance",
+    )
+
+
+def downgrade() -> None:
+    # Remove indexes
+    op.drop_index(
+        op.f("ix_quality_assurance_llm_judges_organization_id"),
+        table_name="llm_judges",
+        schema="quality_assurance",
+    )
+    op.drop_index(
+        op.f("ix_quality_assurance_dataset_project_organization_id"),
+        table_name="dataset_project",
+        schema="quality_assurance",
+    )
+
+    # Delete records without project_id (created while organization_id was the primary reference)
+    op.execute("DELETE FROM quality_assurance.dataset_project WHERE project_id IS NULL")
+    op.execute("DELETE FROM quality_assurance.llm_judges WHERE project_id IS NULL")
+
+    # Make project_id NOT NULL again
+    op.alter_column(
+        "llm_judges",
+        "project_id",
+        nullable=False,
+        schema="quality_assurance",
+    )
+    op.alter_column(
+        "dataset_project",
+        "project_id",
+        nullable=False,
+        schema="quality_assurance",
+    )
+
+    # Remove organization_id columns
+    op.drop_column("llm_judges", "organization_id", schema="quality_assurance")
+    op.drop_column("dataset_project", "organization_id", schema="quality_assurance")

--- a/ada_backend/database/alembic/versions/a1b2c3d4e5f9_add_organization_id_to_qa_tables.py
+++ b/ada_backend/database/alembic/versions/a1b2c3d4e5f9_add_organization_id_to_qa_tables.py
@@ -1,7 +1,7 @@
 """add organization_id to qa tables
 
-Revision ID: a1b2c3d4e5f8
-Revises: b2c3d4e5f6a7
+Revision ID: a1b2c3d4e5f9
+Revises: d3e4f5a6b7c8
 Create Date: 2026-02-09 10:00:00.000000
 
 """
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f8"
-down_revision: Union[str, None] = "b2c3d4e5f6a7"
+revision: str = "a1b2c3d4e5f9"
+down_revision: Union[str, None] = "d3e4f5a6b7c8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -1787,14 +1787,16 @@ class InputGroundtruth(Base):
         return f"InputGroundtruth(id={self.id}, input={self.input})"
 
 
+# TODO: rename to DatasetOrganization
 class DatasetProject(Base):
     __tablename__ = "dataset_project"
     __table_args__ = {"schema": "quality_assurance"}
 
     id = mapped_column(UUID(as_uuid=True), primary_key=True, index=True, server_default=func.gen_random_uuid())
+    organization_id = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     project_id = mapped_column(
-        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
-    )
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
+    )  # TODO: remove project_id
     dataset_name = mapped_column(String, nullable=False)
     created_at = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
@@ -1903,10 +1905,11 @@ class LLMJudge(Base):
     __table_args__ = {"schema": "quality_assurance"}
 
     id = mapped_column(UUID(as_uuid=True), primary_key=True, index=True, server_default=func.gen_random_uuid())
+    organization_id = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     project_id = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("projects.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
     name = mapped_column(String, nullable=False)

--- a/ada_backend/main.py
+++ b/ada_backend/main.py
@@ -34,6 +34,7 @@ from ada_backend.routers.llm_judges_router import router as llm_judges_router
 from ada_backend.routers.llm_models_router import router as llm_models_router
 from ada_backend.routers.monitor_router import router as monitor_router
 from ada_backend.routers.oauth_router import router as oauth_router
+from ada_backend.routers.organization_qa_router import router as organization_qa_router
 from ada_backend.routers.organization_router import router as org_router
 from ada_backend.routers.project_router import router as project_router
 from ada_backend.routers.qa_evaluation_router import router as qa_evaluation_router
@@ -252,6 +253,7 @@ app.include_router(components_router)
 app.include_router(component_version_router)
 app.include_router(categories_router)
 app.include_router(graph_router)
+app.include_router(organization_qa_router)
 app.include_router(quality_assurance_router)
 app.include_router(qa_stream_router)
 app.include_router(llm_judges_router)

--- a/ada_backend/repositories/quality_assurance_repository.py
+++ b/ada_backend/repositories/quality_assurance_repository.py
@@ -315,16 +315,16 @@ def clear_version_outputs_for_input_ids(
 
 
 # Dataset functions
-def get_datasets_by_project(
+def get_datasets_by_organization(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     skip: int = 0,
     limit: int = 100,
 ) -> List[DatasetProject]:
-    """Get datasets for a project with pagination."""
+    """Get datasets for an organization with pagination."""
     return (
         session.query(DatasetProject)
-        .filter(DatasetProject.project_id == project_id)
+        .filter(DatasetProject.organization_id == organization_id)
         .order_by(DatasetProject.created_at.desc())
         .offset(skip)
         .limit(limit)
@@ -332,17 +332,16 @@ def get_datasets_by_project(
     )
 
 
-def create_datasets(
+def create_datasets_for_organization(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     dataset_names: List[str],
 ) -> List[DatasetProject]:
-    """Create multiple datasets."""
     datasets = []
 
     for dataset_name in dataset_names:
         dataset = DatasetProject(
-            project_id=project_id,
+            organization_id=organization_id,
             dataset_name=dataset_name,
         )
         datasets.append(dataset)
@@ -354,54 +353,66 @@ def create_datasets(
     for dataset in datasets:
         session.refresh(dataset)
 
-    LOGGER.info(f"Created {len(datasets)} datasets for project {project_id}")
+    LOGGER.info(f"Created {len(datasets)} datasets for organization {organization_id}")
     return datasets
 
 
-def update_dataset(
+def get_dataset_by_id_and_organization(
+    session: Session,
+    dataset_id: UUID,
+    organization_id: UUID,
+) -> Optional[DatasetProject]:
+    """Get a dataset by ID and verify it belongs to the organization."""
+    return (
+        session.query(DatasetProject)
+        .filter(DatasetProject.id == dataset_id, DatasetProject.organization_id == organization_id)
+        .first()
+    )
+
+
+def update_dataset_in_organization(
     session: Session,
     dataset_id: UUID,
     dataset_name: Optional[str],
-    project_id: UUID,
+    organization_id: UUID,
 ) -> DatasetProject:
-    """Update a dataset"""
-    dataset = (
-        session.query(DatasetProject)
-        .filter(DatasetProject.id == dataset_id, DatasetProject.project_id == project_id)
-        .first()
-    )
+    """Update a dataset in an organization."""
+    dataset = get_dataset_by_id_and_organization(session, dataset_id, organization_id)
+
+    if not dataset:
+        raise ValueError(f"Dataset {dataset_id} not found in organization {organization_id}")
 
     if dataset_name is not None:
         dataset.dataset_name = dataset_name
 
     session.commit()
 
-    LOGGER.info(f"Updated dataset {dataset_id} with name '{dataset_name}' for project {project_id}")
+    LOGGER.info(f"Updated dataset {dataset_id} with name '{dataset_name}' for organization {organization_id}")
     return dataset
 
 
-def delete_datasets(
+def delete_datasets_from_organization(
     session: Session,
     dataset_ids: List[UUID],
-    project_id: UUID,
+    organization_id: UUID,
 ) -> int:
-    """Delete multiple datasets."""
+    """Delete multiple datasets from an organization."""
     deleted_count = (
         session.query(DatasetProject)
-        .filter(DatasetProject.id.in_(dataset_ids), DatasetProject.project_id == project_id)
+        .filter(DatasetProject.id.in_(dataset_ids), DatasetProject.organization_id == organization_id)
         .delete(synchronize_session=False)
     )
 
     session.commit()
 
-    LOGGER.info(f"Deleted {deleted_count} datasets for project {project_id}")
+    LOGGER.info(f"Deleted {deleted_count} datasets for organization {organization_id}")
     return deleted_count
 
 
-def check_dataset_belongs_to_project(session: Session, project_id: UUID, dataset_id: UUID) -> bool:
+def check_dataset_belongs_to_organization(session: Session, organization_id: UUID, dataset_id: UUID) -> bool:
     exists = session.query(
         session.query(DatasetProject)
-        .filter(DatasetProject.id == dataset_id, DatasetProject.project_id == project_id)
+        .filter(DatasetProject.id == dataset_id, DatasetProject.organization_id == organization_id)
         .exists()
     ).scalar()
     return exists

--- a/ada_backend/routers/llm_judges_router.py
+++ b/ada_backend/routers/llm_judges_router.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from ada_backend.database.models import EvaluationType
 from ada_backend.database.setup_db import get_db
+from ada_backend.repositories.project_repository import get_project
 from ada_backend.routers.auth_router import (
     UserRights,
     get_user_from_supabase_token,
@@ -21,11 +22,11 @@ from ada_backend.schemas.llm_judges_schema import (
 )
 from ada_backend.services.errors import LLMJudgeNotFound
 from ada_backend.services.qa.llm_judges_service import (
-    create_llm_judge_service,
-    delete_llm_judges_service,
+    create_llm_judge_for_organization_service,
+    delete_llm_judges_from_organization_service,
     get_llm_judge_defaults_service,
-    get_llm_judges_by_project_service,
-    update_llm_judge_service,
+    get_llm_judges_by_organization_service,
+    update_llm_judge_in_organization_service,
 )
 
 router = APIRouter(tags=["QA Evaluation"])
@@ -36,6 +37,7 @@ LOGGER = logging.getLogger(__name__)
     "/projects/{project_id}/qa/llm-judges",
     response_model=List[LLMJudgeResponse],
     summary="Get LLM Judges by Project",
+    deprecated=True,
 )
 def get_llm_judges_by_project_endpoint(
     project_id: UUID,
@@ -45,11 +47,21 @@ def get_llm_judges_by_project_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> List[LLMJudgeResponse]:
+    """
+    **DEPRECATED**: This endpoint is deprecated. Use `GET /organizations/{organization_id}/qa/llm-judges` instead.
+
+    Returns all LLM judges from the project's organization.
+    LLM judges are now organization-scoped and shared across all projects in the organization.
+    """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        return get_llm_judges_by_project_service(session=session, project_id=project_id)
+        return get_llm_judges_by_organization_service(session=session, organization_id=project.organization_id)
     except Exception as e:
         LOGGER.error(f"Failed to get LLM judges for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error") from e
@@ -74,6 +86,7 @@ def get_llm_judge_defaults(
     "/projects/{project_id}/qa/llm-judges",
     response_model=LLMJudgeResponse,
     summary="Create LLM Judge",
+    deprecated=True,
 )
 def create_llm_judge_endpoint(
     project_id: UUID,
@@ -84,11 +97,23 @@ def create_llm_judge_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> LLMJudgeResponse:
+    """
+    **DEPRECATED**: This endpoint is deprecated. Use `POST /organizations/{organization_id}/qa/llm-judges` instead.
+
+    Creates an LLM judge at the organization level (using the project's organization).
+    LLM judges are now organization-scoped and shared across all projects in the organization.
+    """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        return create_llm_judge_service(session=session, project_id=project_id, judge_data=judge_data)
+        return create_llm_judge_for_organization_service(
+            session=session, organization_id=project.organization_id, judge_data=judge_data
+        )
     except ValueError as e:
         LOGGER.error(f"Failed to create LLM judge for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
@@ -101,6 +126,7 @@ def create_llm_judge_endpoint(
     "/projects/{project_id}/qa/llm-judges/{judge_id}",
     response_model=LLMJudgeResponse,
     summary="Update LLM Judge",
+    deprecated=True,
 )
 def update_llm_judge_endpoint(
     project_id: UUID,
@@ -112,13 +138,23 @@ def update_llm_judge_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> LLMJudgeResponse:
+    """
+    **DEPRECATED**: This endpoint is deprecated.
+    Use `PATCH /organizations/{organization_id}/qa/llm-judges/{judge_id}` instead.
+
+    Updates an LLM judge at the organization level.
+    """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        return update_llm_judge_service(
+        return update_llm_judge_in_organization_service(
             session=session,
-            project_id=project_id,
+            organization_id=project.organization_id,
             judge_id=judge_id,
             judge_data=judge_data,
         )
@@ -136,6 +172,7 @@ def update_llm_judge_endpoint(
     "/projects/{project_id}/qa/llm-judges",
     status_code=204,
     summary="Delete LLM Judges",
+    deprecated=True,
 )
 def delete_llm_judges_endpoint(
     project_id: UUID,
@@ -146,11 +183,22 @@ def delete_llm_judges_endpoint(
     session: Session = Depends(get_db),
     judge_ids: List[UUID] = Body(...),
 ):
+    """
+    **DEPRECATED**: This endpoint is deprecated. Use `DELETE /organizations/{organization_id}/qa/llm-judges` instead.
+
+    Deletes LLM judges at the organization level.
+    """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        delete_llm_judges_service(session=session, project_id=project_id, judge_ids=judge_ids)
+        delete_llm_judges_from_organization_service(
+            session=session, organization_id=project.organization_id, judge_ids=judge_ids
+        )
         return None
     except ValueError as e:
         LOGGER.error(f"Failed to delete LLM judges for project {project_id}: {str(e)}", exc_info=True)

--- a/ada_backend/routers/organization_qa_router.py
+++ b/ada_backend/routers/organization_qa_router.py
@@ -1,0 +1,463 @@
+import logging
+from typing import Annotated, List
+from uuid import UUID
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from ada_backend.database.setup_db import get_db
+from ada_backend.routers.auth_router import (
+    UserRights,
+    user_has_access_to_organization_dependency,
+)
+from ada_backend.schemas.auth_schema import SupabaseUser
+from ada_backend.schemas.dataset_schema import (
+    DatasetCreateList,
+    DatasetDeleteList,
+    DatasetListResponse,
+    DatasetResponse,
+)
+from ada_backend.schemas.input_groundtruth_schema import (
+    InputGroundtruthCreateList,
+    InputGroundtruthDeleteList,
+    InputGroundtruthResponseList,
+    InputGroundtruthUpdateList,
+    PaginatedInputGroundtruthResponse,
+)
+from ada_backend.schemas.llm_judges_schema import (
+    LLMJudgeCreate,
+    LLMJudgeResponse,
+    LLMJudgeUpdate,
+)
+from ada_backend.services.errors import LLMJudgeNotFound
+from ada_backend.services.qa.llm_judges_service import (
+    create_llm_judge_for_organization_service,
+    delete_llm_judges_from_organization_service,
+    get_llm_judges_by_organization_service,
+    update_llm_judge_in_organization_service,
+)
+from ada_backend.services.qa.qa_error import (
+    QADuplicatePositionError,
+    QAPartialPositionError,
+)
+from ada_backend.services.qa.quality_assurance_service import (
+    create_datasets_for_organization_service,
+    create_inputs_groundtruths_service,
+    delete_datasets_from_organization_service,
+    delete_inputs_groundtruths_service,
+    get_datasets_by_organization_service,
+    get_inputs_groundtruths_with_version_outputs_service,
+    update_dataset_in_organization_service,
+    update_inputs_groundtruths_service,
+)
+
+router = APIRouter(tags=["Organization Quality Assurance"])
+LOGGER = logging.getLogger(__name__)
+
+
+# Dataset endpoints
+@router.get(
+    "/organizations/{organization_id}/qa/datasets",
+    response_model=List[DatasetResponse],
+    summary="Get Datasets by Organization",
+    tags=["Organization Quality Assurance"],
+)
+def get_datasets_by_organization_endpoint(
+    organization_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> List[DatasetResponse]:
+    """
+    Get all datasets for an organization.
+
+    This endpoint allows users to retrieve all datasets associated with a specific organization
+    for quality assurance purposes.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return get_datasets_by_organization_service(session, organization_id)
+    except ValueError as e:
+        LOGGER.error(f"Failed to get datasets for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to get datasets for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post(
+    "/organizations/{organization_id}/qa/datasets",
+    response_model=DatasetListResponse,
+    summary="Create Datasets for Organization",
+    tags=["Organization Quality Assurance"],
+)
+def create_dataset_for_organization_endpoint(
+    organization_id: UUID,
+    dataset_data: DatasetCreateList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> DatasetListResponse:
+    """
+    Create datasets for an organization.
+
+    This endpoint allows users to create multiple datasets for quality assurance purposes.
+    All datasets will be associated with the specified organization.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return create_datasets_for_organization_service(session, organization_id, dataset_data)
+    except ValueError as e:
+        LOGGER.error(f"Failed to create datasets for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to create datasets for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.patch(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}",
+    response_model=DatasetResponse,
+    summary="Update Dataset in Organization",
+    tags=["Organization Quality Assurance"],
+)
+def update_dataset_in_organization_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    dataset_name: str,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> DatasetResponse:
+    """
+    Update dataset in an organization.
+
+    This endpoint allows users to update a single dataset.
+    Only the fields provided in the request will be updated.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return update_dataset_in_organization_service(session, organization_id, dataset_id, dataset_name)
+    except ValueError as e:
+        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete(
+    "/organizations/{organization_id}/qa/datasets",
+    summary="Delete Datasets from Organization",
+    tags=["Organization Quality Assurance"],
+)
+def delete_datasets_from_organization_endpoint(
+    organization_id: UUID,
+    delete_data: DatasetDeleteList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> dict:
+    """
+    Delete datasets from an organization.
+
+    This endpoint allows users to delete multiple datasets at once.
+    This action cannot be undone.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        deleted_count = delete_datasets_from_organization_service(session, organization_id, delete_data)
+        return {"message": f"Deleted {deleted_count} datasets successfully"}
+    except ValueError as e:
+        LOGGER.error(f"Failed to delete datasets for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to delete datasets for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+# Input Groundtruth endpoints (dataset entries)
+@router.get(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/entries",
+    response_model=PaginatedInputGroundtruthResponse,
+    summary="Get Input-Groundtruth Entries by Dataset",
+    tags=["Organization Quality Assurance"],
+)
+def get_inputs_groundtruths_by_dataset_in_organization_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+    page: int = Query(1, ge=1, description="Page number (1-based)"),
+    page_size: int = Query(100, ge=1, le=1000, description="Number of items per page"),
+) -> PaginatedInputGroundtruthResponse:
+    """
+    Get all input-groundtruth entries for a dataset WITHOUT outputs.
+
+    This endpoint returns only the base input-groundtruth pairs for a dataset.
+    Use the /outputs endpoint to get outputs for a specific graph_runner.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return get_inputs_groundtruths_with_version_outputs_service(session, dataset_id, page, page_size)
+    except ValueError as e:
+        LOGGER.error(f"Failed to get input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to get input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/entries",
+    response_model=InputGroundtruthResponseList,
+    summary="Create Input-Groundtruth Entries",
+    tags=["Organization Quality Assurance"],
+)
+def create_input_groundtruth_in_organization_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    input_groundtruth_data: InputGroundtruthCreateList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> InputGroundtruthResponseList:
+    """
+    Create input-groundtruth entries.
+
+    This endpoint allows users to create multiple input-groundtruth pairs for quality assurance purposes.
+    All entries will be associated with the specified dataset.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return create_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
+    except (QADuplicatePositionError, QAPartialPositionError) as e:
+        LOGGER.error(f"Failed to create input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except ValueError as e:
+        LOGGER.error(f"Failed to create input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to create input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.patch(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/entries",
+    response_model=InputGroundtruthResponseList,
+    summary="Update Input-Groundtruth Entries",
+    tags=["Organization Quality Assurance"],
+)
+def update_input_groundtruth_in_organization_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    input_groundtruth_data: InputGroundtruthUpdateList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> InputGroundtruthResponseList:
+    """
+    Update input-groundtruth entries.
+
+    This endpoint allows users to update multiple input-groundtruth pairs.
+    Only the fields provided in the request will be updated.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return update_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
+    except ValueError as e:
+        LOGGER.error(f"Failed to update input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to update input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/entries",
+    summary="Delete Input-Groundtruth Entries",
+    tags=["Organization Quality Assurance"],
+)
+def delete_input_groundtruth_in_organization_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    delete_data: InputGroundtruthDeleteList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> dict:
+    """
+    Delete input-groundtruth entries.
+
+    This endpoint allows users to delete multiple input-groundtruth pairs at once.
+    This action cannot be undone.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        deleted_count = delete_inputs_groundtruths_service(session, dataset_id, delete_data)
+        return {"message": f"Deleted {deleted_count} input-groundtruth entries successfully"}
+    except ValueError as e:
+        LOGGER.error(f"Failed to delete input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to delete input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+# LLM Judge endpoints
+@router.get(
+    "/organizations/{organization_id}/qa/llm-judges",
+    response_model=List[LLMJudgeResponse],
+    summary="Get LLM Judges by Organization",
+    tags=["Organization Quality Assurance"],
+)
+def get_llm_judges_by_organization_endpoint(
+    organization_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> List[LLMJudgeResponse]:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return get_llm_judges_by_organization_service(session=session, organization_id=organization_id)
+    except Exception as e:
+        LOGGER.error(f"Failed to get LLM judges for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post(
+    "/organizations/{organization_id}/qa/llm-judges",
+    response_model=LLMJudgeResponse,
+    summary="Create LLM Judge for Organization",
+    tags=["Organization Quality Assurance"],
+)
+def create_llm_judge_for_organization_endpoint(
+    organization_id: UUID,
+    judge_data: LLMJudgeCreate,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> LLMJudgeResponse:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return create_llm_judge_for_organization_service(
+            session=session, organization_id=organization_id, judge_data=judge_data
+        )
+    except ValueError as e:
+        LOGGER.error(f"Failed to create LLM judge for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to create LLM judge for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.patch(
+    "/organizations/{organization_id}/qa/llm-judges/{judge_id}",
+    response_model=LLMJudgeResponse,
+    summary="Update LLM Judge in Organization",
+    tags=["Organization Quality Assurance"],
+)
+def update_llm_judge_in_organization_endpoint(
+    organization_id: UUID,
+    judge_id: UUID,
+    judge_data: LLMJudgeUpdate,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> LLMJudgeResponse:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return update_llm_judge_in_organization_service(
+            session=session,
+            organization_id=organization_id,
+            judge_id=judge_id,
+            judge_data=judge_data,
+        )
+    except LLMJudgeNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except ValueError as e:
+        LOGGER.error(
+            f"Failed to update LLM judge {judge_id} for organization {organization_id}: {str(e)}", exc_info=True
+        )
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to update LLM judge {judge_id} for organization {organization_id}: {str(e)}", exc_info=True
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete(
+    "/organizations/{organization_id}/qa/llm-judges",
+    status_code=204,
+    summary="Delete LLM Judges from Organization",
+    tags=["Organization Quality Assurance"],
+)
+def delete_llm_judges_from_organization_endpoint(
+    organization_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+    judge_ids: List[UUID] = Body(...),
+):
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        delete_llm_judges_from_organization_service(
+            session=session, organization_id=organization_id, judge_ids=judge_ids
+        )
+        return None
+    except ValueError as e:
+        LOGGER.error(f"Failed to delete LLM judges for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to delete LLM judges for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/ada_backend/routers/quality_assurance_router.py
+++ b/ada_backend/routers/quality_assurance_router.py
@@ -9,8 +9,13 @@ from sqlalchemy.orm import Session
 
 from ada_backend.database.models import RunStatus
 from ada_backend.database.setup_db import get_db
+from ada_backend.repositories.project_repository import get_project
 from ada_backend.repositories.qa_session_repository import update_qa_session_status
-from ada_backend.routers.auth_router import UserRights, user_has_access_to_project_dependency
+from ada_backend.routers.auth_router import (
+    UserRights,
+    user_has_access_to_organization_dependency,
+    user_has_access_to_project_dependency,
+)
 from ada_backend.schemas.auth_schema import SupabaseUser
 from ada_backend.schemas.dataset_schema import (
     DatasetCreateList,
@@ -40,7 +45,7 @@ from ada_backend.services.qa.qa_error import (
     CSVMissingDatasetColumnError,
     CSVNonUniquePositionError,
     QAColumnNotFoundError,
-    QADatasetNotInProjectError,
+    QADatasetNotInOrgError,
     QADuplicatePositionError,
     QAPartialPositionError,
 )
@@ -51,13 +56,12 @@ from ada_backend.services.qa.qa_metadata_service import (
     rename_qa_column_service,
 )
 from ada_backend.services.qa.quality_assurance_service import (
-    create_datasets_service,
+    create_datasets_for_organization_service,
     create_inputs_groundtruths_service,
-    create_qa_session_service,
-    delete_datasets_service,
+    delete_datasets_from_organization_service,
     delete_inputs_groundtruths_service,
     export_qa_data_to_csv_service,
-    get_datasets_by_project_service,
+    get_datasets_by_organization_service,
     get_inputs_groundtruths_with_version_outputs_service,
     get_outputs_by_graph_runner_service,
     get_qa_session_service,
@@ -66,7 +70,7 @@ from ada_backend.services.qa.quality_assurance_service import (
     list_qa_sessions_service,
     run_qa_service,
     save_conversation_to_groundtruth_service,
-    update_dataset_service,
+    update_dataset_in_organization_service,
     update_inputs_groundtruths_service,
     validate_qa_run_request,
 )
@@ -82,6 +86,7 @@ LOGGER = logging.getLogger(__name__)
     response_model=List[DatasetResponse],
     summary="Get Datasets by Project",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def get_datasets_by_project_endpoint(
     project_id: UUID,
@@ -94,14 +99,20 @@ def get_datasets_by_project_endpoint(
     """
     Get all datasets for a project.
 
-    This endpoint allows users to retrieve all datasets associated with a specific project
-    for quality assurance purposes.
+    **DEPRECATED**: This endpoint is deprecated. Use `/organizations/{organization_id}/qa/datasets` instead.
+
+    This endpoint returns all datasets from the project's organization.
+    Datasets are now organization-scoped and shared across all projects in the organization.
     """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        return get_datasets_by_project_service(session, project_id)
+        return get_datasets_by_organization_service(session, project.organization_id)
     except ValueError as e:
         LOGGER.error(f"Failed to get datasets for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
@@ -115,6 +126,7 @@ def get_datasets_by_project_endpoint(
     response_model=DatasetListResponse,
     summary="Create Datasets",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def create_dataset_endpoint(
     project_id: UUID,
@@ -128,14 +140,20 @@ def create_dataset_endpoint(
     """
     Create datasets for a project.
 
-    This endpoint allows users to create multiple datasets for quality assurance purposes.
-    All datasets will be associated with the specified project.
+    **DEPRECATED**: This endpoint is deprecated. Use `POST /organizations/{organization_id}/qa/datasets` instead.
+
+    This endpoint creates datasets at the organization level (using the project's organization).
+    Datasets are now organization-scoped and shared across all projects in the organization.
     """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        return create_datasets_service(session, project_id, dataset_data)
+        return create_datasets_for_organization_service(session, project.organization_id, dataset_data)
     except ValueError as e:
         LOGGER.error(f"Failed to create datasets for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
@@ -149,6 +167,7 @@ def create_dataset_endpoint(
     response_model=DatasetResponse,
     summary="Update Dataset",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def update_dataset_endpoint(
     project_id: UUID,
@@ -163,17 +182,25 @@ def update_dataset_endpoint(
     """
     Update dataset.
 
-    This endpoint allows users to update a single dataset.
-    Only the fields provided in the request will be updated.
+    **DEPRECATED**: This endpoint is deprecated.
+    Use `PATCH /organizations/{organization_id}/qa/datasets/{dataset_id}` instead.
+
+    This endpoint updates datasets at the organization level.
     """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        return update_dataset_service(session, project_id, dataset_id, dataset_name)
-    except QADatasetNotInProjectError as e:
+        return update_dataset_in_organization_service(session, project.organization_id, dataset_id, dataset_name)
+    except QADatasetNotInOrgError as e:
         LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e)) from e
+    except HTTPException:
+        raise
     except ValueError as e:
         LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
@@ -186,6 +213,7 @@ def update_dataset_endpoint(
     "/projects/{project_id}/qa/datasets",
     summary="Delete Datasets",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def delete_dataset_endpoint(
     project_id: UUID,
@@ -199,16 +227,22 @@ def delete_dataset_endpoint(
     """
     Delete datasets.
 
-    This endpoint allows users to delete multiple datasets at once.
+    **DEPRECATED**: This endpoint is deprecated. Use `DELETE /organizations/{organization_id}/qa/datasets` instead.
+
+    This endpoint deletes datasets at the organization level.
     This action cannot be undone.
     """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        deleted_count = delete_datasets_service(session, project_id, delete_data)
+        deleted_count = delete_datasets_from_organization_service(session, project.organization_id, delete_data)
         return {"message": f"Deleted {deleted_count} datasets successfully"}
-    except QADatasetNotInProjectError as e:
+    except QADatasetNotInOrgError as e:
         LOGGER.error(f"Failed to delete datasets for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e)) from e
     except ValueError as e:
@@ -225,6 +259,7 @@ def delete_dataset_endpoint(
     response_model=List[QAColumnResponse],
     summary="Get Custom Columns for Dataset",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def get_columns_by_dataset_endpoint(
     project_id: UUID,
@@ -235,12 +270,22 @@ def get_columns_by_dataset_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> List[QAColumnResponse]:
+    """
+    **DEPRECATED**: This endpoint is deprecated.
+    Use `GET /organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns` instead.
+
+    Custom columns are now organization-scoped and shared across all projects in the organization.
+    """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        return get_qa_columns_by_dataset_service(session, project_id, dataset_id)
-    except QADatasetNotInProjectError as e:
+        return get_qa_columns_by_dataset_service(session, project.organization_id, dataset_id)
+    except QADatasetNotInOrgError as e:
         LOGGER.error(
             f"Failed to get columns for dataset {dataset_id} in project {project_id}: {str(e)}", exc_info=True
         )
@@ -257,6 +302,7 @@ def get_columns_by_dataset_endpoint(
     response_model=QAColumnResponse,
     summary="Add Custom Column to Dataset",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def add_column_to_dataset_endpoint(
     project_id: UUID,
@@ -268,12 +314,22 @@ def add_column_to_dataset_endpoint(
     session: Session = Depends(get_db),
     column_name: str = Body(..., embed=True),
 ) -> QAColumnResponse:
+    """
+    **DEPRECATED**: This endpoint is deprecated.
+    Use `POST /organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns` instead.
+
+    Custom columns are now organization-scoped and shared across all projects in the organization.
+    """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        return create_qa_column_service(session, project_id, dataset_id, column_name)
-    except QADatasetNotInProjectError as e:
+        return create_qa_column_service(session, project.organization_id, dataset_id, column_name)
+    except QADatasetNotInOrgError as e:
         LOGGER.error(f"Failed to add column to dataset {dataset_id} for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
@@ -286,6 +342,7 @@ def add_column_to_dataset_endpoint(
     response_model=QAColumnResponse,
     summary="Rename Custom Column",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def rename_column_endpoint(
     project_id: UUID,
@@ -298,12 +355,22 @@ def rename_column_endpoint(
     session: Session = Depends(get_db),
     column_name: str = Body(..., embed=True),
 ) -> QAColumnResponse:
+    """
+    **DEPRECATED**: This endpoint is deprecated.
+    Use `PATCH /organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}` instead.
+
+    Custom columns are now organization-scoped and shared across all projects in the organization.
+    """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        return rename_qa_column_service(session, project_id, dataset_id, column_id, column_name)
-    except QADatasetNotInProjectError as e:
+        return rename_qa_column_service(session, project.organization_id, dataset_id, column_id, column_name)
+    except QADatasetNotInOrgError as e:
         LOGGER.error(
             f"Failed to rename column {column_id} in dataset {dataset_id} for project {project_id}: {str(e)}",
             exc_info=True,
@@ -327,6 +394,7 @@ def rename_column_endpoint(
     "/projects/{project_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}",
     summary="Delete Custom Column",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def delete_column_endpoint(
     project_id: UUID,
@@ -338,12 +406,22 @@ def delete_column_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> dict:
+    """
+    **DEPRECATED**: This endpoint is deprecated.
+    Use `DELETE /organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}` instead.
+
+    Custom columns are now organization-scoped and shared across all projects in the organization.
+    """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
-        return delete_qa_column_service(session, project_id, dataset_id, column_id)
-    except QADatasetNotInProjectError as e:
+        return delete_qa_column_service(session, project.organization_id, dataset_id, column_id)
+    except QADatasetNotInOrgError as e:
         LOGGER.error(
             f"Failed to delete column {column_id} from dataset {dataset_id} for project {project_id}: {str(e)}",
             exc_info=True,
@@ -363,12 +441,171 @@ def delete_column_endpoint(
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
+# QA Metadata (Custom Columns) org-level endpoints
+@router.get(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns",
+    response_model=List[QAColumnResponse],
+    summary="Get Custom Columns for Dataset",
+    tags=["Quality Assurance"],
+)
+def get_columns_by_dataset_org_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> List[QAColumnResponse]:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return get_qa_columns_by_dataset_service(session, organization_id, dataset_id)
+    except QADatasetNotInOrgError as e:
+        LOGGER.error(
+            f"Failed to get columns for dataset {dataset_id} in organization {organization_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to get columns for dataset {dataset_id} in organization {organization_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns",
+    response_model=QAColumnResponse,
+    summary="Add Custom Column to Dataset",
+    tags=["Quality Assurance"],
+)
+def add_column_to_dataset_org_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+    column_name: str = Body(..., embed=True),
+) -> QAColumnResponse:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return create_qa_column_service(session, organization_id, dataset_id, column_name)
+    except QADatasetNotInOrgError as e:
+        LOGGER.error(
+            f"Failed to add column to dataset {dataset_id} for organization {organization_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to add column to dataset {dataset_id} for organization {organization_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.patch(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}",
+    response_model=QAColumnResponse,
+    summary="Rename Custom Column",
+    tags=["Quality Assurance"],
+)
+def rename_column_org_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    column_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+    column_name: str = Body(..., embed=True),
+) -> QAColumnResponse:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return rename_qa_column_service(session, organization_id, dataset_id, column_id, column_name)
+    except QADatasetNotInOrgError as e:
+        LOGGER.error(
+            f"Failed to rename column {column_id} in dataset {dataset_id} "
+            f"for organization {organization_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except QAColumnNotFoundError as e:
+        LOGGER.error(
+            f"Failed to rename column {column_id} in dataset {dataset_id} "
+            f"for organization {organization_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to rename column {column_id} in dataset {dataset_id} "
+            f"for organization {organization_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}",
+    summary="Delete Custom Column",
+    tags=["Quality Assurance"],
+)
+def delete_column_org_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    column_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> dict:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return delete_qa_column_service(session, organization_id, dataset_id, column_id)
+    except QADatasetNotInOrgError as e:
+        LOGGER.error(
+            f"Failed to delete column {column_id} from dataset {dataset_id} "
+            f"for organization {organization_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except QAColumnNotFoundError as e:
+        LOGGER.error(
+            f"Failed to delete column {column_id} from dataset {dataset_id} "
+            f"for organization {organization_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to delete column {column_id} from dataset {dataset_id} "
+            f"for organization {organization_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
 # Input Groundtruth endpoints
 @router.get(
     "/projects/{project_id}/qa/datasets/{dataset_id}/entries",
     response_model=PaginatedInputGroundtruthResponse,
     summary="Get Input-Groundtruth Entries by Dataset",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def get_inputs_groundtruths_by_dataset_endpoint(
     project_id: UUID,
@@ -383,6 +620,9 @@ def get_inputs_groundtruths_by_dataset_endpoint(
 ) -> PaginatedInputGroundtruthResponse:
     """
     Get all input-groundtruth entries for a dataset WITHOUT outputs.
+
+    **DEPRECATED**: This endpoint is deprecated.
+    Use `GET /organizations/{organization_id}/qa/datasets/{dataset_id}/entries` instead.
 
     This endpoint returns only the base input-groundtruth pairs for a dataset.
     Use the /outputs endpoint to get outputs for a specific graph_runner.
@@ -475,6 +715,7 @@ def get_version_output_ids_endpoint(
     response_model=InputGroundtruthResponseList,
     summary="Create Input-Groundtruth Entries",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def create_input_groundtruth_endpoint(
     project_id: UUID,
@@ -488,6 +729,9 @@ def create_input_groundtruth_endpoint(
 ) -> InputGroundtruthResponseList:
     """
     Create input-groundtruth entries.
+
+    **DEPRECATED**: This endpoint is deprecated.
+    Use `POST /organizations/{organization_id}/qa/datasets/{dataset_id}/entries` instead.
 
     This endpoint allows users to create multiple input-groundtruth pairs for quality assurance purposes.
     All entries will be associated with the specified dataset.
@@ -513,6 +757,7 @@ def create_input_groundtruth_endpoint(
     response_model=InputGroundtruthResponseList,
     summary="Update Input-Groundtruth Entries",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def update_input_groundtruth_endpoint(
     project_id: UUID,
@@ -526,6 +771,9 @@ def update_input_groundtruth_endpoint(
 ) -> InputGroundtruthResponseList:
     """
     Update input-groundtruth entries.
+
+    **DEPRECATED**: This endpoint is deprecated.
+    Use `PATCH /organizations/{organization_id}/qa/datasets/{dataset_id}/entries` instead.
 
     This endpoint allows users to update multiple input-groundtruth pairs.
     Only the fields provided in the request will be updated.
@@ -547,6 +795,7 @@ def update_input_groundtruth_endpoint(
     "/projects/{project_id}/qa/datasets/{dataset_id}/entries",
     summary="Delete Input-Groundtruth Entries",
     tags=["Quality Assurance"],
+    deprecated=True,
 )
 def delete_input_groundtruth_endpoint(
     project_id: UUID,
@@ -560,6 +809,9 @@ def delete_input_groundtruth_endpoint(
 ) -> dict:
     """
     Delete input-groundtruth entries.
+
+    **DEPRECATED**: This endpoint is deprecated.
+    Use `DELETE /organizations/{organization_id}/qa/datasets/{dataset_id}/entries` instead.
 
     This endpoint allows users to delete multiple input-groundtruth pairs at once.
     This action cannot be undone.
@@ -683,7 +935,8 @@ async def run_qa_async_endpoint(
         run_request_data=run_request.model_dump(mode="json"),
     ):
         update_qa_session_status(
-            session, qa_session.id,
+            session,
+            qa_session.id,
             status=RunStatus.FAILED,
             error={"message": "Failed to enqueue QA run; Redis unavailable.", "type": "EnqueueError"},
         )
@@ -823,12 +1076,16 @@ async def import_qa_data_from_csv_endpoint(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     try:
         await file.seek(0)
 
         result = import_qa_data_from_csv_service(
             session=session,
-            project_id=project_id,
+            organization_id=project.organization_id,
             dataset_id=dataset_id,
             csv_file=file.file,
         )
@@ -842,7 +1099,7 @@ async def import_qa_data_from_csv_endpoint(
         CSVInvalidPositionError,
     ) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except QADatasetNotInProjectError as e:
+    except QADatasetNotInOrgError as e:
         LOGGER.error(
             f"Failed to import QA data for dataset {dataset_id} in project {project_id}: {str(e)}", exc_info=True
         )

--- a/ada_backend/schemas/dataset_schema.py
+++ b/ada_backend/schemas/dataset_schema.py
@@ -28,7 +28,8 @@ class DatasetResponse(BaseModel):
     """Schema for dataset response."""
 
     id: UUID
-    project_id: UUID
+    organization_id: UUID
+    project_id: Optional[UUID] = None
     dataset_name: str
     created_at: datetime
     updated_at: datetime

--- a/ada_backend/schemas/llm_judges_schema.py
+++ b/ada_backend/schemas/llm_judges_schema.py
@@ -20,7 +20,8 @@ class LLMJudgeResponse(LLMJudgeCreate):
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
-    project_id: UUID
+    organization_id: UUID
+    project_id: Optional[UUID] = None
     created_at: datetime
     updated_at: datetime
 

--- a/ada_backend/services/qa/llm_judges_service.py
+++ b/ada_backend/services/qa/llm_judges_service.py
@@ -6,9 +6,9 @@ from sqlalchemy.orm import Session
 
 from ada_backend.database.models import EvaluationType
 from ada_backend.repositories.llm_judges_repository import (
-    create_llm_judge,
-    delete_llm_judges,
-    get_llm_judges_by_project,
+    create_llm_judge_for_organization,
+    delete_llm_judges_from_organization,
+    get_llm_judges_by_organization,
     update_llm_judge,
 )
 from ada_backend.schemas.llm_judges_schema import (
@@ -28,15 +28,15 @@ from ada_backend.services.qa.utils import (
 LOGGER = logging.getLogger(__name__)
 
 
-def get_llm_judges_by_project_service(
+def get_llm_judges_by_organization_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
 ) -> List[LLMJudgeResponse]:
     try:
-        judges = get_llm_judges_by_project(session=session, project_id=project_id)
+        judges = get_llm_judges_by_organization(session=session, organization_id=organization_id)
         return [LLMJudgeResponse.model_validate(judge) for judge in judges]
     except Exception as e:
-        LOGGER.error(f"Error in get_llm_judges_by_project_service for project {project_id}: {str(e)}")
+        LOGGER.error(f"Error in get_llm_judges_by_organization_service for organization {organization_id}: {str(e)}")
         raise ValueError(f"Failed to list LLM judges: {str(e)}") from e
 
 
@@ -60,15 +60,15 @@ def get_llm_judge_defaults_service(
     )
 
 
-def create_llm_judge_service(
+def create_llm_judge_for_organization_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     judge_data: LLMJudgeCreate,
 ) -> LLMJudgeResponse:
     try:
-        llm_judge = create_llm_judge(
+        llm_judge = create_llm_judge_for_organization(
             session=session,
-            project_id=project_id,
+            organization_id=organization_id,
             name=judge_data.name,
             description=judge_data.description,
             evaluation_type=judge_data.evaluation_type,
@@ -76,16 +76,18 @@ def create_llm_judge_service(
             prompt_template=judge_data.prompt_template,
             temperature=judge_data.temperature,
         )
-        LOGGER.info(f"Created LLM judge {llm_judge.id} for project {project_id}")
+        LOGGER.info(f"Created LLM judge {llm_judge.id} for organization {organization_id}")
         return LLMJudgeResponse.model_validate(llm_judge)
     except Exception as e:
-        LOGGER.error(f"Error in create_llm_judge_service for project {project_id}: {str(e)}")
+        LOGGER.error(
+            f"Error in create_llm_judge_for_organization_service for organization {organization_id}: {str(e)}"
+        )
         raise ValueError(f"Failed to create LLM judge: {str(e)}") from e
 
 
-def update_llm_judge_service(
+def update_llm_judge_in_organization_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     judge_id: UUID,
     judge_data: LLMJudgeUpdate,
 ) -> LLMJudgeResponse:
@@ -93,7 +95,6 @@ def update_llm_judge_service(
         updated_judge = update_llm_judge(
             session=session,
             judge_id=judge_id,
-            project_id=project_id,
             name=judge_data.name,
             description=judge_data.description,
             evaluation_type=judge_data.evaluation_type,
@@ -102,28 +103,30 @@ def update_llm_judge_service(
             temperature=judge_data.temperature,
         )
         if not updated_judge:
-            raise LLMJudgeNotFound(judge_id=judge_id, project_id=project_id)
-        LOGGER.info(f"Updated LLM judge {judge_id} for project {project_id}")
+            raise LLMJudgeNotFound(judge_id=judge_id, project_id=None)
+        LOGGER.info(f"Updated LLM judge {judge_id} for organization {organization_id}")
         return LLMJudgeResponse.model_validate(updated_judge)
     except LLMJudgeNotFound:
         raise
     except Exception as e:
-        LOGGER.error(f"Error in update_llm_judge_service for judge {judge_id}: {str(e)}")
+        LOGGER.error(f"Error in update_llm_judge_in_organization_service for judge {judge_id}: {str(e)}")
         raise ValueError(f"Failed to update LLM judge: {str(e)}") from e
 
 
-def delete_llm_judges_service(
+def delete_llm_judges_from_organization_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     judge_ids: List[UUID],
 ) -> None:
     try:
-        deleted_count = delete_llm_judges(
+        deleted_count = delete_llm_judges_from_organization(
             session=session,
             judge_ids=judge_ids,
-            project_id=project_id,
+            organization_id=organization_id,
         )
-        LOGGER.info(f"Deleted {deleted_count} LLM judges for project {project_id}")
+        LOGGER.info(f"Deleted {deleted_count} LLM judges for organization {organization_id}")
     except Exception as e:
-        LOGGER.error(f"Error in delete_llm_judges_service for project {project_id}: {str(e)}")
+        LOGGER.error(
+            f"Error in delete_llm_judges_from_organization_service for organization {organization_id}: {str(e)}"
+        )
         raise ValueError(f"Failed to delete LLM judges: {str(e)}") from e

--- a/ada_backend/services/qa/qa_error.py
+++ b/ada_backend/services/qa/qa_error.py
@@ -98,7 +98,7 @@ class InvalidFormatError(Exception):
         super().__init__(f"Invalid {expected_format} format in {field_name}")
 
 
-class QADatasetNotInProjectError(Exception):
+class QADatasetNotInOrgError(Exception):
     """Raised when a dataset is not linked to the given project"""
 
     def __init__(self, project_id: UUID, dataset_id: UUID):

--- a/ada_backend/services/qa/qa_metadata_service.py
+++ b/ada_backend/services/qa/qa_metadata_service.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from ada_backend.repositories.quality_assurance_repository import (
     check_column_exist,
-    check_dataset_belongs_to_project,
+    check_dataset_belongs_to_organization,
     create_custom_column,
     delete_custom_column,
     get_dataset_custom_columns_display_max_position,
@@ -16,38 +16,38 @@ from ada_backend.repositories.quality_assurance_repository import (
     rename_custom_column,
 )
 from ada_backend.schemas.qa_metadata_schema import QAColumnResponse
-from ada_backend.services.qa.qa_error import QAColumnNotFoundError, QADatasetNotInProjectError
+from ada_backend.services.qa.qa_error import QAColumnNotFoundError, QADatasetNotInOrgError
 
 LOGGER = logging.getLogger(__name__)
 
 
 def get_qa_columns_by_dataset_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     dataset_id: UUID,
 ) -> List[QAColumnResponse]:
     try:
-        dataset_existence = check_dataset_belongs_to_project(session, project_id, dataset_id)
+        dataset_existence = check_dataset_belongs_to_organization(session, organization_id, dataset_id)
         if not dataset_existence:
-            raise QADatasetNotInProjectError(project_id, dataset_id)
+            raise QADatasetNotInOrgError(organization_id, dataset_id)
 
         columns = get_qa_columns_by_dataset(session, dataset_id)
 
         return [QAColumnResponse.model_validate(col) for col in columns]
-    except QADatasetNotInProjectError:
+    except QADatasetNotInOrgError:
         raise
 
 
 def create_qa_column_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     dataset_id: UUID,
     column_name: str,
 ) -> QAColumnResponse:
     try:
-        dataset_existence = check_dataset_belongs_to_project(session, project_id, dataset_id)
+        dataset_existence = check_dataset_belongs_to_organization(session, organization_id, dataset_id)
         if not dataset_existence:
-            raise QADatasetNotInProjectError(project_id, dataset_id)
+            raise QADatasetNotInOrgError(organization_id, dataset_id)
 
         max_position = get_dataset_custom_columns_display_max_position(session, dataset_id)
         new_position = (max_position + 1) if max_position is not None else 0
@@ -63,22 +63,22 @@ def create_qa_column_service(
         )
 
         return QAColumnResponse.model_validate(qa_metadata)
-    except QADatasetNotInProjectError:
-        LOGGER.error(f"Dataset {dataset_id} not found in project {project_id}")
+    except QADatasetNotInOrgError:
+        LOGGER.error(f"Dataset {dataset_id} not found in organization {organization_id}")
         raise
 
 
 def rename_qa_column_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     dataset_id: UUID,
     column_id: UUID,
     column_name: str,
 ) -> QAColumnResponse:
     try:
-        dataset_existence = check_dataset_belongs_to_project(session, project_id, dataset_id)
+        dataset_existence = check_dataset_belongs_to_organization(session, organization_id, dataset_id)
         if not dataset_existence:
-            raise QADatasetNotInProjectError(project_id, dataset_id)
+            raise QADatasetNotInOrgError(organization_id, dataset_id)
 
         column_existence = check_column_exist(session, dataset_id, column_id)
         if not column_existence:
@@ -92,24 +92,25 @@ def rename_qa_column_service(
         )
 
         LOGGER.info(
-            f"Renamed QA column {column_id} to '{column_name}' for dataset {dataset_id} in project {project_id}"
+            f"Renamed QA column {column_id} to '{column_name}' for dataset "
+            f"{dataset_id} in organization {organization_id}"
         )
 
         return QAColumnResponse.model_validate(qa_metadata)
-    except (QADatasetNotInProjectError, QAColumnNotFoundError):
+    except (QADatasetNotInOrgError, QAColumnNotFoundError):
         raise
 
 
 def delete_qa_column_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     dataset_id: UUID,
     column_id: UUID,
 ) -> dict:
     try:
-        dataset_existence = check_dataset_belongs_to_project(session, project_id, dataset_id)
+        dataset_existence = check_dataset_belongs_to_organization(session, organization_id, dataset_id)
         if not dataset_existence:
-            raise QADatasetNotInProjectError(project_id, dataset_id)
+            raise QADatasetNotInOrgError(organization_id, dataset_id)
 
         column_existence = check_column_exist(session, dataset_id, column_id)
         if not column_existence:
@@ -118,8 +119,8 @@ def delete_qa_column_service(
         remove_column_value_from_custom_column(session, dataset_id, column_id)
         delete_custom_column(session, dataset_id, column_id)
 
-        LOGGER.info(f"Deleted QA column {column_id} from dataset {dataset_id} in project {project_id}")
+        LOGGER.info(f"Deleted QA column {column_id} from dataset {dataset_id} in organization {organization_id}")
 
         return {"message": f"Deleted column {column_id} successfully"}
-    except (QADatasetNotInProjectError, QAColumnNotFoundError):
+    except (QADatasetNotInOrgError, QAColumnNotFoundError):
         raise

--- a/ada_backend/services/qa/quality_assurance_service.py
+++ b/ada_backend/services/qa/quality_assurance_service.py
@@ -21,13 +21,13 @@ from ada_backend.repositories.qa_session_repository import (
     update_qa_session_status,
 )
 from ada_backend.repositories.quality_assurance_repository import (
-    check_dataset_belongs_to_project,
+    check_dataset_belongs_to_organization,
     clear_version_outputs_for_input_ids,
-    create_datasets,
+    create_datasets_for_organization,
     create_inputs_groundtruths,
-    delete_datasets,
+    delete_datasets_from_organization,
     delete_inputs_groundtruths,
-    get_datasets_by_project,
+    get_datasets_by_organization,
     get_inputs_groundtruths_by_dataset,
     get_inputs_groundtruths_by_ids,
     get_inputs_groundtruths_count_by_dataset,
@@ -35,7 +35,7 @@ from ada_backend.repositories.quality_assurance_repository import (
     get_positions_of_dataset,
     get_qa_columns_by_dataset,
     get_version_output_ids_by_input_ids_and_graph_runner,
-    update_dataset,
+    update_dataset_in_organization,
     update_inputs_groundtruths,
     upsert_version_output,
 )
@@ -70,7 +70,7 @@ from ada_backend.services.qa.qa_error import (
     CSVInvalidPositionError,
     CSVMissingDatasetColumnError,
     CSVNonUniquePositionError,
-    QADatasetNotInProjectError,
+    QADatasetNotInOrgError,
     QADuplicatePositionError,
     QAPartialPositionError,
 )
@@ -579,130 +579,110 @@ def delete_inputs_groundtruths_service(
         raise ValueError(f"Failed to delete input-groundtruth entries: {str(e)}") from e
 
 
-def get_datasets_by_project_service(
+def get_datasets_by_organization_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
 ) -> List[DatasetResponse]:
-    """
-    Get all datasets for a project.
-
-    Args:
-        session (Session): SQLAlchemy session
-        project_id (UUID): ID of the project
-
-    Returns:
-        List[DatasetResponse]: List of datasets
-    """
     try:
-        datasets = get_datasets_by_project(session, project_id)
+        datasets = get_datasets_by_organization(session, organization_id)
         return [DatasetResponse.model_validate(dataset) for dataset in datasets]
     except Exception as e:
-        LOGGER.error(f"Error in get_datasets_by_project_service: {str(e)}")
+        LOGGER.error(f"Error in get_datasets_by_organization_service: {str(e)}")
         raise ValueError(f"Failed to get datasets: {str(e)}") from e
 
 
-def create_datasets_service(
+def create_datasets_for_organization_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     datasets_data: DatasetCreateList,
 ) -> DatasetListResponse:
-    """
-    Create datasets.
-
-    Args:
-        session (Session): SQLAlchemy session
-        project_id (UUID): ID of the project
-        datasets_data (DatasetCreateList): Dataset data to create
-
-    Returns:
-        DatasetListResponse: The created datasets
-    """
     try:
-        created_datasets = create_datasets(
+        created_datasets = create_datasets_for_organization(
             session,
-            project_id,
+            organization_id,
             datasets_data.datasets_name,
         )
 
-        LOGGER.info(f"Created {len(created_datasets)} datasets for project {project_id}")
+        LOGGER.info(f"Created {len(created_datasets)} datasets for organization {organization_id}")
         return DatasetListResponse(datasets=[DatasetResponse.model_validate(dataset) for dataset in created_datasets])
     except Exception as e:
-        LOGGER.error(f"Error in create_datasets_service: {str(e)}")
+        LOGGER.error(f"Error in create_datasets_for_organization_service: {str(e)}")
         raise ValueError(f"Failed to create datasets: {str(e)}") from e
 
 
-def update_dataset_service(
+def update_dataset_in_organization_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     dataset_id: UUID,
     dataset_name: str,
 ) -> DatasetResponse:
     """
-    Update a single dataset.
+    Update a single dataset in an organization.
 
     Args:
         session (Session): SQLAlchemy session
-        project_id (UUID): ID of the project
+        organization_id (UUID): ID of the organization
         dataset_id (UUID): ID of the dataset to update
         dataset_name (str): New name for the dataset
 
     Returns:
         DatasetResponse: The updated dataset
     """
-    if not check_dataset_belongs_to_project(session, project_id, dataset_id):
-        LOGGER.error(f"Failed to update dataset {dataset_id}: Dataset {dataset_id} not found in project {project_id}")
-        raise QADatasetNotInProjectError(project_id, dataset_id)
+    if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
+        LOGGER.error(
+            f"Failed to update dataset {dataset_id}: Dataset {dataset_id} not found in organization {organization_id}"
+        )
+        raise QADatasetNotInOrgError(organization_id, dataset_id)
 
     try:
-        updated_dataset = update_dataset(
+        updated_dataset = update_dataset_in_organization(
             session,
             dataset_id,
             dataset_name,
-            project_id,
+            organization_id,
         )
 
-        LOGGER.info(f"Updated dataset {dataset_id} with name '{dataset_name}' for project {project_id}")
+        LOGGER.info(f"Updated dataset {dataset_id} with name '{dataset_name}' for organization {organization_id}")
         return DatasetResponse.model_validate(updated_dataset)
     except Exception as e:
-        LOGGER.error(f"Error in update_dataset_service: {str(e)}")
+        LOGGER.error(f"Error in update_dataset_in_organization_service: {str(e)}")
         raise ValueError(f"Failed to update dataset: {str(e)}") from e
 
 
-def delete_datasets_service(
+def delete_datasets_from_organization_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     delete_data: DatasetDeleteList,
 ) -> int:
     """
-    Delete multiple datasets.
+    Delete multiple datasets from an organization.
 
     Args:
         session (Session): SQLAlchemy session
-        project_id (UUID): ID of the project
+        organization_id (UUID): ID of the organization
         delete_data (DatasetDeleteList): IDs of datasets to delete
 
     Returns:
         int: Number of deleted datasets
     """
     for dataset_id in delete_data.dataset_ids:
-        if not check_dataset_belongs_to_project(session, project_id, dataset_id):
+        if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
             LOGGER.error(
-                f"Failed to delete datasets for project {project_id}: "
-                f"Dataset {dataset_id} not found in project {project_id}"
+                f"Failed to delete datasets: Dataset {dataset_id} not found in organization {organization_id}"
             )
-            raise QADatasetNotInProjectError(project_id, dataset_id)
+            raise QADatasetNotInOrgError(organization_id, dataset_id)
 
     try:
-        deleted_count = delete_datasets(
+        deleted_count = delete_datasets_from_organization(
             session,
             delete_data.dataset_ids,
-            project_id,
+            organization_id,
         )
 
-        LOGGER.info(f"Deleted {deleted_count} datasets for project {project_id}")
+        LOGGER.info(f"Deleted {deleted_count} datasets for organization {organization_id}")
         return deleted_count
     except Exception as e:
-        LOGGER.error(f"Error in delete_datasets_service: {str(e)}")
+        LOGGER.error(f"Error in delete_datasets_from_organization_service: {str(e)}")
         raise ValueError(f"Failed to delete datasets: {str(e)}") from e
 
 
@@ -788,7 +768,7 @@ def export_qa_data_to_csv_service(
 
 def import_qa_data_from_csv_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     dataset_id: UUID,
     csv_file: BinaryIO,
 ) -> InputGroundtruthResponseList:
@@ -813,7 +793,7 @@ def import_qa_data_from_csv_service(
         for column_name in custom_columns_to_add:
             create_qa_column_service(
                 session=session,
-                project_id=project_id,
+                organization_id=organization_id,
                 dataset_id=dataset_id,
                 column_name=column_name,
             )

--- a/tests/ada_backend/test_qa_evaluation_services.py
+++ b/tests/ada_backend/test_qa_evaluation_services.py
@@ -6,7 +6,7 @@ import pytest
 from ada_backend.database.models import EvaluationType, VersionOutput
 from ada_backend.database.setup_db import get_db_session
 from ada_backend.repositories.quality_assurance_repository import (
-    create_datasets,
+    create_datasets_for_organization,
     create_inputs_groundtruths,
 )
 from ada_backend.schemas.input_groundtruth_schema import InputGroundtruthCreate
@@ -15,17 +15,17 @@ from ada_backend.schemas.qa_evaluation_schema import BooleanEvaluationResult, Er
 from ada_backend.services.errors import LLMJudgeNotFound
 from ada_backend.services.project_service import delete_project_service
 from ada_backend.services.qa.llm_judges_service import (
-    create_llm_judge_service,
-    delete_llm_judges_service,
-    get_llm_judges_by_project_service,
-    update_llm_judge_service,
+    create_llm_judge_for_organization_service,
+    delete_llm_judges_from_organization_service,
+    get_llm_judges_by_organization_service,
+    update_llm_judge_in_organization_service,
 )
 from ada_backend.services.qa.qa_evaluation_service import (
     delete_judge_evaluations_service,
     get_evaluations_by_version_output_service,
     run_judge_evaluation_service,
 )
-from tests.ada_backend.test_utils import create_project_and_graph_runner
+from tests.ada_backend.test_utils import ORGANIZATION_ID, create_project_and_graph_runner
 
 MOCK_LLM_SERVICE_PATH = (
     "ada_backend.services.qa.qa_evaluation_service.CompletionService.constrained_complete_with_pydantic_async"
@@ -33,9 +33,9 @@ MOCK_LLM_SERVICE_PATH = (
 
 
 def _create_evaluation_scenario(session, project_id: UUID, graph_runner_id: UUID) -> dict:
-    datasets = create_datasets(
+    datasets = create_datasets_for_organization(
         session=session,
-        project_id=project_id,
+        organization_id=ORGANIZATION_ID,
         dataset_names=["test_dataset"],
     )
 
@@ -57,9 +57,9 @@ def _create_evaluation_scenario(session, project_id: UUID, graph_runner_id: UUID
     )
     session.add(version_output)
 
-    judge = create_llm_judge_service(
+    judge = create_llm_judge_for_organization_service(
         session=session,
-        project_id=project_id,
+        organization_id=ORGANIZATION_ID,
         judge_data=LLMJudgeCreate(
             name="Test Judge",
             evaluation_type=EvaluationType.BOOLEAN,
@@ -81,8 +81,8 @@ def test_llm_judge_management():
             session, project_name_prefix="llm_judge_management_test", description="Test project"
         )
 
-        judges = get_llm_judges_by_project_service(session=session, project_id=project_id)
-        assert judges == []
+        initial_judges = get_llm_judges_by_organization_service(session=session, organization_id=ORGANIZATION_ID)
+        initial_count = len(initial_judges)
 
         create_data = LLMJudgeCreate(
             name="Test Judge",
@@ -90,24 +90,24 @@ def test_llm_judge_management():
             evaluation_type=EvaluationType.BOOLEAN,
             prompt_template="Test: {{input}}",
         )
-        judge = create_llm_judge_service(
+        judge = create_llm_judge_for_organization_service(
             session=session,
-            project_id=project_id,
+            organization_id=ORGANIZATION_ID,
             judge_data=create_data,
         )
         assert judge.name == "Test Judge"
         judge_id = judge.id
 
-        judges = get_llm_judges_by_project_service(session=session, project_id=project_id)
-        assert len(judges) == 1
-        assert judges[0].id == judge_id
-        assert judges[0].name == "Test Judge"
-        assert judges[0].project_id == project_id
+        judges = get_llm_judges_by_organization_service(session=session, organization_id=ORGANIZATION_ID)
+        assert len(judges) == initial_count + 1
+        our_judge = next(j for j in judges if j.id == judge_id)
+        assert our_judge.name == "Test Judge"
+        assert our_judge.organization_id == ORGANIZATION_ID
 
         update_data = LLMJudgeUpdate(name="Updated Judge Name", description="Updated description", temperature=0.9)
-        updated_judge = update_llm_judge_service(
+        updated_judge = update_llm_judge_in_organization_service(
             session=session,
-            project_id=project_id,
+            organization_id=ORGANIZATION_ID,
             judge_id=judge_id,
             judge_data=update_data,
         )
@@ -116,17 +116,17 @@ def test_llm_judge_management():
         assert updated_judge.temperature == 0.9
         assert updated_judge.id == judge_id
 
-        delete_llm_judges_service(
+        delete_llm_judges_from_organization_service(
             session=session,
-            project_id=project_id,
+            organization_id=ORGANIZATION_ID,
             judge_ids=[judge_id],
         )
 
         update_data = LLMJudgeUpdate(name="Update on unexisting judge")
         with pytest.raises(LLMJudgeNotFound):
-            update_llm_judge_service(
+            update_llm_judge_in_organization_service(
                 session=session,
-                project_id=project_id,
+                organization_id=ORGANIZATION_ID,
                 judge_id=judge_id,
                 judge_data=update_data,
             )

--- a/tests/ada_backend/test_quality_assurance_service.py
+++ b/tests/ada_backend/test_quality_assurance_service.py
@@ -29,7 +29,7 @@ from ada_backend.services.qa.qa_error import (
     CSVMissingDatasetColumnError,
     CSVNonUniquePositionError,
     QAColumnNotFoundError,
-    QADatasetNotInProjectError,
+    QADatasetNotInOrgError,
     QADuplicatePositionError,
     QAPartialPositionError,
 )
@@ -40,20 +40,20 @@ from ada_backend.services.qa.qa_metadata_service import (
     rename_qa_column_service,
 )
 from ada_backend.services.qa.quality_assurance_service import (
-    create_datasets_service,
+    create_datasets_for_organization_service,
     create_inputs_groundtruths_service,
-    delete_datasets_service,
+    delete_datasets_from_organization_service,
     delete_inputs_groundtruths_service,
     export_qa_data_to_csv_service,
-    get_datasets_by_project_service,
+    get_datasets_by_organization_service,
     get_inputs_groundtruths_with_version_outputs_service,
     import_qa_data_from_csv_service,
     run_qa_service,
-    update_dataset_service,
+    update_dataset_in_organization_service,
     update_inputs_groundtruths_service,
 )
 from engine.trace.trace_context import set_trace_manager
-from tests.ada_backend.test_utils import create_project_and_graph_runner
+from tests.ada_backend.test_utils import ORGANIZATION_ID, create_project_and_graph_runner
 
 # JSON constants for test workflow configuration
 DEFAULT_PAYLOAD_SCHEMA = {"messages": [{"role": "user", "content": "Hello"}], "additional_info": "info"}
@@ -115,8 +115,8 @@ def test_pagination():
             session, project_name_prefix="pagination_test", description="Test project for pagination"
         )
 
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"pagination_dataset_{project_id}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"pagination_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -160,6 +160,10 @@ def test_pagination():
         page2_ids = {entry.id for entry in page2_entries}
         assert page1_ids.isdisjoint(page2_ids)
 
+        delete_datasets_from_organization_service(
+            session, ORGANIZATION_ID, DatasetDeleteList(dataset_ids=[dataset_id])
+        )
+
         delete_project_service(session=session, project_id=project_id)
 
 
@@ -170,49 +174,58 @@ def test_dataset_management():
             session, project_name_prefix="dataset_test", description="Test project for dataset management"
         )
 
+        initial_datasets = get_datasets_by_organization_service(session, ORGANIZATION_ID)
+        initial_count = len(initial_datasets)
+
         # Test dataset creation
         create_payload = DatasetCreateList(datasets_name=["dataset1", "dataset2", "dataset3"])
-        created_response = create_datasets_service(session, project_id, create_payload)
+        created_response = create_datasets_for_organization_service(session, ORGANIZATION_ID, create_payload)
         created_datasets = created_response.datasets
         assert len(created_datasets) == 3
 
-        # Test dataset retrieval
-        retrieved_datasets = get_datasets_by_project_service(session, project_id)
-        assert len(retrieved_datasets) == 3
+        # Test dataset retrieval - should have 3 more than before
+        retrieved_datasets = get_datasets_by_organization_service(session, ORGANIZATION_ID)
+        assert len(retrieved_datasets) == initial_count + 3
 
         # Test dataset update
         dataset_to_update = created_datasets[0].id
-        updated_dataset = update_dataset_service(session, project_id, dataset_to_update, "updated_dataset1")
+        updated_dataset = update_dataset_in_organization_service(
+            session, ORGANIZATION_ID, dataset_to_update, "updated_dataset1"
+        )
         assert updated_dataset.dataset_name == "updated_dataset1"
 
         # Test dataset deletion
         dataset_to_delete = created_datasets[1].id
         delete_payload = DatasetDeleteList(dataset_ids=[dataset_to_delete])
-        deleted_count = delete_datasets_service(session, project_id, delete_payload)
+        deleted_count = delete_datasets_from_organization_service(session, ORGANIZATION_ID, delete_payload)
         assert deleted_count == 1  # Should have deleted 1 dataset
 
-        # Verify the dataset was deleted
-        remaining_datasets = get_datasets_by_project_service(session, project_id)
-        assert len(remaining_datasets) == 2  # Should now have 2 datasets instead of 3
+        # Verify the dataset was deleted - should have 2 more than initial
+        remaining_datasets = get_datasets_by_organization_service(session, ORGANIZATION_ID)
+        assert len(remaining_datasets) == initial_count + 2
 
         # Test that deleting a dataset cascades to QA metadata (custom columns)
+        # Do this before cleanup so the dataset still exists
         dataset_with_columns = created_datasets[0].id
-        # Create custom columns for this dataset
-        create_qa_column_service(session, project_id, dataset_with_columns, "Priority")
-        create_qa_column_service(session, project_id, dataset_with_columns, "Category")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_with_columns, "Priority")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_with_columns, "Category")
 
         # Verify columns exist
         columns_before = get_qa_columns_by_dataset(session, dataset_with_columns)
         assert len(columns_before) == 2
 
-        # Delete the dataset
+        # Delete the dataset and verify QA metadata is cascaded (deleted)
         delete_payload2 = DatasetDeleteList(dataset_ids=[dataset_with_columns])
-        deleted_count2 = delete_datasets_service(session, project_id, delete_payload2)
+        deleted_count2 = delete_datasets_from_organization_service(session, ORGANIZATION_ID, delete_payload2)
         assert deleted_count2 == 1
 
-        # Verify QA metadata was cascaded (deleted)
         columns_after = get_qa_columns_by_dataset(session, dataset_with_columns)
         assert len(columns_after) == 0  # All columns should be deleted with the dataset
+
+        # Clean up the remaining dataset created by this test (created_datasets[2]; 0 and 1 already deleted)
+        cleanup_ids = [d.id for d in created_datasets if d.id not in (dataset_to_delete, dataset_with_columns)]
+        cleanup_payload = DatasetDeleteList(dataset_ids=cleanup_ids)
+        delete_datasets_from_organization_service(session, ORGANIZATION_ID, cleanup_payload)
 
         delete_project_service(session=session, project_id=project_id)
 
@@ -228,8 +241,8 @@ def test_input_groundtruth_basic_operations():
 
         # Create a dataset
         dataset_uuid = str(uuid4())
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"input_groundtruth_dataset_{dataset_uuid}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"input_groundtruth_dataset_{dataset_uuid}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -281,6 +294,10 @@ def test_input_groundtruth_basic_operations():
         remaining_data = get_inputs_groundtruths_with_version_outputs_service(session, dataset_id)
         remaining_inputs = remaining_data.inputs_groundtruths
         assert len(remaining_inputs) == 2  # Should now have 2 inputs instead of 3
+
+        delete_datasets_from_organization_service(
+            session, ORGANIZATION_ID, DatasetDeleteList(dataset_ids=[dataset_id])
+        )
 
         delete_project_service(session=session, project_id=project_id)
 
@@ -426,8 +443,8 @@ async def test_run_qa_service():
 
         # Create a dataset
         dataset_uuid = str(uuid4())
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"qa_run_dataset_{dataset_uuid}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"qa_run_dataset_{dataset_uuid}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -514,6 +531,10 @@ async def test_run_qa_service():
         assert summary_all.failed == 0
         assert summary_all.success_rate == 100.0
 
+        delete_datasets_from_organization_service(
+            session, ORGANIZATION_ID, DatasetDeleteList(dataset_ids=[dataset_id])
+        )
+
         delete_project_service(session=session, project_id=project_id)
 
 
@@ -524,8 +545,8 @@ def test_position_field_in_responses():
             session, project_name_prefix="index_test", description="Test project for index field"
         )
 
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"index_dataset_{project_id}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"index_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -569,6 +590,10 @@ def test_position_field_in_responses():
         final_positions = [entry.position for entry in final_entries]
         assert sorted(final_positions) == [1, 2, 4, 5, 6]
 
+        delete_datasets_from_organization_service(
+            session, ORGANIZATION_ID, DatasetDeleteList(dataset_ids=[dataset_id])
+        )
+
         delete_project_service(session=session, project_id=project_id)
 
 
@@ -579,8 +604,8 @@ def test_duplicate_positions_validation():
             session, project_name_prefix="duplicate_test", description="Test project for duplicate positions"
         )
 
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"duplicate_dataset_{project_id}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"duplicate_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -595,6 +620,10 @@ def test_duplicate_positions_validation():
             create_inputs_groundtruths_service(session, dataset_id, create_payload)
         assert "Duplicate positions" in str(exc_info.value)
 
+        delete_datasets_from_organization_service(
+            session, ORGANIZATION_ID, DatasetDeleteList(dataset_ids=[dataset_id])
+        )
+
         delete_project_service(session=session, project_id=project_id)
 
 
@@ -605,8 +634,8 @@ def test_partial_position_validation():
             session, project_name_prefix="partial_test", description="Test project for partial positions"
         )
 
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"partial_dataset_{project_id}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"partial_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -621,6 +650,10 @@ def test_partial_position_validation():
             create_inputs_groundtruths_service(session, dataset_id, create_payload)
         assert "Partial positioning" in str(exc_info.value)
 
+        delete_datasets_from_organization_service(
+            session, ORGANIZATION_ID, DatasetDeleteList(dataset_ids=[dataset_id])
+        )
+
         delete_project_service(session=session, project_id=project_id)
 
 
@@ -631,8 +664,8 @@ def test_position_auto_generation():
             session, project_name_prefix="auto_index_test", description="Test project for auto-generated positions"
         )
 
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"auto_index_dataset_{project_id}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"auto_index_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -648,6 +681,10 @@ def test_position_auto_generation():
         assert created[0].position == 1
         assert created[1].position == 2
 
+        delete_datasets_from_organization_service(
+            session, ORGANIZATION_ID, DatasetDeleteList(dataset_ids=[dataset_id])
+        )
+
         delete_project_service(session=session, project_id=project_id)
 
 
@@ -658,8 +695,8 @@ def test_csv_import_duplicate_positions_inside_csv():
             session, project_name_prefix="csv_duplicate_test", description="Test project for CSV duplicate positions"
         )
 
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_duplicate_dataset_{project_id}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_duplicate_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -675,10 +712,14 @@ def test_csv_import_duplicate_positions_inside_csv():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         with pytest.raises(CSVNonUniquePositionError) as exc_info:
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         error_detail = str(exc_info.value)
         assert "Duplicate positions found in CSV import: [1]" in error_detail
         assert "CSV import" in error_detail
+
+        delete_datasets_from_organization_service(
+            session, ORGANIZATION_ID, DatasetDeleteList(dataset_ids=[dataset_id])
+        )
 
         delete_project_service(session=session, project_id=project_id)
 
@@ -692,8 +733,8 @@ def test_csv_import_invalid_positions_values():
             description="Test project for CSV invalid position values",
         )
 
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_invalid_index_dataset_{project_id}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_invalid_index_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -707,10 +748,14 @@ def test_csv_import_invalid_positions_values():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         with pytest.raises(CSVInvalidPositionError) as exc_info:
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         error_detail = str(exc_info.value)
         assert "Invalid integer in 'position' column" in error_detail
         assert "row" in error_detail
+
+        delete_datasets_from_organization_service(
+            session, ORGANIZATION_ID, DatasetDeleteList(dataset_ids=[dataset_id])
+        )
 
         delete_project_service(session=session, project_id=project_id)
 
@@ -722,8 +767,8 @@ def test_csv_import_position_less_than_one():
             session, project_name_prefix="csv_position_lt_one_test", description="Test project for CSV position < 1"
         )
 
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_position_lt_one_dataset_{project_id}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_position_lt_one_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -736,10 +781,14 @@ def test_csv_import_position_less_than_one():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         with pytest.raises(CSVInvalidPositionError) as exc_info:
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         error_detail = str(exc_info.value)
         assert "Invalid integer in 'position' column" in error_detail
         assert "greater than or equal to 1" in error_detail
+
+        delete_datasets_from_organization_service(
+            session, ORGANIZATION_ID, DatasetDeleteList(dataset_ids=[dataset_id])
+        )
 
         delete_project_service(session=session, project_id=project_id)
 
@@ -753,7 +802,7 @@ def test_csv_import_creates_new_custom_columns_and_values():
             description="Test project for CSV import with custom columns",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"csv_custom_cols_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
@@ -774,7 +823,7 @@ def test_csv_import_creates_new_custom_columns_and_values():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         # Import CSV
-        import_response = import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+        import_response = import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         imported_entries = import_response.inputs_groundtruths
         assert len(imported_entries) == 2
 
@@ -816,14 +865,14 @@ def test_csv_import_requires_all_existing_custom_columns_in_header():
             description="Test project for CSV import missing required columns",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"csv_missing_cols_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create two existing custom columns
-        create_qa_column_service(session, project_id, dataset_id, "col_a")
-        create_qa_column_service(session, project_id, dataset_id, "col_b")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "col_a")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "col_b")
 
         # Verify columns exist
         existing_columns = get_qa_columns_by_dataset(session, dataset_id)
@@ -842,7 +891,7 @@ def test_csv_import_requires_all_existing_custom_columns_in_header():
 
         # Should raise CSVMissingDatasetColumnError
         with pytest.raises(CSVMissingDatasetColumnError) as exc_info:
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         error_detail = str(exc_info.value)
         assert "col_b" in error_detail or "col_b" in error_detail.lower()
 
@@ -858,13 +907,13 @@ def test_csv_import_adds_new_columns_while_preserving_existing():
             description="Test project for CSV import with mixed existing/new columns",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"csv_mixed_cols_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create one existing custom column
-        existing_col_response = create_qa_column_service(session, project_id, dataset_id, "existing_col")
+        existing_col_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "existing_col")
         existing_column_id = existing_col_response.column_id
 
         # CSV with both existing and new column
@@ -877,7 +926,7 @@ def test_csv_import_adds_new_columns_while_preserving_existing():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         # Import CSV
-        import_response = import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+        import_response = import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         assert len(import_response.inputs_groundtruths) == 1
 
         # Verify both columns exist
@@ -913,7 +962,7 @@ def test_csv_import_handles_missing_cell_values_for_custom_columns():
             description="Test project for CSV import with empty custom column cells",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"csv_empty_cells_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
@@ -930,7 +979,7 @@ def test_csv_import_handles_missing_cell_values_for_custom_columns():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         # Import CSV
-        import_response = import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+        import_response = import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         assert len(import_response.inputs_groundtruths) == 2
 
         # Verify column was created
@@ -963,7 +1012,7 @@ def test_csv_import_uses_get_headers_from_csv_and_processes_all_rows():
             description="Test project for CSV import processing all rows",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"csv_all_rows_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
@@ -982,7 +1031,7 @@ def test_csv_import_uses_get_headers_from_csv_and_processes_all_rows():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         # Import CSV
-        import_response = import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+        import_response = import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         imported_entries = import_response.inputs_groundtruths
         assert len(imported_entries) == 3
 
@@ -1018,7 +1067,7 @@ def test_get_qa_columns_by_dataset_service():
             description="Test project for getting custom columns",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"get_columns_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
@@ -1028,8 +1077,8 @@ def test_get_qa_columns_by_dataset_service():
         assert len(columns_response) == 0
 
         # Create two columns
-        create_qa_column_service(session, project_id, dataset_id, "Priority")
-        create_qa_column_service(session, project_id, dataset_id, "Category")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Category")
 
         # Get columns again
         columns_response = get_qa_columns_by_dataset_service(session, project_id, dataset_id)
@@ -1047,7 +1096,7 @@ def test_get_qa_columns_by_dataset_service():
             description="Test project 2",
         )
 
-        with pytest.raises(QADatasetNotInProjectError) as exc_info:
+        with pytest.raises(QADatasetNotInOrgError) as exc_info:
             get_qa_columns_by_dataset_service(session, project_id2, dataset_id)
         assert str(project_id2) in str(exc_info.value)
         assert str(dataset_id) in str(exc_info.value)
@@ -1065,26 +1114,26 @@ def test_create_qa_column_service():
             description="Test project for creating custom columns",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"create_column_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create first column
-        col_response = create_qa_column_service(session, project_id, dataset_id, "Priority")
+        col_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
         assert col_response.column_name == "Priority"
         assert col_response.column_display_position == 0
         assert col_response.column_id is not None
         assert col_response.dataset_id == dataset_id
 
         # Create second column
-        col2_response = create_qa_column_service(session, project_id, dataset_id, "Category")
+        col2_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Category")
         assert col2_response.column_name == "Category"
         assert col2_response.column_display_position == 1
         assert col2_response.column_id != col_response.column_id
 
         # Create third column to verify sequential column positions
-        col3_response = create_qa_column_service(session, project_id, dataset_id, "Third")
+        col3_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Third")
         assert col3_response.column_display_position == 2
 
         # Verify all columns exist and positions are sequential
@@ -1093,20 +1142,15 @@ def test_create_qa_column_service():
         positions = [col.column_display_position for col in columns]
         assert positions == [0, 1, 2]
 
-        # Test error case: dataset not in project
-        project_id2, _ = create_project_and_graph_runner(
-            session,
-            project_name_prefix="create_col_project2",
-            description="Test project 2",
-        )
+        # Test error case: dataset not in organization
+        wrong_org_id = uuid4()
 
-        with pytest.raises(QADatasetNotInProjectError) as exc_info:
-            create_qa_column_service(session, project_id2, dataset_id, "Priority")
-        assert str(project_id2) in str(exc_info.value)
+        with pytest.raises(QADatasetNotInOrgError) as exc_info:
+            create_qa_column_service(session, wrong_org_id, dataset_id, "Priority")
+        assert str(wrong_org_id) in str(exc_info.value)
         assert str(dataset_id) in str(exc_info.value)
 
         delete_project_service(session=session, project_id=project_id)
-        delete_project_service(session=session, project_id=project_id2)
 
 
 def test_rename_qa_column_service():
@@ -1118,13 +1162,13 @@ def test_rename_qa_column_service():
             description="Test project for renaming custom columns",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"rename_column_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create a column
-        original_col = create_qa_column_service(session, project_id, dataset_id, "OldName")
+        original_col = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "OldName")
         original_column_id = original_col.column_id
         original_column_display_position = original_col.column_display_position
 
@@ -1156,7 +1200,7 @@ def test_rename_qa_column_service():
             description="Test project 2",
         )
 
-        with pytest.raises(QADatasetNotInProjectError) as exc_info:
+        with pytest.raises(QADatasetNotInOrgError) as exc_info:
             rename_qa_column_service(session, project_id2, dataset_id, original_column_id, "NewName")
         assert str(project_id2) in str(exc_info.value)
 
@@ -1173,14 +1217,14 @@ def test_delete_qa_column_service():
             description="Test project for deleting custom columns",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"delete_column_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create two columns
-        col1 = create_qa_column_service(session, project_id, dataset_id, "Priority")
-        col2 = create_qa_column_service(session, project_id, dataset_id, "Category")
+        col1 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
+        col2 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Category")
 
         # Verify both exist
         columns = get_qa_columns_by_dataset(session, dataset_id)
@@ -1253,9 +1297,9 @@ def test_delete_qa_column_service():
         )
 
         # Recreate a column for this test
-        col3 = create_qa_column_service(session, project_id, dataset_id, "TestCol")
+        col3 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "TestCol")
 
-        with pytest.raises(QADatasetNotInProjectError) as exc_info:
+        with pytest.raises(QADatasetNotInOrgError) as exc_info:
             delete_qa_column_service(session, project_id2, dataset_id, col3.column_id)
         assert str(project_id2) in str(exc_info.value)
 
@@ -1272,14 +1316,14 @@ def test_export_qa_data_to_csv_service_with_custom_columns():
             description="Test project for CSV export",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"export_csv_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create custom columns
-        col1 = create_qa_column_service(session, project_id, dataset_id, "Priority")
-        col2 = create_qa_column_service(session, project_id, dataset_id, "Score")
+        col1 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
+        col2 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Score")
         column_id1_str = str(col1.column_id)
         column_id2_str = str(col2.column_id)
 
@@ -1333,13 +1377,13 @@ def test_update_inputs_groundtruths_service_with_custom_columns():
             description="Test project for updating custom columns",
         )
 
-        dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"update_custom_cols_dataset_{project_id}"])
+        dataset_data = create_datasets_for_organization_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"update_custom_cols_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create custom column
-        col = create_qa_column_service(session, project_id, dataset_id, "Priority")
+        col = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
         column_id_str = str(col.column_id)
 
         # Create entry with custom column
@@ -1393,7 +1437,7 @@ def test_csv_import_export_without_custom_columns():
             description="Test project for CSV import/export without custom columns",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"csv_basic_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
@@ -1409,7 +1453,7 @@ def test_csv_import_export_without_custom_columns():
         csv_content = csv_buffer.getvalue()
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
-        import_response = import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+        import_response = import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         assert len(import_response.inputs_groundtruths) == 2
 
         # Verify entries were created correctly
@@ -1442,7 +1486,7 @@ def test_csv_import_invalid_json_error():
             description="Test project for CSV invalid JSON",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"csv_invalid_json_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
@@ -1456,7 +1500,7 @@ def test_csv_import_invalid_json_error():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         with pytest.raises(CSVInvalidJSONError) as exc_info:
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         assert "Invalid JSON" in str(exc_info.value)
         assert "row" in str(exc_info.value)
 
@@ -1472,7 +1516,7 @@ def test_csv_import_empty_file_error():
             description="Test project for CSV empty file",
         )
 
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"csv_empty_file_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
@@ -1485,7 +1529,7 @@ def test_csv_import_empty_file_error():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         with pytest.raises(CSVEmptyFileError):
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
 
         delete_project_service(session=session, project_id=project_id)
 
@@ -1500,7 +1544,7 @@ def test_csv_export_error_cases():
         )
 
         # Test empty dataset
-        dataset_data = create_datasets_service(
+        dataset_data = create_datasets_for_organization_service(
             session, project_id, DatasetCreateList(datasets_name=[f"csv_export_empty_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id


### PR DESCRIPTION
# Move evaluation to organization-level

## Overview

**QA Datasets and LLM Evaluators** have been moved from **project-level to organization-level** to enable sharing across all projects within an organization.
_For simplicity's sake and to avoid confusing the user, the project level QA tab does not change._ 

### What Changed:

- Datasets are now organization-scoped (shared across all projects in the org)
- LLM Judges (Evaluators) are now organization-scoped (shared across all projects in the org)
-  QA Test Runs remain project-scoped (they test specific project versions)

### Key Benefits:
- Reuse the same test datasets across multiple projects
- Share evaluators across all projects in your organization
- Centralized QA asset management

## How to test 
- Run `make db-upgrade`
- Pull the frontend (same branch name)
- You will see the new evaluation tab in the left-side menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added organization-scoped quality assurance management endpoints for datasets, LLM judges, and dataset entries.
  * Added admin views for dataset projects and input-groundtruth entries.

* **Deprecations**
  * Deprecated project-scoped quality assurance endpoints in favor of organization-level APIs; existing endpoints remain functional but will be removed in a future release.

* **Database**
  * Database schema updated to support organization-level quality assurance resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->