### PR TITLE
feat(tool): updategoogle agenda tool description dra-1213

### DIFF
--- a/engine/components/tools/google_calendar_mcp/client.py
+++ b/engine/components/tools/google_calendar_mcp/client.py
@@ -22,6 +22,16 @@ class GoogleCalendarClient:
             raise ValueError("access_token is required")
         creds = Credentials(token=access_token)
         self._service = build("calendar", "v3", credentials=creds)
+        self._user_email: str | None = None
+
+    async def get_user_email(self) -> str:
+        if self._user_email is None:
+            def _call():
+                cal = self._service.calendarList().get(calendarId="primary").execute()
+                return cal["id"]
+
+            self._user_email = await asyncio.to_thread(_call)
+        return self._user_email
 
     async def list_calendars(self) -> list[dict[str, Any]]:
         def _call():

--- a/engine/components/tools/google_calendar_mcp/server.py
+++ b/engine/components/tools/google_calendar_mcp/server.py
@@ -66,12 +66,24 @@ async def calendar_get_event(
 
 
 @mcp.tool(
+    name="calendar_get_my_email",
+    description="Return the email address of the authenticated calendar owner.",
+)
+async def calendar_get_my_email() -> dict[str, str]:
+    email = await _client.get_user_email()
+    return {"email": email}
+
+
+@mcp.tool(
     name="calendar_create_event",
     description=(
         "Create a new event on a Google Calendar. "
         "Provide start and end as RFC3339 datetime strings with timezone offset "
         "(e.g. '2026-03-20T10:00:00+01:00') or as date strings for all-day events. "
-        "To add a Google Meet link, include conferenceData with a createRequest."
+        "To add a Google Meet link, include conferenceData with a createRequest. "
+        "When adding attendees, don't forget to also add the calendar owner if they "
+        "should participate in the meeting, otherwise they won't appear as an attendee. "
+        "Use calendar_get_my_email to get the owner's email if needed."
     ),
 )
 async def calendar_create_event(

--- a/engine/components/tools/google_calendar_mcp_tool.py
+++ b/engine/components/tools/google_calendar_mcp_tool.py
@@ -15,6 +15,7 @@ _DEFAULT_TOOLS = {
     "calendar_list_calendars",
     "calendar_list_events",
     "calendar_get_event",
+    "calendar_get_my_email",
     "calendar_create_event",
     "calendar_update_event",
     "calendar_delete_event",

--- a/tests/components/test_google_calendar_mcp_tool.py
+++ b/tests/components/test_google_calendar_mcp_tool.py
@@ -1,15 +1,18 @@
 """
-Unit tests for GoogleCalendarMCPTool wrapper.
+Unit tests for GoogleCalendarMCPTool wrapper and server logic.
 
 These tests validate the wrapper layer (tool descriptions, env injection,
-missing-token guard) without hitting the real Google Calendar API.
+missing-token guard) and the MCP tool surface without hitting the real
+Google Calendar API.
 """
 
 import subprocess
 import sys
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from engine.components.tools.google_calendar_mcp import server as gcal_server
 from engine.components.tools.google_calendar_mcp_tool import (
     _DEFAULT_TOOLS,
     GoogleCalendarMCPTool,
@@ -90,3 +93,17 @@ class TestGoogleCalendarMCPToolRunGuard:
         inputs = MCPToolInputs(tool_name="calendar_list_calendars", tool_arguments={})
         with pytest.raises(ValueError, match="OAuth connection"):
             await tool._run_without_io_trace(inputs, ctx={})
+
+
+class TestCalendarGetMyEmail:
+    @pytest.mark.asyncio
+    async def test_returns_user_email(self):
+        mock_client = AsyncMock()
+        mock_client.get_user_email = AsyncMock(return_value="owner@example.com")
+        with patch.object(gcal_server, "_client", mock_client, create=True):
+            result = await gcal_server.calendar_get_my_email()
+        assert result == {"email": "owner@example.com"}
+
+    @pytest.mark.asyncio
+    async def test_get_my_email_in_default_tools(self):
+        assert "calendar_get_my_email" in _DEFAULT_TOOLS


### PR DESCRIPTION
# Add calendar_get_my_email tool and improve attendee guidance for Google Calendar

## Summary
- Added a new `calendar_get_my_email `MCP tool that returns the authenticated calendar owner's email address, so agents can look it up when building attendee lists.
- Updated the `calendar_create_event` tool description to remind the LLM to include the calendar owner as an attendee when they should participate, without forcing it for every event.
- Added `get_user_email()` method to `GoogleCalendarClient` with caching to avoid redundant API calls.

### Context
When a user asked their agent to "add a meeting with Marc to my agenda", the agent would create the event with only Marc as an attendee, leaving the calendar owner out of the meeting. Rather than silently injecting the owner server-side (which would break use cases like scheduling a meeting between other people), we expose the owner's email as a tool and guide the LLM via the tool description.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new tool to retrieve your primary calendar email address, simplifying event management workflows.

* **Documentation**
  * Enhanced the event creation tool description with guidance on properly adding the calendar owner when inviting attendees.

* **Tests**
  * Added tests to validate the new email retrieval functionality works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->