### PR TITLE
fix(webhook): wrap direct trigger payload in input_data dra-1220

### DIFF
--- a/tests/webhook_scripts/test_webhook_main.py
+++ b/tests/webhook_scripts/test_webhook_main.py
@@ -1,12 +1,21 @@
+from uuid import uuid4
+
 import pytest
 
 import webhook_scripts.webhook_main as webhook_main
 
 
 class DummyResponse:
-    def __init__(self, status_code: int):
+    def __init__(self, status_code: int, json_data=None):
         self.status_code = status_code
         self.request = object()
+        self._json_data = json_data or {}
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        pass
 
 
 class DummyClient:
@@ -56,3 +65,41 @@ async def test_post_maps_network_errors_to_retryable(monkeypatch):
 
     with pytest.raises(webhook_main.RetryableWebhookError):
         await webhook_main._post("http://x", {}, "k", "ctx")
+
+
+class CapturingClient:
+    """Records the kwargs passed to post() and returns a canned response."""
+
+    def __init__(self):
+        self.captured_kwargs: dict | None = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, **kwargs):
+        self.captured_kwargs = {"url": url, **kwargs}
+        return DummyResponse(status_code=202, json_data={"status": "accepted", "run_id": str(uuid4())})
+
+
+@pytest.mark.asyncio
+async def test_direct_trigger_wraps_payload_in_input_data(monkeypatch):
+    """Regression: _run_direct_trigger must send {"input_data": <payload>} not the raw payload."""
+    client = CapturingClient()
+    monkeypatch.setattr(webhook_main.httpx, "AsyncClient", lambda: client)
+    monkeypatch.setenv("ADA_URL", "http://test")
+    monkeypatch.setenv("WEBHOOK_API_KEY", "key")
+
+    user_payload = {"messages": [{"role": "user", "content": "hello"}]}
+    await webhook_main.webhook_main_async(
+        webhook_id=uuid4(),
+        provider="direct_trigger",
+        event_id="evt-1",
+        payload={**user_payload, "env": "production"},
+    )
+
+    body = client.captured_kwargs["json"]
+    assert "input_data" in body, "Body must wrap payload under 'input_data'"
+    assert body["input_data"] == user_payload

--- a/webhook_scripts/webhook_main.py
+++ b/webhook_scripts/webhook_main.py
@@ -157,7 +157,7 @@ async def _run_direct_trigger(
 
     await _post(
         url=url,
-        body=payload,
+        body={"input_data": payload},
         webhook_api_key=webhook_api_key,
         context="direct trigger",
         params=params,


### PR DESCRIPTION
# fix(webhook): wrap direct trigger payload in input_data for RunProjectBody

## Summary
- Fixes a 422 Unprocessable Entity error on the internal direct trigger endpoint (POST `/internal/webhooks/projects/{id}/envs/{env}/run) `introduced by #529.
- #529 changed the endpoint body from a flat Dict[str, Any] to `RunProjectBody` (which expects `{"input_data": {...}}`), but `webhook_main.py`'s _run_direct_trigger was still sending the raw payload without wrapping it.
- Adds a regression test verifying the body is correctly structured.
