### PR TITLE
feat(traces): Add date range filtering to traces endpoint DRA-1203

### DIFF
--- a/ada_backend/docs/api-reference.md
+++ b/ada_backend/docs/api-reference.md
@@ -153,7 +153,7 @@ Run input data is persisted in the `run_inputs` table (keyed by `retry_group_id`
 |---|---|---|---|
 | GET | `/monitor/org/{organization_id}/charts` | JWT(Member) | Org charts |
 | GET | `/monitor/org/{organization_id}/kpis` | JWT(Member) | Org KPIs |
-| GET | `/projects/{project_id}/traces` | JWT(Member) | List traces (optional `search` query param for keyword filtering on input content) |
+| GET | `/projects/{project_id}/traces` | JWT(Member) | List traces. Filters: `duration` (days lookback), `start_time`/`end_time` (ISO 8601 date range), `search`, `environment`, `call_type`, `graph_runner_id`. Requires `duration` or at least one of `start_time`/`end_time`. **Precedence:** if `start_time` or `end_time` is provided, `duration` is ignored (explicit bounds override the lookback window). |
 | GET | `/traces/{trace_id}/tree` | JWT | Trace span tree |
 
 ## Cron Jobs (`cron_router.py`)

--- a/ada_backend/routers/trace_router.py
+++ b/ada_backend/routers/trace_router.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from typing import Annotated, Optional
 from uuid import UUID
 
@@ -29,11 +30,11 @@ router = APIRouter()
 @router.get("/projects/{project_id}/traces", response_model=PaginatedRootTracesResponse, tags=["Metrics"])
 async def get_root_traces(
     project_id: UUID,
-    duration: int,
     user: Annotated[
         SupabaseUser,
         Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
     ],
+    duration: Optional[int] = Query(None, description="Lookback window in days (ignored when start_time is provided)"),
     environment: Optional[EnvType] = None,
     call_type: Optional[CallType] = None,
     page: int = Query(1, ge=1, description="Page number (1-based)"),
@@ -42,24 +43,33 @@ async def get_root_traces(
     search: Optional[str] = Query(
         None, min_length=1, max_length=500, description="Search traces by input message content"
     ),
+    start_time: Optional[datetime] = Query(None, description="Start of date range filter (ISO 8601)"),
+    end_time: Optional[datetime] = Query(None, description="End of date range filter (ISO 8601)"),
     session: Session = Depends(get_db),
 ) -> PaginatedRootTracesResponse:
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
+    if duration is None and start_time is None and end_time is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Either 'duration' or at least one of 'start_time'/'end_time' must be provided",
+        )
     project = get_project(session, project_id)
     organization_id = project.organization_id if project else None
     try:
         response = get_root_traces_by_project(
             user.id,
             project_id,
-            duration,
-            environment,
-            call_type,
-            page,
-            page_size,
-            graph_runner_id,
+            duration=duration,
+            environment=environment,
+            call_type=call_type,
+            page=page,
+            page_size=page_size,
+            graph_runner_id=graph_runner_id,
             organization_id=organization_id,
             search=search,
+            start_time=start_time,
+            end_time=end_time,
         )
         return response
     except ValueError as e:

--- a/ada_backend/services/metrics/utils.py
+++ b/ada_backend/services/metrics/utils.py
@@ -94,26 +94,42 @@ def query_trace_duration(
 
 def query_root_trace_duration(
     project_id: UUID,
-    duration_days: int,
+    duration_days: Optional[int] = None,
     environment: Optional[EnvType] = None,
     call_type: Optional[CallType] = None,
     graph_runner_id: Optional[UUID] = None,
     page: int = 1,
     page_size: int = 20,
     search: Optional[str] = None,
+    start_time: Optional[datetime] = None,
+    end_time: Optional[datetime] = None,
 ) -> Tuple[List[dict], int]:
     """Query root traces with server-side pagination.
 
     Returns a tuple of (rows_as_dicts, total_pages).
+    Time filtering: explicit start_time/end_time take precedence over duration_days.
     """
-    start_time_offset_days = (datetime.now() - timedelta(days=duration_days)).isoformat()
+    if start_time is None and end_time is None and duration_days is None:
+        duration_days = 30
+
     offset = (page - 1) * page_size
 
     filters = f"""
         project_id = '{project_id}'
-        AND start_time > '{start_time_offset_days}'
         AND parent_id IS NULL
     """
+    params: dict = {}
+
+    if start_time is not None or end_time is not None:
+        if start_time is not None:
+            filters += "\n        AND start_time >= :filter_start_time"
+            params["filter_start_time"] = start_time.isoformat()
+        if end_time is not None:
+            filters += "\n        AND start_time <= :filter_end_time"
+            params["filter_end_time"] = end_time.isoformat()
+    elif duration_days is not None:
+        start_time_offset_days = (datetime.now() - timedelta(days=duration_days)).isoformat()
+        filters += f"\n        AND start_time > '{start_time_offset_days}'"
     if environment is not None:
         filters += f"\n        AND environment = '{environment.value}'"
     if call_type is not None:
@@ -121,7 +137,6 @@ def query_root_trace_duration(
     if graph_runner_id is not None:
         filters += f"\n        AND graph_runner_id = '{graph_runner_id}'"
 
-    params = {}
     if search is not None:
         filters += """
         AND EXISTS (

--- a/ada_backend/services/trace_service.py
+++ b/ada_backend/services/trace_service.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from collections import defaultdict
+from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
@@ -189,7 +190,7 @@ def get_span_trace_service(user_id: UUID, trace_id: UUID) -> TraceSpan:
 def get_root_traces_by_project(
     user_id: UUID,
     project_id: UUID,
-    duration: int,
+    duration: Optional[int] = None,
     environment: Optional[EnvType] = None,
     call_type: Optional[CallType] = None,
     page: int = 1,
@@ -197,6 +198,8 @@ def get_root_traces_by_project(
     graph_runner_id: Optional[UUID] = None,
     organization_id: Optional[UUID] = None,
     search: Optional[str] = None,
+    start_time: Optional[datetime] = None,
+    end_time: Optional[datetime] = None,
 ) -> PaginatedRootTracesResponse:
     if page_size <= 0:
         page_size = 20
@@ -205,16 +208,19 @@ def get_root_traces_by_project(
 
     rows, total_pages = query_root_trace_duration(
         project_id,
-        duration,
+        duration_days=duration,
         environment=environment,
         call_type=call_type,
         graph_runner_id=graph_runner_id,
         page=page,
         page_size=page_size,
         search=search,
+        start_time=start_time,
+        end_time=end_time,
     )
     track_monitoring_loaded(user_id, project_count=1, organization_id=organization_id)
-    LOGGER.info(f"Querying root spans for project {project_id} with duration {duration} days")
+    LOGGER.info("Querying root spans for project %s with duration=%s start_time=%s end_time=%s",
+                project_id, duration, start_time, end_time)
 
     traces = build_root_spans(rows)
     return PaginatedRootTracesResponse(

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -132,7 +132,7 @@ Custom tools (validation, multi-step, client-side logic) are still defined as `@
 | Release stage | Component catalog auto-filtered by org tier. Cannot be overridden by the AI. |
 | Agent name | `create_agent` rejects empty/whitespace names. |
 | Pagination | `list_runs` caps page_size at 100. |
-| Monitoring | Duration clamped 1–90 days. |
+| Monitoring | Duration clamped 1–90 days. `list_traces` also accepts `start_time`/`end_time` (ISO 8601) for date range filtering. |
 | Response size | Responses > 50KB are trimmed by default. `ToolSpec.trim=False` disables trimming per tool (e.g. `get_graph`, `list_components` for round-trip safety). |
 | Session diagnostics | `get_current_context` includes `session.session_id` and `session.storage_backend` ("redis" or "memory"). |
 | Agent tools | `add_tool_to_agent` rejects non-`function_callable`, duplicate, or integration-backed tools that it cannot wire safely. Use the display name from `search_components()`, not hard-coded names. The AI Agent's `skip_tools_with_missing_oauth` parameter (default `True`) silently drops any tool whose OAuth connection is missing at agent startup. |

--- a/mcp_server/docs.py
+++ b/mcp_server/docs.py
@@ -113,7 +113,9 @@ document content, or file outputs.
 ## Important Constraints
 
 - `list_runs` caps `page_size` at 100
-- `get_org_charts`, `get_org_kpis`, and `list_traces` clamp `duration` to 1–90 days. `list_traces` also accepts `start_time`/`end_time` (ISO 8601) for precise date range filtering; when provided, `duration` is ignored
+- `get_org_charts`, `get_org_kpis`, and `list_traces` clamp `duration` to 1–90 days. \
+`list_traces` also accepts `start_time`/`end_time` (ISO 8601) for precise date range \
+filtering; when provided, `duration` is ignored
 - Batch deletions: `delete_datasets`, `delete_entries`, `delete_judges` accept lists of IDs
 - Graph updates send the full graph structure — always `get_graph` first, modify, then `update_graph`
 - Secrets values are write-only; `list_secrets` returns masked values
@@ -878,7 +880,8 @@ Call `get_run_result(project_id, run_id)` to retrieve the final output.
 1. `list_runs(project_id)` → find the run
 2. `get_run(project_id, run_id)` → status and metadata
 3. `get_run_result(project_id, run_id)` → output data
-4. `list_traces(project_id, duration=30)` or `list_traces(project_id, start_time="...", end_time="...")` → find trace for debugging
+4. `list_traces(project_id, duration=30)` or \
+`list_traces(project_id, start_time="...", end_time="...")` → find trace for debugging
 5. `get_trace_tree(trace_id)` → full span tree with timings
 
 ## Retry a Failed Run
@@ -1704,7 +1707,9 @@ read/revoke operations only; the actual connect flow happens in the web UI.
 
 ## Monitoring
 
-- `list_traces(project_id, duration=30)` → recent traces (duration in days, 1–90). Also accepts `start_time`/`end_time` (ISO 8601) for date range filtering
+- `list_traces(project_id, duration=30)` → recent traces (duration in days, 1–90). \
+Also accepts `start_time`/`end_time` (ISO 8601) for precise date range filtering; \
+when provided, `duration` is ignored
 - `get_trace_tree(trace_id)` → full span tree with timings (`trace_id` is an OTel hex string, e.g. `0x6d4e...`)
 - `get_org_charts(duration_days)` → usage charts (1–90 days)
 - `get_org_kpis(duration_days)` → key metrics

--- a/mcp_server/docs.py
+++ b/mcp_server/docs.py
@@ -113,7 +113,7 @@ document content, or file outputs.
 ## Important Constraints
 
 - `list_runs` caps `page_size` at 100
-- `get_org_charts`, `get_org_kpis`, and `list_traces` clamp `duration` to 1–90 days
+- `get_org_charts`, `get_org_kpis`, and `list_traces` clamp `duration` to 1–90 days. `list_traces` also accepts `start_time`/`end_time` (ISO 8601) for precise date range filtering; when provided, `duration` is ignored
 - Batch deletions: `delete_datasets`, `delete_entries`, `delete_judges` accept lists of IDs
 - Graph updates send the full graph structure — always `get_graph` first, modify, then `update_graph`
 - Secrets values are write-only; `list_secrets` returns masked values
@@ -878,7 +878,7 @@ Call `get_run_result(project_id, run_id)` to retrieve the final output.
 1. `list_runs(project_id)` → find the run
 2. `get_run(project_id, run_id)` → status and metadata
 3. `get_run_result(project_id, run_id)` → output data
-4. `list_traces(project_id, duration=30)` → find trace for debugging
+4. `list_traces(project_id, duration=30)` or `list_traces(project_id, start_time="...", end_time="...")` → find trace for debugging
 5. `get_trace_tree(trace_id)` → full span tree with timings
 
 ## Retry a Failed Run
@@ -1704,7 +1704,7 @@ read/revoke operations only; the actual connect flow happens in the web UI.
 
 ## Monitoring
 
-- `list_traces(project_id, duration=30)` → recent traces (duration in days, 1–90)
+- `list_traces(project_id, duration=30)` → recent traces (duration in days, 1–90). Also accepts `start_time`/`end_time` (ISO 8601) for date range filtering
 - `get_trace_tree(trace_id)` → full span tree with timings (`trace_id` is an OTel hex string, e.g. `0x6d4e...`)
 - `get_org_charts(duration_days)` → usage charts (1–90 days)
 - `get_org_kpis(duration_days)` → key metrics

--- a/mcp_server/tools/monitoring.py
+++ b/mcp_server/tools/monitoring.py
@@ -1,6 +1,7 @@
 """Monitoring, traces, and credit usage tools."""
 
-from typing import Annotated
+from datetime import datetime
+from typing import Annotated, Optional
 from uuid import UUID
 
 from fastmcp import FastMCP
@@ -56,27 +57,42 @@ def register(mcp: FastMCP) -> None:
     async def list_traces(
         project_id: Annotated[UUID, Field(description="The project ID (from list_projects or get_project_overview).")],
         duration: Annotated[
-            int,
-            Field(description="Number of days to include. Clamped to 1-90."),
+            Optional[int],
+            Field(description="Number of days to include (1-90). Ignored when start_time is provided."),
         ] = DEFAULT_DURATION_DAYS,
+        start_time: Annotated[
+            Optional[str],
+            Field(description="Start of date range filter (ISO 8601, e.g. '2025-06-01T00:00:00Z')."),
+        ] = None,
+        end_time: Annotated[
+            Optional[str],
+            Field(description="End of date range filter (ISO 8601, e.g. '2025-06-30T23:59:59Z')."),
+        ] = None,
         page: Annotated[int, Field(description="Page number (1-based).")] = 1,
         page_size: Annotated[int, Field(description="Results per page (max 100).")] = 50,
     ) -> dict:
-        """List execution traces for a project."""
+        """List execution traces for a project. Filter by duration (days lookback) or by explicit date range."""
         if page < 1:
             raise ValueError("page must be >= 1")
         if page_size < 1:
             raise ValueError("page_size must be >= 1")
-        duration = _normalize_duration(duration)
+
+        params: dict = {"page": page, "page_size": min(page_size, 100)}
+
+        if start_time is not None or end_time is not None:
+            if start_time is not None:
+                datetime.fromisoformat(start_time)
+                params["start_time"] = start_time
+            if end_time is not None:
+                datetime.fromisoformat(end_time)
+                params["end_time"] = end_time
+        elif duration is not None:
+            params["duration"] = _normalize_duration(duration)
+        else:
+            raise ValueError("Provide either 'duration' or at least one of 'start_time'/'end_time'.")
 
         jwt, _ = _get_auth()
-        return await api.get(
-            f"/projects/{project_id}/traces",
-            jwt,
-            duration=duration,
-            page=page,
-            page_size=min(page_size, 100),
-        )
+        return await api.get(f"/projects/{project_id}/traces", jwt, **params)
 
     @mcp.tool()
     async def get_org_charts(

--- a/mcp_server/tools/monitoring.py
+++ b/mcp_server/tools/monitoring.py
@@ -58,7 +58,7 @@ def register(mcp: FastMCP) -> None:
         project_id: Annotated[UUID, Field(description="The project ID (from list_projects or get_project_overview).")],
         duration: Annotated[
             Optional[int],
-            Field(description="Number of days to include (1-90). Ignored when start_time is provided."),
+            Field(description="Number of days to include (1-90). Ignored when start_time or end_time is provided."),
         ] = DEFAULT_DURATION_DAYS,
         start_time: Annotated[
             Optional[str],

--- a/tests/ada_backend/services/metrics/test_trace_search.py
+++ b/tests/ada_backend/services/metrics/test_trace_search.py
@@ -111,3 +111,68 @@ def test_search_traces_by_keyword():
                 Span.trace_rowid.in_([str(trace1_id), str(trace2_id), str(trace3_id)])
             ).delete(synchronize_session=False)
             session.commit()
+
+
+def test_filter_traces_by_date_range():
+    now = datetime.now()
+    project_id = uuid4()
+
+    trace1_id, span1_id = uuid4(), uuid4()
+    trace2_id, span2_id = uuid4(), uuid4()
+    trace3_id, span3_id = uuid4(), uuid4()
+
+    with get_db_session() as session:
+        span1 = _create_root_span(project_id, trace1_id, span1_id, now - timedelta(hours=1))
+        span2 = _create_root_span(project_id, trace2_id, span2_id, now - timedelta(hours=5))
+        span3 = _create_root_span(project_id, trace3_id, span3_id, now - timedelta(hours=10))
+        session.add_all([span1, span2, span3])
+        session.commit()
+
+        msg1 = _create_span_message(span1_id, json.dumps([{"messages": [{"role": "user", "content": "a"}]}]))
+        msg2 = _create_span_message(span2_id, json.dumps([{"messages": [{"role": "user", "content": "b"}]}]))
+        msg3 = _create_span_message(span3_id, json.dumps([{"messages": [{"role": "user", "content": "c"}]}]))
+        session.add_all([msg1, msg2, msg3])
+        session.commit()
+
+        try:
+            rows, _ = query_root_trace_duration(
+                project_id,
+                start_time=now - timedelta(hours=6),
+                end_time=now,
+            )
+            assert len(rows) == 2
+            trace_ids = {row["trace_rowid"] for row in rows}
+            assert str(trace1_id) in trace_ids
+            assert str(trace2_id) in trace_ids
+
+            rows_start_only, _ = query_root_trace_duration(
+                project_id,
+                start_time=now - timedelta(hours=2),
+            )
+            assert len(rows_start_only) == 1
+            assert rows_start_only[0]["trace_rowid"] == str(trace1_id)
+
+            rows_end_only, _ = query_root_trace_duration(
+                project_id,
+                end_time=now - timedelta(hours=4),
+            )
+            assert len(rows_end_only) == 2
+            trace_ids_end = {row["trace_rowid"] for row in rows_end_only}
+            assert str(trace2_id) in trace_ids_end
+            assert str(trace3_id) in trace_ids_end
+
+            rows_range_takes_precedence, _ = query_root_trace_duration(
+                project_id,
+                duration_days=1,
+                start_time=now - timedelta(hours=2),
+                end_time=now,
+            )
+            assert len(rows_range_takes_precedence) == 1
+            assert rows_range_takes_precedence[0]["trace_rowid"] == str(trace1_id)
+
+        finally:
+            span_ids = [str(span1_id), str(span2_id), str(span3_id)]
+            trace_ids_cleanup = [str(trace1_id), str(trace2_id), str(trace3_id)]
+            session.query(SpanMessage).filter(SpanMessage.span_id.in_(span_ids)).delete(synchronize_session=False)
+            session.query(Span).filter(Span.trace_rowid.in_(trace_ids_cleanup)).delete(synchronize_session=False)
+            session.commit()


### PR DESCRIPTION
# feat(traces): Add date range filtering to traces endpoint DRA-1203

## Summary
- Add optional `start_time` and `end_time` query parameters (ISO 8601) to GET `/projects/{project_id}/traces`, enabling precise date range filtering on the observability page.
- Make the existing duration parameter optional; the endpoint now requires either duration or at least one of `start_time`/`end_time`. When both are provided, the explicit date range takes precedence.
- Use parameterized SQL (`:filter_start_time`, `:filter_end_time`) for the new datetime filters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Traces API and monitoring tools support ISO 8601 date-range filtering (start_time/end_time) in addition to duration-based lookback; added environment, call_type, and graph_runner_id filters.
* **Behavior Change**
  * Requests must include either duration or at least one of start_time/end_time; explicit start_time/end_time take precedence over duration.
* **Documentation**
  * API and monitoring docs updated to reflect new parameters and validation.
* **Tests**
  * Added tests for date-range filtering and precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->