### PR TITLE
feat(tool): Fix missing email notifications dra-1214

### DIFF
--- a/engine/components/tools/google_calendar_mcp/client.py
+++ b/engine/components/tools/google_calendar_mcp/client.py
@@ -76,7 +76,7 @@ class GoogleCalendarClient:
         def _call():
             return (
                 self._service.events()
-                .insert(calendarId=calendar_id, body=event_body, conferenceDataVersion=1)
+                .insert(calendarId=calendar_id, body=event_body, conferenceDataVersion=1, sendUpdates="all")
                 .execute()
             )
 
@@ -88,7 +88,13 @@ class GoogleCalendarClient:
         def _call():
             return (
                 self._service.events()
-                .patch(calendarId=calendar_id, eventId=event_id, body=event_body, conferenceDataVersion=1)
+                .patch(
+                    calendarId=calendar_id,
+                    eventId=event_id,
+                    body=event_body,
+                    conferenceDataVersion=1,
+                    sendUpdates="all",
+                )
                 .execute()
             )
 
@@ -96,7 +102,7 @@ class GoogleCalendarClient:
 
     async def delete_event(self, event_id: str, calendar_id: str = "primary") -> dict[str, Any]:
         def _call():
-            self._service.events().delete(calendarId=calendar_id, eventId=event_id).execute()
+            self._service.events().delete(calendarId=calendar_id, eventId=event_id, sendUpdates="all").execute()
             return {"status": "deleted", "eventId": event_id}
 
         return await asyncio.to_thread(_call)

--- a/tests/components/test_google_calendar_mcp_tool.py
+++ b/tests/components/test_google_calendar_mcp_tool.py
@@ -8,11 +8,12 @@ Google Calendar API.
 
 import subprocess
 import sys
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from engine.components.tools.google_calendar_mcp import server as gcal_server
+from engine.components.tools.google_calendar_mcp.client import GoogleCalendarClient
 from engine.components.tools.google_calendar_mcp_tool import (
     _DEFAULT_TOOLS,
     GoogleCalendarMCPTool,
@@ -93,6 +94,47 @@ class TestGoogleCalendarMCPToolRunGuard:
         inputs = MCPToolInputs(tool_name="calendar_list_calendars", tool_arguments={})
         with pytest.raises(ValueError, match="OAuth connection"):
             await tool._run_without_io_trace(inputs, ctx={})
+
+
+class TestSendUpdatesParameter:
+    """Regression: mutating calls must pass sendUpdates='all' so attendees get email notifications."""
+
+    def _build_mock_service(self):
+        service = MagicMock()
+        events = MagicMock()
+        service.events.return_value = events
+        execute = MagicMock(return_value={"id": "evt123", "status": "confirmed"})
+        events.insert.return_value.execute = execute
+        events.patch.return_value.execute = execute
+        events.delete.return_value.execute = MagicMock()
+        return service, events
+
+    @pytest.mark.asyncio
+    async def test_create_event_sends_updates(self):
+        service, events = self._build_mock_service()
+        client = object.__new__(GoogleCalendarClient)
+        client._service = service
+        await client.create_event({"summary": "Test"})
+        events.insert.assert_called_once()
+        assert events.insert.call_args.kwargs["sendUpdates"] == "all"
+
+    @pytest.mark.asyncio
+    async def test_update_event_sends_updates(self):
+        service, events = self._build_mock_service()
+        client = object.__new__(GoogleCalendarClient)
+        client._service = service
+        await client.update_event("evt123", {"summary": "Updated"})
+        events.patch.assert_called_once()
+        assert events.patch.call_args.kwargs["sendUpdates"] == "all"
+
+    @pytest.mark.asyncio
+    async def test_delete_event_sends_updates(self):
+        service, events = self._build_mock_service()
+        client = object.__new__(GoogleCalendarClient)
+        client._service = service
+        await client.delete_event("evt123")
+        events.delete.assert_called_once()
+        assert events.delete.call_args.kwargs["sendUpdates"] == "all"
 
 
 class TestCalendarGetMyEmail:


### PR DESCRIPTION
# Fix missing email notifications for Google Calendar attendees

## Summary
- Attendees were not receiving email invitations when events were created, updated, or deleted via our Google Calendar MCP tool, unlike events created from the Google Calendar UI.
- Root cause: the Google Calendar API requires `sendUpdates="all"` as a query parameter on mutating calls (`insert`, `patch`, `delete`) to trigger attendee notifications. Our client was not passing it.
- Added `sendUpdates="all"` to `create_event`, `update_event`, and `delete_event` in `GoogleCalendarClient`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar event operations now send notifications to all event recipients when creating, updating, or deleting events.

* **Tests**
  * Added tests to verify notification behavior for create/update/delete calendar operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->