### PR TITLE
feat(component): fix coercion error dra-1195

### DIFF
--- a/engine/coercion_matrix.py
+++ b/engine/coercion_matrix.py
@@ -22,6 +22,7 @@ GRAPH_RUNTIME_TARGET_TYPES: frozenset[type] = frozenset({
     float,
     bool,
     dict,
+    list,
     list[str],
     list[dict],
     list[ChatMessage],
@@ -146,6 +147,12 @@ class CoercionMatrix:
         self._coercers[(list[dict], str)] = extract_string_from_dict_list
         self._coercers[(list[dict], list[ChatMessage])] = convert_dict_list_to_chatmessage_list
         self._coercers[(type(None), str)] = lambda x: ""
+
+        # String → dict / list (JSON parse)
+        self._coercers[(str, dict)] = lambda x: json.loads(x)
+        self._coercers[(str, Optional[dict])] = lambda x: json.loads(x)
+        self._coercers[(str, list)] = lambda x: json.loads(x)
+        self._coercers[(str, Optional[list])] = lambda x: json.loads(x)
 
         # Passthrough coercions (no-op)
         self._coercers[(list[ChatMessage], list[ChatMessage])] = lambda x: x

--- a/engine/components/component.py
+++ b/engine/components/component.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ValidationError
 from tenacity import RetryError
 
 from engine import legacy_compatibility
-from engine.coercion_matrix import CoercionError
+from engine.coercion_matrix import CoercionError, get_coercion_matrix
 from engine.components.types import (
     AgentPayload,
     ChatMessage,
@@ -24,6 +24,27 @@ from engine.trace.serializer import serialize_to_json
 from engine.trace.trace_manager import TraceManager
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _coerce_inputs_for_model(data: dict[str, Any], model: Type[BaseModel]) -> dict[str, Any]:
+    """Coerce input values to match the Pydantic model's field types.
+
+    Uses the global CoercionMatrix so that the legacy tool-invocation path
+    benefits from the same coercion rules as the graph-runner path.
+    Failures are silently skipped — Pydantic validation will report them.
+    """
+    matrix = get_coercion_matrix()
+    for field_name, field_info in model.model_fields.items():
+        if field_name not in data:
+            continue
+        target_type = field_info.annotation
+        if target_type is None or not matrix.should_attempt_coercion(target_type):
+            continue
+        try:
+            data[field_name] = matrix.coerce(data[field_name], target_type)
+        except (CoercionError, Exception):
+            continue
+    return data
 
 
 class Component(ABC):
@@ -248,6 +269,8 @@ class Component(ABC):
                             data[input_port_name] = last_message.content or ""
                         elif isinstance(last_message, dict):
                             data[input_port_name] = last_message.get("content", "")
+
+                    _coerce_inputs_for_model(data, InputModel)
 
                     try:
                         validated_inputs = InputModel(**data)

--- a/tests/components/rag/test_retriever.py
+++ b/tests/components/rag/test_retriever.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from engine.components.rag.retriever import Retriever
+from engine.components.rag.retriever import Retriever, RetrieverInputs
 from engine.components.types import SourceChunk
 from engine.llm_services.llm_service import EmbeddingService
 from engine.qdrant_service import QdrantService
@@ -62,3 +62,33 @@ async def test_get_chunks_(retriever, mock_qdrant_service):
         max_retrieved_chunks_after_penalty=None,
         source_schemas=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_run_with_string_filters(retriever, mock_qdrant_service):
+    """Regression: LLM or LiteralNode may pass filters as JSON string '{}' instead of dict."""
+    mock_qdrant_service.retrieve_similar_chunks_async.return_value = [
+        SourceChunk(content="chunk1", name="1", document_name="1", url="url1", metadata={"key": "value"}),
+    ]
+
+    result = await retriever.run(query="test query", filters="{}")
+
+    assert result.messages
+    mock_qdrant_service.retrieve_similar_chunks_async.assert_called_once()
+    call_kwargs = mock_qdrant_service.retrieve_similar_chunks_async.call_args.kwargs
+    assert call_kwargs["filter"] is None or isinstance(call_kwargs["filter"], dict)
+
+
+def test_retriever_inputs_accepts_string_filters_after_preprocessing():
+    """Regression: RetrieverInputs should accept dict filters after component preprocessing."""
+    from engine.components.component import _coerce_inputs_for_model
+
+    data = {"query": "test", "filters": "{}"}
+    _coerce_inputs_for_model(data, RetrieverInputs)
+    inputs = RetrieverInputs(**data)
+    assert inputs.filters == {}
+
+    data2 = {"query": "test", "filters": '{"must": [{"key": "date", "range": {"gte": "2024-01-01"}}]}'}
+    _coerce_inputs_for_model(data2, RetrieverInputs)
+    inputs2 = RetrieverInputs(**data2)
+    assert inputs2.filters == {"must": [{"key": "date", "range": {"gte": "2024-01-01"}}]}

--- a/tests/engine/test_coercion_matrix.py
+++ b/tests/engine/test_coercion_matrix.py
@@ -10,8 +10,10 @@ from datetime import date
 from typing import Optional
 
 import pytest
+from pydantic import BaseModel
 
 from engine.coercion_matrix import CoercionError, CoercionMatrix, coerce_value, get_coercion_matrix
+from engine.components.component import _coerce_inputs_for_model
 from engine.components.types import AgentPayload, ChatMessage, SourceChunk
 
 
@@ -628,3 +630,63 @@ def test_arbitrary_dict_to_chat_messages():
     assert isinstance(result[0], ChatMessage)
     assert result[0].role == "user"
     assert result[0].content == "hello"
+
+
+def test_string_to_dict_coercion():
+    """Regression: JSON string '{}' must be coerced to dict when target is dict."""
+    coercion_matrix = get_coercion_matrix()
+
+    assert coercion_matrix.coerce("{}", dict) == {}
+    assert coercion_matrix.coerce('{"key": "value"}', dict) == {"key": "value"}
+    assert coercion_matrix.coerce('{"must": []}', dict) == {"must": []}
+
+    assert coercion_matrix.coerce("{}", Optional[dict]) == {}
+    assert coercion_matrix.coerce('{"a": 1}', Optional[dict]) == {"a": 1}
+
+    with pytest.raises(CoercionError):
+        coercion_matrix.coerce("not json", dict)
+
+    assert coercion_matrix.can_coerce(str, dict) is True
+    assert coercion_matrix.can_coerce(str, Optional[dict]) is True
+
+
+class _SampleInputs(BaseModel):
+    query: str
+    filters: Optional[dict] = None
+    tags: Optional[list] = None
+    count: int = 0
+
+
+def test_preprocess_inputs_parses_json_string_for_dict_field():
+    """Regression: LiteralNode / LLM may deliver '{}' for dict-typed fields."""
+    data = {"query": "hello", "filters": "{}"}
+    _coerce_inputs_for_model(data, _SampleInputs)
+    assert data["filters"] == {}
+
+    data2 = {"query": "hello", "filters": '{"must": []}'}
+    _coerce_inputs_for_model(data2, _SampleInputs)
+    assert data2["filters"] == {"must": []}
+
+
+def test_preprocess_inputs_parses_json_string_for_list_field():
+    data = {"query": "hello", "tags": '["a", "b"]'}
+    _coerce_inputs_for_model(data, _SampleInputs)
+    assert data["tags"] == ["a", "b"]
+
+
+def test_preprocess_inputs_leaves_non_json_strings_alone():
+    data = {"query": "hello", "filters": "not json"}
+    _coerce_inputs_for_model(data, _SampleInputs)
+    assert data["filters"] == "not json"
+
+
+def test_preprocess_inputs_does_not_touch_str_fields():
+    data = {"query": '{"looks": "like json"}', "count": 5}
+    _coerce_inputs_for_model(data, _SampleInputs)
+    assert data["query"] == '{"looks": "like json"}'
+
+
+def test_preprocess_inputs_does_not_touch_already_correct_types():
+    data = {"query": "hello", "filters": {"must": []}}
+    _coerce_inputs_for_model(data, _SampleInputs)
+    assert data["filters"] == {"must": []}


### PR DESCRIPTION
# fix: coerce JSON strings to dict/list for component inputs (DRA-1195)

## Summary
- Fix "cannot coerce" error when `knowledge_search_retriever` (or any component) receives JSON-encoded strings (`"{}"`, `'["a"]'`) for dict or list typed input ports — a common scenario when values originate from a LiteralNode or LLM tool call.
Add `str` → `dict`, `str `→ `list` (and their `Optional` variants) coercion rules to the CoercionMatrix, and apply the coercion matrix to the tool-invocation path in Component before Pydantic validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Components now auto-parse JSON-encoded strings into structured types (dicts and lists) for inputs and filters, enabling passing JSON strings for queries/filters.

* **Tests**
  * Added tests covering JSON string coercion, preprocessing of inputs, and retriever behavior with string filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->