### PR TITLE
feat(ci): Split prod-to-staging sync into separate DB and Qdrant steps dra-1211

### DIFF
--- a/.github/workflows/sync-prod-to-staging.yml
+++ b/.github/workflows/sync-prod-to-staging.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run sync as Kubernetes Job
-        id: sync
+      - name: Sync databases
+        id: sync_db
         continue-on-error: true
         uses: appleboy/ssh-action@master
         with:
@@ -32,21 +32,16 @@ jobs:
             set -e
             NS="ada-staging"
             STATE_FILE="/tmp/ada-sync-status-${{ github.run_id }}.txt"
-            JOB_NAME="data-sync-${{ github.run_id }}"
+            JOB_NAME="db-sync-${{ github.run_id }}"
 
-            # Get the current image from the deployment
             IMAGE=$(kubectl get deployment/ada-api -n ${NS} -o jsonpath='{.spec.template.spec.containers[0].image}')
+            echo "🔍 Running DB sync as Kubernetes Job using image: ${IMAGE}"
 
-            echo "🔍 Running sync as Kubernetes Job using image: ${IMAGE}"
-            
-            # Build force sync flag
             FORCE_SYNC_FLAG=""
             if [ "${{ inputs.force_sync }}" = "true" ]; then
               FORCE_SYNC_FLAG="--force-sync"
             fi
 
-            # Create Job to run sync (code already exists in the image)
-            # Note: Setting PATH to include .venv for uv and Python packages
             kubectl create job ${JOB_NAME} -n ${NS} \
               --image=${IMAGE} \
               -- bash -c "\
@@ -58,45 +53,92 @@ jobs:
                   --source-ingestion-db-url '${{ secrets.PROD_INGESTION_DB_URL }}' \
                   --target-db-url '${{ secrets.STAGING_DB_URL }}' \
                   --target-ingestion-db-url '${{ secrets.STAGING_INGESTION_DB_URL }}' \
-                  --source-qdrant-url '${{ secrets.PROD_QDRANT_CLUSTER_URL }}' \
-                  --source-qdrant-key '${{ secrets.PROD_QDRANT_API_KEY }}' \
-                  --target-qdrant-url '${{ secrets.STAGING_QDRANT_CLUSTER_URL }}' \
-                  --target-qdrant-key '${{ secrets.STAGING_QDRANT_API_KEY }}' \
+                  --skip-qdrant \
                   ${FORCE_SYNC_FLAG} \
               "
 
-            # Wait for job to complete (or fail)
-            echo "⏳ Waiting for sync job to complete..."
+            echo "⏳ Waiting for DB sync job to complete..."
             if kubectl wait --for=condition=complete job/${JOB_NAME} -n ${NS} --timeout=15m 2>/dev/null; then
-              # Job completed successfully - check logs to see if it was skipped (unless force_sync was requested)
               echo "📋 Checking job logs..."
               LOGS=$(kubectl logs job/${JOB_NAME} -n ${NS})
               echo "$LOGS"
-              
+
               FORCE_SYNC="${{ inputs.force_sync }}"
               if [ "$FORCE_SYNC" = "true" ]; then
-                echo "✅ Sync completed (force_sync was requested)"
+                echo "✅ DB sync completed (force_sync was requested)"
                 echo "SYNCED" > "$STATE_FILE"
                 kubectl delete job ${JOB_NAME} -n ${NS}
                 exit 0
               fi
               if echo "$LOGS" | grep -qi "skip\|cache.*valid\|already.*synced"; then
-                echo "⏭️ Sync not needed - TTL cache is valid"
+                echo "⏭️ DB sync not needed - TTL cache is valid"
                 echo "SKIPPED" > "$STATE_FILE"
                 kubectl delete job ${JOB_NAME} -n ${NS}
                 exit 0
               else
-                echo "✅ Sync completed successfully"
+                echo "✅ DB sync completed successfully"
                 echo "SYNCED" > "$STATE_FILE"
                 kubectl delete job ${JOB_NAME} -n ${NS}
                 exit 0
               fi
             else
-              # Job failed
-              echo "❌ Sync job failed"
+              echo "❌ DB sync job failed"
               echo "📋 Job logs:"
               kubectl logs job/${JOB_NAME} -n ${NS} || true
               echo "FAILED" > "$STATE_FILE"
+              kubectl delete job ${JOB_NAME} -n ${NS} || true
+              exit 1
+            fi
+
+      - name: Sync Qdrant collections
+        id: sync_qdrant
+        continue-on-error: true
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST_K8S_STAGING }}
+          username: ec2-user
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: 22
+          command_timeout: 15m
+          script: |
+            set -e
+            NS="ada-staging"
+            STATE_FILE="/tmp/ada-sync-status-${{ github.run_id }}.txt"
+            JOB_NAME="qdrant-sync-${{ github.run_id }}"
+
+            if [ -f "$STATE_FILE" ] && [ "$(cat "$STATE_FILE")" != "SYNCED" ]; then
+              echo "⏭️ Skipping Qdrant sync - DB sync was not performed (status: $(cat "$STATE_FILE"))"
+              exit 0
+            fi
+
+            IMAGE=$(kubectl get deployment/ada-api -n ${NS} -o jsonpath='{.spec.template.spec.containers[0].image}')
+            echo "🔍 Running Qdrant sync as Kubernetes Job using image: ${IMAGE}"
+
+            kubectl create job ${JOB_NAME} -n ${NS} \
+              --image=${IMAGE} \
+              -- bash -c "\
+                export PATH=/app/.venv/bin:\$PATH && \
+                export PYTHONPATH=/app && \
+                cd /app && \
+                ./scripts/copy_data/sync_data.sh \
+                  --source-db-url '${{ secrets.PROD_DB_URL }}' \
+                  --source-qdrant-url '${{ secrets.PROD_QDRANT_CLUSTER_URL }}' \
+                  --source-qdrant-key '${{ secrets.PROD_QDRANT_API_KEY }}' \
+                  --target-qdrant-url '${{ secrets.STAGING_QDRANT_CLUSTER_URL }}' \
+                  --target-qdrant-key '${{ secrets.STAGING_QDRANT_API_KEY }}' \
+                  --only-qdrant \
+              "
+
+            echo "⏳ Waiting for Qdrant sync job to complete..."
+            if kubectl wait --for=condition=complete job/${JOB_NAME} -n ${NS} --timeout=15m 2>/dev/null; then
+              echo "📋 Job logs:"
+              kubectl logs job/${JOB_NAME} -n ${NS}
+              echo "✅ Qdrant sync completed successfully"
+              kubectl delete job ${JOB_NAME} -n ${NS}
+            else
+              echo "❌ Qdrant sync job failed"
+              echo "📋 Job logs:"
+              kubectl logs job/${JOB_NAME} -n ${NS} || true
               kubectl delete job ${JOB_NAME} -n ${NS} || true
               exit 1
             fi

--- a/scripts/copy_data/sync_data.sh
+++ b/scripts/copy_data/sync_data.sh
@@ -5,6 +5,11 @@ set -e
 # Only runs dump + restore (and optional Qdrant sync) if cache is expired (24h)
 # TTL source of truth: ada_backend.latest.dump
 #
+# Modes:
+#   --skip-qdrant   Sync DBs only, skip Qdrant
+#   --only-qdrant   Sync Qdrant only, skip DBs and TTL check
+#   (default)       Sync both DBs and Qdrant
+#
 # Usage:
 #   ./sync_data.sh \\
 #     --source-db-url              postgres://... \\
@@ -15,7 +20,7 @@ set -e
 #     [--source-qdrant-key         xxx ] \\
 #     [--target-qdrant-url         https://... ] \\
 #     [--target-qdrant-key         xxx ] \\
-#     [--force-sync]
+#     [--force-sync] [--skip-qdrant] [--only-qdrant]
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/db_utils.sh"
@@ -31,7 +36,9 @@ Usage: ./sync_data.sh \\
   [--source-qdrant-key         xxx] \\
   [--target-qdrant-url         https://...] \\
   [--target-qdrant-key         xxx] \\
-  [--force-sync]
+  [--force-sync] \\
+  [--skip-qdrant] \\
+  [--only-qdrant]
 EOF
 }
 
@@ -45,6 +52,8 @@ SOURCE_QDRANT_API_KEY=""
 TARGET_QDRANT_CLUSTER_URL=""
 TARGET_QDRANT_API_KEY=""
 FORCE_SYNC="${FORCE_SYNC:-0}"
+SKIP_QDRANT=0
+ONLY_QDRANT=0
 
 # Parse flags
 while [ $# -gt 0 ]; do
@@ -67,6 +76,10 @@ while [ $# -gt 0 ]; do
       TARGET_QDRANT_API_KEY="$2"; shift 2 ;;
     --force-sync)
       FORCE_SYNC=1; shift 1 ;;
+    --skip-qdrant)
+      SKIP_QDRANT=1; shift 1 ;;
+    --only-qdrant)
+      ONLY_QDRANT=1; shift 1 ;;
     -h|--help)
       print_usage; exit 0 ;;
     *)
@@ -76,72 +89,89 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# Validate required DB flags
-if [ -z "$SOURCE_DB_URL" ] || [ -z "$SOURCE_INGESTION_DB_URL" ] || \
-   [ -z "$TARGET_DB_URL" ] || [ -z "$TARGET_INGESTION_DB_URL" ]; then
-  echo "ERROR: Missing required database URLs." >&2
-  print_usage
+if [ "$SKIP_QDRANT" = "1" ] && [ "$ONLY_QDRANT" = "1" ]; then
+  echo "ERROR: --skip-qdrant and --only-qdrant are mutually exclusive." >&2
   exit 1
 fi
 
-echo "===> Checking if sync is needed (TTL 24h, based on ada_backend dump only)"
-
-# Single TTL source of truth: ada_backend.latest.dump
-# FORCE_SYNC=1 (or --force-sync) will skip TTL and force a full sync (DBs + Qdrant)
-if [ "$FORCE_SYNC" != "1" ]; then
-  if check_dump_ttl "$BACKEND_DUMP_PATH" "ada_backend"; then
-    echo "===> Cache valid based on ada_backend dump, nothing to do"
-    exit 0
+# Validate required flags based on mode
+if [ "$ONLY_QDRANT" = "1" ]; then
+  if [ -z "$SOURCE_QDRANT_CLUSTER_URL" ] || [ -z "$SOURCE_QDRANT_API_KEY" ] || \
+     [ -z "$TARGET_QDRANT_CLUSTER_URL" ] || [ -z "$TARGET_QDRANT_API_KEY" ] || \
+     [ -z "$SOURCE_DB_URL" ]; then
+    echo "ERROR: --only-qdrant requires all Qdrant flags and --source-db-url." >&2
+    print_usage
+    exit 1
   fi
 else
-  echo "===> FORCE_SYNC enabled, skipping TTL check and forcing full sync"
+  if [ -z "$SOURCE_DB_URL" ] || [ -z "$SOURCE_INGESTION_DB_URL" ] || \
+     [ -z "$TARGET_DB_URL" ] || [ -z "$TARGET_INGESTION_DB_URL" ]; then
+    echo "ERROR: Missing required database URLs." >&2
+    print_usage
+    exit 1
+  fi
 fi
 
-echo "===> Cache expired or missing (based on ada_backend) or forced, starting sync process"
+sync_databases() {
+  echo "===> Checking if sync is needed (TTL 24h, based on ada_backend dump only)"
 
-# Ensure PostgreSQL tools are installed
-ensure_pg_tools
-
-# Sync ada_backend: dump, drop/create, and restore
-echo "===> Dumping ada_backend from source"
-pg_dump -Fc "$SOURCE_DB_URL" -f "$BACKEND_DUMP_PATH"
-drop_and_create_db "$TARGET_DB_URL" "ada_backend"
-echo "===> Restoring ada_backend"
-pg_restore -d "$TARGET_DB_URL" --no-owner --no-privileges --single-transaction --verbose -Fc "$BACKEND_DUMP_PATH"
-
-# Deactivate all cron jobs in staging database
-echo "===> Deactivating all cron jobs in staging database"
-DEACTIVATED_COUNT=$(psql "$TARGET_DB_URL" -t -A -c "
-  WITH updated AS (
-    UPDATE scheduler.cron_jobs 
-    SET is_enabled = false 
-    WHERE is_enabled = true 
-    RETURNING id
-  )
-  SELECT COUNT(*) FROM updated;
-" 2>/dev/null | tr -d ' ' || echo "0")
-if [ "$DEACTIVATED_COUNT" != "0" ] && [ "$DEACTIVATED_COUNT" != "" ]; then
-  echo "===> Deactivated $DEACTIVATED_COUNT cron job(s) in staging database"
-else
-  # Check if schema exists to provide better error message
-  SCHEMA_EXISTS=$(psql "$TARGET_DB_URL" -t -A -c "SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = 'scheduler');" 2>/dev/null | tr -d ' ' || echo "f")
-  if [ "$SCHEMA_EXISTS" = "t" ]; then
-    echo "===> No enabled cron jobs found to deactivate"
+  if [ "$FORCE_SYNC" != "1" ]; then
+    if check_dump_ttl "$BACKEND_DUMP_PATH" "ada_backend"; then
+      echo "===> Cache valid based on ada_backend dump, nothing to do"
+      return 1
+    fi
   else
-    echo "===> Scheduler schema not found, skipping cron job deactivation"
+    echo "===> FORCE_SYNC enabled, skipping TTL check and forcing full sync"
   fi
-fi
 
-# Sync ada_ingestion: dump, drop/create, and restore
-echo "===> Dumping ada_ingestion from source"
-pg_dump -Fc "$SOURCE_INGESTION_DB_URL" -f "$INGESTION_DUMP_PATH"
-drop_and_create_db "$TARGET_INGESTION_DB_URL" "ada_ingestion"
-echo "===> Restoring ada_ingestion"
-pg_restore -d "$TARGET_INGESTION_DB_URL" --no-owner --no-privileges --single-transaction --verbose -Fc "$INGESTION_DUMP_PATH"
+  echo "===> Cache expired or missing (based on ada_backend) or forced, starting sync process"
 
-# Sync Qdrant collections (if configured)
-if [ -n "$SOURCE_QDRANT_CLUSTER_URL" ] && [ -n "$SOURCE_QDRANT_API_KEY" ] && \
-   [ -n "$TARGET_QDRANT_CLUSTER_URL" ] && [ -n "$TARGET_QDRANT_API_KEY" ]; then
+  ensure_pg_tools
+
+  echo "===> Dumping ada_backend from source"
+  pg_dump -Fc "$SOURCE_DB_URL" -f "$BACKEND_DUMP_PATH"
+  drop_and_create_db "$TARGET_DB_URL" "ada_backend"
+  echo "===> Restoring ada_backend"
+  pg_restore -d "$TARGET_DB_URL" --no-owner --no-privileges --single-transaction --verbose -Fc "$BACKEND_DUMP_PATH"
+
+  echo "===> Deactivating all cron jobs in staging database"
+  DEACTIVATED_COUNT=$(psql "$TARGET_DB_URL" -t -A -c "
+    WITH updated AS (
+      UPDATE scheduler.cron_jobs 
+      SET is_enabled = false 
+      WHERE is_enabled = true 
+      RETURNING id
+    )
+    SELECT COUNT(*) FROM updated;
+  " 2>/dev/null | tr -d ' ' || echo "0")
+  if [ "$DEACTIVATED_COUNT" != "0" ] && [ "$DEACTIVATED_COUNT" != "" ]; then
+    echo "===> Deactivated $DEACTIVATED_COUNT cron job(s) in staging database"
+  else
+    SCHEMA_EXISTS=$(psql "$TARGET_DB_URL" -t -A -c "SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = 'scheduler');" 2>/dev/null | tr -d ' ' || echo "f")
+    if [ "$SCHEMA_EXISTS" = "t" ]; then
+      echo "===> No enabled cron jobs found to deactivate"
+    else
+      echo "===> Scheduler schema not found, skipping cron job deactivation"
+    fi
+  fi
+
+  echo "===> Dumping ada_ingestion from source"
+  pg_dump -Fc "$SOURCE_INGESTION_DB_URL" -f "$INGESTION_DUMP_PATH"
+  drop_and_create_db "$TARGET_INGESTION_DB_URL" "ada_ingestion"
+  echo "===> Restoring ada_ingestion"
+  pg_restore -d "$TARGET_INGESTION_DB_URL" --no-owner --no-privileges --single-transaction --verbose -Fc "$INGESTION_DUMP_PATH"
+
+  echo "===> Database sync completed"
+  return 0
+}
+
+sync_qdrant() {
+  if [ -z "$SOURCE_QDRANT_CLUSTER_URL" ] || [ -z "$SOURCE_QDRANT_API_KEY" ] || \
+     [ -z "$TARGET_QDRANT_CLUSTER_URL" ] || [ -z "$TARGET_QDRANT_API_KEY" ]; then
+    echo "===> Qdrant flags not fully set, skipping Qdrant sync"
+    return 0
+  fi
+
   echo "===> Syncing Qdrant collections"
   python scripts/copy_data/copy_qdrant_collections.py \
     --source-url="$SOURCE_QDRANT_CLUSTER_URL" \
@@ -149,9 +179,17 @@ if [ -n "$SOURCE_QDRANT_CLUSTER_URL" ] && [ -n "$SOURCE_QDRANT_API_KEY" ] && \
     --target-url="$TARGET_QDRANT_CLUSTER_URL" \
     --target-key="$TARGET_QDRANT_API_KEY" \
     --source-db-url="$SOURCE_DB_URL"
-else
-  echo "===> Qdrant flags not fully set, skipping Qdrant sync"
-fi
+  echo "===> Qdrant sync completed"
+  return 0
+}
 
-echo "===> Sync completed"
+if [ "$ONLY_QDRANT" = "1" ]; then
+  sync_qdrant
+elif [ "$SKIP_QDRANT" = "1" ]; then
+  sync_databases || true
+else
+  if sync_databases; then
+    sync_qdrant
+  fi
+fi
 


### PR DESCRIPTION
# Split prod-to-staging sync into separate DB and Qdrant steps

## Problem
The sync-prod-to-staging workflow runs DB dump/restore and Qdrant collection sync as a single Kubernetes job. As data has grown, the combined operation exceeds the 15-minute command_timeout on the SSH action step, causing the workflow to fail.

## Solution
Split the sync into two independent Kubernetes jobs, each with its own 15-minute timeout:

1. Sync databases (`db-sync-*`) — dumps and restores ada_backend + ada_ingestion, deactivates cron jobs
2. Sync Qdrant collections (`qdrant-sync-*`) — copies Qdrant collections from prod to staging
The Qdrant step checks the STATE_FILE and only runs if the DB step wrote `SYNCED` (skips on `SKIPPED` or `FAILED`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split the sync workflow into separate database and vector-store (Qdrant) steps so each can run and be tracked independently.

* **New Features**
  * Added modes to skip vector-store sync, run vector-store-only sync, or run both in sequence for finer operational control and clearer status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->