### PR TITLE
feat(model): Add GPT-5.4 to reasoning="none" support list DRA-1200

### DIFF
--- a/engine/llm_services/utils.py
+++ b/engine/llm_services/utils.py
@@ -152,19 +152,19 @@ def build_openai_responses_kwargs(
     """
     Return kwargs for OpenAI Responses API, adding verbosity/reasoning only for GPT-5 models.
 
-    Note: For GPT-5 models (except 5.1 and 5.2), when reasoning is None, it defaults to "minimal".
+    Models in supports_reasoning_none accept reasoning="none"; other GPT-5 models fall back to "minimal".
     """
-    gpt5_1_or_5_2 = ["gpt-5.1", "gpt-5.2"]
+    supports_reasoning_none = ["gpt-5.1", "gpt-5.2", "gpt-5.4"]
     kwargs = dict(base_kwargs)
     model_name_lower = (model_name or "").lower()
     is_gpt5 = "gpt-5" in model_name_lower
     if is_gpt5:
         if verbosity is not None:
             kwargs["text"] = {"verbosity": verbosity}
-        is_gpt5_1_or_5_2 = any(model in model_name_lower for model in gpt5_1_or_5_2)
+        has_reasoning_none = any(model in model_name_lower for model in supports_reasoning_none)
         if reasoning is not None:
             if reasoning.lower() == "none":
-                if is_gpt5_1_or_5_2:
+                if has_reasoning_none:
                     kwargs["reasoning"] = {"effort": "none"}
                 else:
                     kwargs["reasoning"] = {"effort": "minimal"}


### PR DESCRIPTION
Fix GPT-5.4 reasoning parameter to support "none" value

GPT-5.4 supports reasoning.effort="none" but not "minimal". Updated the allowlist to include gpt-5.4 alongside gpt-5.1 and gpt-5.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded support for "reasoning: none" across additional GPT-5 variants (including gpt-5.4), preventing unintended fallback to minimal reasoning and ensuring the specified reasoning setting is honored.

* **Documentation**
  * Updated user-facing documentation to reflect broader model support and confirm behavior for other reasoning values remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->