### PR TITLE
feat(DBIngetsion): Use sync_id instead of file_id DRA-1171

### DIFF
--- a/ada_backend/database/alembic/versions/a2b3c4d5e6f7_add_sync_id_to_org_chunks.py
+++ b/ada_backend/database/alembic/versions/a2b3c4d5e6f7_add_sync_id_to_org_chunks.py
@@ -1,0 +1,151 @@
+"""add_sync_id_to_org_chunks
+
+Revision ID: a2b3c4d5e6f7
+Revises: b6c7d8e9f0a1
+Create Date: 2026-04-02
+
+"""
+
+import logging
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import create_engine, text
+
+from settings import settings
+
+revision: str = "a2b3c4d5e6f7"
+down_revision: Union[str, None] = "b6c7d8e9f0a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy = "migrate-first"
+
+LOGGER = logging.getLogger("alembic.migration")
+LOGGER.setLevel(logging.DEBUG)
+
+if not LOGGER.handlers:
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(levelname)-5.5s [%(name)s] %(message)s")
+    console_handler.setFormatter(formatter)
+    LOGGER.addHandler(console_handler)
+    LOGGER.propagate = False
+
+
+def upgrade() -> None:
+    if not settings.INGESTION_DB_URL:
+        LOGGER.info("INGESTION_DB_URL is not set. Skipping sync_id migration.")
+        return
+
+    ingestion_engine = create_engine(settings.INGESTION_DB_URL, isolation_level="AUTOCOMMIT")
+    ingestion_conn = ingestion_engine.connect()
+
+    try:
+        tables = ingestion_conn.execute(
+            text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'public' AND table_name LIKE 'org_%_chunks'"
+            )
+        ).fetchall()
+
+        if not tables:
+            LOGGER.info("No org chunk tables found. Nothing to migrate.")
+            return
+
+        LOGGER.info(f"Found {len(tables)} org chunk tables to add sync_id column")
+
+        for (table_name,) in tables:
+            has_column = ingestion_conn.execute(
+                text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema = 'public' AND table_name = :table_name AND column_name = 'sync_id'"
+                ),
+                {"table_name": table_name},
+            ).fetchone()
+
+            if has_column:
+                LOGGER.info(f"Table {table_name} already has sync_id column, skipping ADD COLUMN")
+            else:
+                ingestion_conn.execute(text(f'ALTER TABLE public."{table_name}" ADD COLUMN sync_id VARCHAR'))
+                LOGGER.info(f"Added sync_id column to {table_name}")
+
+        backend_conn = op.get_bind()
+        db_sources = backend_conn.execute(
+            text(
+                "SELECT sa.source_id, sa.source_table_name, ds.database_table_name "
+                "FROM source_attributes sa "
+                "JOIN data_sources ds ON ds.id = sa.source_id "
+                "WHERE ds.type = 'database' AND sa.source_table_name IS NOT NULL "
+                "AND ds.database_table_name IS NOT NULL"
+            )
+        ).fetchall()
+
+        if not db_sources:
+            LOGGER.info("No database sources found for backfill.")
+            return
+
+        LOGGER.info(f"Backfilling sync_id for {len(db_sources)} database sources")
+
+        existing_tables = {t[0] for t in tables}
+
+        for source_id, source_table_name, database_table_name in db_sources:
+            if database_table_name not in existing_tables:
+                LOGGER.info(f"Table {database_table_name} not found in ingestion DB, skipping source {source_id}")
+                continue
+
+            prefix = f"{source_table_name}_"
+            prefix_len = len(prefix)
+            ingestion_conn.execute(
+                text(
+                    f'UPDATE public."{database_table_name}" '
+                    "SET sync_id = SUBSTRING(file_id FROM :prefix_len + 1) "
+                    "WHERE source_id = :source_id AND file_id LIKE :prefix_pattern AND sync_id IS NULL"
+                ),
+                {
+                    "prefix_len": prefix_len,
+                    "source_id": str(source_id),
+                    "prefix_pattern": f"{prefix}%",
+                },
+            )
+
+            LOGGER.info(f"Backfilled sync_id for source {source_id} (table: {database_table_name})")
+
+    except Exception as e:
+        LOGGER.error(f"Error during sync_id migration: {e}", exc_info=True)
+        raise
+    finally:
+        ingestion_conn.close()
+        ingestion_engine.dispose()
+
+
+def downgrade() -> None:
+    if not settings.INGESTION_DB_URL:
+        return
+
+    ingestion_engine = create_engine(settings.INGESTION_DB_URL, isolation_level="AUTOCOMMIT")
+    ingestion_conn = ingestion_engine.connect()
+
+    try:
+        tables = ingestion_conn.execute(
+            text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'public' AND table_name LIKE 'org_%_chunks'"
+            )
+        ).fetchall()
+
+        for (table_name,) in tables:
+            has_column = ingestion_conn.execute(
+                text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema = 'public' AND table_name = :table_name AND column_name = 'sync_id'"
+                ),
+                {"table_name": table_name},
+            ).fetchone()
+
+            if has_column:
+                ingestion_conn.execute(text(f'ALTER TABLE public."{table_name}" DROP COLUMN sync_id'))
+                LOGGER.info(f"Dropped sync_id column from {table_name}")
+    finally:
+        ingestion_conn.close()
+        ingestion_engine.dispose()

--- a/engine/qdrant_service.py
+++ b/engine/qdrant_service.py
@@ -1159,7 +1159,12 @@ class QdrantService:
             collection_name=collection_name,
             filter=query_filter_qdrant,
         )
+        LOGGER.info(
+            f"Qdrant sync diff: {len(incoming_ids_with_timestamp)} incoming, "
+            f"{collection_count} existing in Qdrant (filter={query_filter_qdrant})"
+        )
         if collection_count == 0:
+            LOGGER.info("Qdrant collection empty for filter — uploading all chunks")
             ids_to_upsert = set(incoming_ids_with_timestamp.keys())
         else:
             fields = [chunk_id_field] + ([timestamp_field] if timestamp_field else [])
@@ -1189,6 +1194,11 @@ class QdrantService:
                         existing_ids_with_timestamp[chunk_id],
                     )
                 }
+            LOGGER.info(
+                f"Qdrant sync diff result: {len(ids_to_add)} to add, "
+                f"{len(ids_to_update)} to update, {len(ids_to_delete)} to delete, "
+                f"{len(common_ids) - len(ids_to_update)} unchanged"
+            )
 
             ids_to_delete = ids_to_delete | ids_to_update
             ids_to_upsert = ids_to_add | ids_to_update

--- a/ingestion_script/ingest_db_source.py
+++ b/ingestion_script/ingest_db_source.py
@@ -23,6 +23,7 @@ from ingestion_script.utils import (
     METADATA_COLUMN_NAME,
     ORDER_COLUMN_NAME,
     SOURCE_ID_COLUMN_NAME,
+    SYNC_ID_COLUMN_NAME,
     UNIFIED_QDRANT_SCHEMA,
     UNIFIED_TABLE_DEFINITION,
     URL_COLUMN_NAME,
@@ -33,15 +34,6 @@ from ingestion_script.utils import (
 )
 
 LOGGER = logging.getLogger(__name__)
-
-
-def build_file_id(table_name: str, row_id) -> str:
-    return f"{table_name}_{row_id}"
-
-
-def extract_row_id_from_file_id(file_id: str, table_name: str) -> str:
-    prefix = f"{table_name}_"
-    return file_id[len(prefix) :]
 
 
 def _serialize_value(value):
@@ -109,17 +101,14 @@ def get_db_source_ids(
         schema_name=source_schema_name,
         sql_query_filter=sql_query_filter,
     )
-    # TODO: Have a sync_id column in the source table and use it to track the sync progress
     return {
-        build_file_id(table_name, row[id_column_name]): _serialize_value(row.get(timestamp_column_name))
-        if timestamp_column_name
-        else None
+        str(row[id_column_name]): _serialize_value(row.get(timestamp_column_name)) if timestamp_column_name else None
         for row in id_timestamp_data
     }
 
 
 def fetch_db_source_chunks(
-    file_ids: set[str],
+    sync_ids: set[str],
     sql_local_service: SQLLocalService,
     table_name: str,
     id_column_name: str,
@@ -132,11 +121,10 @@ def fetch_db_source_chunks(
     chunk_size: int = 1024,
     chunk_overlap: int = 0,
 ) -> list[dict]:
-    if not file_ids:
+    if not sync_ids:
         return []
 
-    raw_row_ids = [extract_row_id_from_file_id(file_id, table_name) for file_id in file_ids]
-    id_filter = f"{id_column_name} IN ({','.join(repr(str(raw_id)) for raw_id in raw_row_ids)})"
+    id_filter = f"{id_column_name} IN ({','.join(repr(str(sync_id)) for sync_id in sync_ids)})"
 
     source_rows = sql_local_service.get_table_rows(
         table_name=table_name,
@@ -149,9 +137,10 @@ def fetch_db_source_chunks(
 
     for source_row in source_rows:
         row_id = source_row[id_column_name]
+        sync_id = str(row_id)
         combined_text = " ".join(str(source_row.get(col) or "") for col in text_column_names)
         chunks = splitter.split_text(combined_text)
-        file_id = build_file_id(table_name, row_id)
+        file_id = f"{table_name}_{row_id}"
         timestamp_value = source_row.get(timestamp_column_name) if timestamp_column_name else None
 
         for chunk_index, chunk_text in enumerate(chunks, start=1):
@@ -177,6 +166,7 @@ def fetch_db_source_chunks(
                 CHUNK_ID_COLUMN_NAME: chunk_id,
                 CHUNK_COLUMN_NAME: chunk_text,
                 FILE_ID_COLUMN_NAME: file_id,
+                SYNC_ID_COLUMN_NAME: sync_id,
                 ORDER_COLUMN_NAME: chunk_index - 1,
                 DOCUMENT_TITLE_COLUMN_NAME: file_id,
                 TIMESTAMP_COLUMN_NAME: _serialize_value(timestamp_value),
@@ -278,7 +268,7 @@ async def upload_db_source(
             ),
             table_name=storage_table_name,
             table_definition=db_definition,
-            id_column_name=FILE_ID_COLUMN_NAME,
+            id_column_name=SYNC_ID_COLUMN_NAME,
             timestamp_column_name=TIMESTAMP_COLUMN_NAME,
             append_mode=update_existing,
             schema_name=storage_schema_name,

--- a/ingestion_script/utils.py
+++ b/ingestion_script/utils.py
@@ -45,6 +45,7 @@ DOCUMENT_TITLE_COLUMN_NAME = "document_title"
 ORDER_COLUMN_NAME = "order"
 URL_COLUMN_NAME = "url"
 SOURCE_ID_COLUMN_NAME = "source_id"
+SYNC_ID_COLUMN_NAME = "sync_id"
 METADATA_COLUMN_NAME = "metadata"  # JSONB column for source-specific metadata
 
 DEFAULT_EMBEDDING_MODEL = "openai:text-embedding-3-large"
@@ -60,6 +61,7 @@ UNIFIED_TABLE_COLUMNS = [
     CHUNK_COLUMN_NAME,
     TIMESTAMP_COLUMN_NAME,
     METADATA_COLUMN_NAME,
+    SYNC_ID_COLUMN_NAME,
 ]
 
 # Unified table definition for all source types
@@ -75,6 +77,7 @@ UNIFIED_TABLE_DEFINITION = DBDefinition(
         DBColumn(name=CHUNK_COLUMN_NAME, type="VARCHAR"),
         DBColumn(name=TIMESTAMP_COLUMN_NAME, type="VARCHAR"),
         DBColumn(name=METADATA_COLUMN_NAME, type="JSONB"),
+        DBColumn(name=SYNC_ID_COLUMN_NAME, type="VARCHAR", is_nullable=True),
         DBColumn(name=CREATED_AT_COLUMN, type="TIMESTAMP_TZ", default="CURRENT_TIMESTAMP"),
         DBColumn(name=UPDATED_AT_COLUMN, type="TIMESTAMP_TZ", default="CURRENT_TIMESTAMP"),
     ]

--- a/tests/ingestion_script/test_ingest_db_source.py
+++ b/tests/ingestion_script/test_ingest_db_source.py
@@ -1,10 +1,10 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
 from ingestion_script import ingest_db_source
-from ingestion_script.utils import UNIFIED_TABLE_DEFINITION
+from ingestion_script.utils import SYNC_ID_COLUMN_NAME, UNIFIED_TABLE_DEFINITION
 
 
 @pytest.mark.asyncio
@@ -76,3 +76,59 @@ async def test_upload_db_source_closes_sql_service_on_failure(monkeypatch: pytes
         )
 
     fake_sql_local_service.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_db_source_uses_sync_id_as_id_column(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_sql_local_service = MagicMock()
+    fake_sql_local_service.close = AsyncMock()
+    monkeypatch.setattr(ingest_db_source, "SQLLocalService", MagicMock(return_value=fake_sql_local_service))
+    monkeypatch.setattr(ingest_db_source, "_validate_source_columns", lambda *args, **kwargs: {"id": "VARCHAR"})
+    monkeypatch.setattr(ingest_db_source, "get_db_source_ids", MagicMock(return_value={"row_1": None}))
+    monkeypatch.setattr(ingest_db_source, "sync_chunks_to_qdrant", AsyncMock())
+
+    db_service = MagicMock()
+    qdrant_service = MagicMock()
+    qdrant_service._build_combined_filter.return_value = None
+
+    await ingest_db_source.upload_db_source(
+        db_service=db_service,
+        qdrant_service=qdrant_service,
+        db_definition=UNIFIED_TABLE_DEFINITION,
+        storage_schema_name="storage_schema",
+        storage_table_name="storage_table",
+        qdrant_collection_name="qdrant_collection",
+        source_id=uuid4(),
+        source_db_url="postgresql://example",
+        source_table_name="source_table",
+        id_column_name="id",
+        text_column_names=["content"],
+    )
+
+    call_kwargs = db_service.update_table.call_args.kwargs
+    assert call_kwargs["id_column_name"] == SYNC_ID_COLUMN_NAME
+
+
+def test_fetch_db_source_chunks_sets_sync_id() -> None:
+    fake_sql = MagicMock()
+    fake_sql.get_table_rows.return_value = [
+        {"id": 42, "content": "hello world"},
+        {"id": 99, "content": "foo bar"},
+    ]
+
+    with patch("ingestion_script.ingest_db_source.SentenceSplitter") as mock_splitter_cls:
+        mock_splitter_cls.return_value.split_text.side_effect = lambda txt: [txt]
+
+        chunks = ingest_db_source.fetch_db_source_chunks(
+            sync_ids={"42", "99"},
+            sql_local_service=fake_sql,
+            table_name="source_table",
+            id_column_name="id",
+            text_column_names=["content"],
+        )
+
+    assert len(chunks) == 2
+    assert chunks[0][SYNC_ID_COLUMN_NAME] == "42"
+    assert chunks[1][SYNC_ID_COLUMN_NAME] == "99"
+    for chunk in chunks:
+        assert SYNC_ID_COLUMN_NAME in chunk


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new sync_id field across ingestion pipelines and unified tables; migration adds the column to chunk tables and backfills values when applicable, with safe rollback support.

* **Behavior Changes**
  * Ingestion now keys and updates by sync_id and emits sync_id alongside existing file identifiers for chunk records.

* **Tests**
  * Added tests validating sync_id generation/propagation, chunk creation and grouping, query filtering, and empty-input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->