### PR TITLE
fix(webhook): fail orphan runs on fatal errors dra-1222

### DIFF
--- a/ada_ingestion_system/worker/base_worker.py
+++ b/ada_ingestion_system/worker/base_worker.py
@@ -272,6 +272,7 @@ class BaseWorker:
                 logger.info("message_ack_fatal stream=%s message_id=%s", self.stream_name, message_id)
             except Exception as e:
                 logger.error("xack_failed stream=%s message_id=%s error=%s", self.stream_name, message_id, str(e))
+            self._on_fatal_ack(message_id, fields, reason=retry_reason)
             return
 
         delivery_count = self._get_delivery_count(message_id)
@@ -426,6 +427,11 @@ class BaseWorker:
     def _on_dead_letter(self, message_id: str, fields: Dict[str, str], reason: str = "") -> None:
         """Called when a message is dead-lettered.  Override in subclasses to
         mark the task as failed in the API, send alerts, etc."""
+        pass
+
+    def _on_fatal_ack(self, message_id: str, fields: Dict[str, str], reason: str = "") -> None:
+        """Called when a message is ACKed due to a fatal (non-retryable) failure.
+        Override in subclasses to mark the task as failed, send alerts, etc."""
         pass
 
     def _log_queued_task(self, payload: Dict[str, Any]) -> None:

--- a/ada_ingestion_system/worker/webhook_worker.py
+++ b/ada_ingestion_system/worker/webhook_worker.py
@@ -201,13 +201,13 @@ class WebhookWorker(BaseWorker):
             logger.error("webhook_processing_error error=%s", str(e), exc_info=True)
             return ProcessTaskOutcome.FAIL_RETRY
 
-    def _on_dead_letter(self, message_id: str, fields: Dict[str, str], reason: str = "") -> None:
-        """Mark the pre-created run as FAILED when a direct-trigger message is dead-lettered."""
+    def _fail_run(self, fields: Dict[str, str], error_message: str, error_type: str) -> None:
+        """Mark the pre-created run as FAILED via the internal API."""
         try:
             raw = fields.get("data", "")
             payload = json.loads(raw) if raw else {}
         except (json.JSONDecodeError, TypeError):
-            logger.error("dead_letter_unparseable message_id=%s", message_id)
+            logger.error("fail_run_unparseable_payload")
             return
 
         run_id = payload.get("run_id")
@@ -219,28 +219,37 @@ class WebhookWorker(BaseWorker):
         webhook_api_key = os.getenv("WEBHOOK_API_KEY", "")
 
         logger.error(
-            "dead_letter_failing_run run_id=%s project_id=%s event_id=%s reason=%s",
+            "failing_run run_id=%s project_id=%s event_id=%s error_type=%s",
             run_id,
             project_id,
             payload.get("event_id"),
-            reason,
+            error_type,
         )
 
         try:
             response = httpx.patch(
                 f"{api_base_url}/internal/webhooks/projects/{project_id}/runs/{run_id}/fail",
-                json={
-                    "error": {
-                        "message": f"Webhook processing failed after repeated crashes: {reason}",
-                        "type": "DeadLetter",
-                    }
-                },
+                json={"error": {"message": error_message, "type": error_type}},
                 headers={"X-Webhook-API-Key": webhook_api_key, "Content-Type": "application/json"},
                 timeout=10,
             )
             response.raise_for_status()
         except httpx.HTTPError as e:
-            logger.error("dead_letter_fail_run_request_failed run_id=%s error=%s", run_id, str(e))
+            logger.error("fail_run_request_failed run_id=%s error=%s", run_id, str(e))
+
+    def _on_dead_letter(self, message_id: str, fields: Dict[str, str], reason: str = "") -> None:
+        self._fail_run(
+            fields,
+            error_message=f"Webhook processing failed after repeated crashes: {reason}",
+            error_type="DeadLetter",
+        )
+
+    def _on_fatal_ack(self, message_id: str, fields: Dict[str, str], reason: str = "") -> None:
+        self._fail_run(
+            fields,
+            error_message=f"Webhook processing failed with non-retryable error: {reason}",
+            error_type="FatalError",
+        )
 
     def _log_queued_task(self, payload: Dict[str, Any]) -> None:
         """Log queued webhook task."""

--- a/tests/ada_ingestion_system/worker/test_base_worker.py
+++ b/tests/ada_ingestion_system/worker/test_base_worker.py
@@ -29,6 +29,7 @@ class DummyWorker(BaseWorker):
         self._return_raw = return_raw
         self.dead_letter_calls = []
         self.dead_letter_hook_calls = []
+        self.fatal_ack_hook_calls = []
 
     def get_required_fields(self) -> list[str]:
         return ["k"]
@@ -46,6 +47,9 @@ class DummyWorker(BaseWorker):
 
     def _on_dead_letter(self, message_id: str, fields: Dict[str, str], reason: str = "") -> None:
         self.dead_letter_hook_calls.append((message_id, fields, reason))
+
+    def _on_fatal_ack(self, message_id: str, fields: Dict[str, str], reason: str = "") -> None:
+        self.fatal_ack_hook_calls.append((message_id, fields, reason))
 
 
 class DummyRedis:
@@ -82,6 +86,19 @@ def test_fatal_acks_once(monkeypatch):
     worker._process_and_ack({"k": "v"}, "1-0", {"data": "{}"})
 
     assert redis.acks == [("stream", base_worker.CONSUMER_GROUP, "1-0")]
+
+
+def test_fatal_ack_calls_on_fatal_ack_hook(monkeypatch):
+    redis = DummyRedis()
+    monkeypatch.setattr(base_worker, "redis_client", redis)
+    worker = DummyWorker(outcome=ProcessTaskOutcome.FAIL_FATAL_ACK)
+    fields = {"data": '{"run_id": "abc"}'}
+
+    worker._process_and_ack({"k": "v"}, "1-0", fields)
+
+    assert len(worker.fatal_ack_hook_calls) == 1
+    assert worker.fatal_ack_hook_calls[0][0] == "1-0"
+    assert worker.fatal_ack_hook_calls[0][1] == fields
 
 
 def test_retry_under_threshold_does_not_ack(monkeypatch):

--- a/tests/ada_ingestion_system/worker/test_webhook_worker.py
+++ b/tests/ada_ingestion_system/worker/test_webhook_worker.py
@@ -1,5 +1,9 @@
+import json
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
 from ada_ingestion_system.worker.base_worker import ProcessTaskOutcome
-from ada_ingestion_system.worker.webhook_worker import _classify_script_failure
+from ada_ingestion_system.worker.webhook_worker import WebhookWorker, _classify_script_failure
 
 
 def test_classify_script_failure_fatal_marker():
@@ -23,3 +27,66 @@ def test_classify_script_failure_partial_marker():
 def test_classify_script_failure_both_markers_fatal_wins():
     output = "WEBHOOK_FAILURE_CLASS=fatal something WEBHOOK_FAILURE_CLASS=retry"
     assert _classify_script_failure(output) == ProcessTaskOutcome.FAIL_FATAL_ACK
+
+
+def _make_worker() -> WebhookWorker:
+    """Construct a WebhookWorker without connecting to Redis."""
+    with patch("ada_ingestion_system.worker.base_worker._xgroup_create_if_not_exists"):
+        return WebhookWorker()
+
+
+class TestFailRun:
+    def test_on_fatal_ack_calls_fail_endpoint(self, monkeypatch):
+        """_on_fatal_ack must PATCH the fail endpoint for direct-trigger runs."""
+        worker = _make_worker()
+        run_id = str(uuid4())
+        project_id = str(uuid4())
+        fields = {"data": json.dumps({"run_id": run_id, "webhook_id": project_id, "event_id": "evt-1"})}
+
+        monkeypatch.setenv("ADA_URL", "http://test")
+        monkeypatch.setenv("WEBHOOK_API_KEY", "key")
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("ada_ingestion_system.worker.webhook_worker.httpx.patch", return_value=mock_response) as mock_patch:
+            worker._on_fatal_ack("msg-1", fields, reason="422 Unprocessable Entity")
+
+        mock_patch.assert_called_once()
+        call_args = mock_patch.call_args
+        assert f"/runs/{run_id}/fail" in call_args[0][0]
+        body = call_args[1]["json"]
+        assert body["error"]["type"] == "FatalError"
+
+    def test_on_dead_letter_calls_fail_endpoint(self, monkeypatch):
+        """_on_dead_letter must PATCH the fail endpoint for direct-trigger runs."""
+        worker = _make_worker()
+        run_id = str(uuid4())
+        project_id = str(uuid4())
+        fields = {"data": json.dumps({"run_id": run_id, "webhook_id": project_id, "event_id": "evt-2"})}
+
+        monkeypatch.setenv("ADA_URL", "http://test")
+        monkeypatch.setenv("WEBHOOK_API_KEY", "key")
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("ada_ingestion_system.worker.webhook_worker.httpx.patch", return_value=mock_response) as mock_patch:
+            worker._on_dead_letter("msg-2", fields, reason="exceeded max attempts")
+
+        mock_patch.assert_called_once()
+        body = mock_patch.call_args[1]["json"]
+        assert body["error"]["type"] == "DeadLetter"
+
+    def test_fail_run_skipped_without_run_id(self, monkeypatch):
+        """Messages without run_id (provider webhooks) should not call the fail endpoint."""
+        worker = _make_worker()
+        fields = {"data": json.dumps({"webhook_id": str(uuid4()), "event_id": "evt-3"})}
+
+        monkeypatch.setenv("ADA_URL", "http://test")
+        monkeypatch.setenv("WEBHOOK_API_KEY", "key")
+
+        with patch("ada_ingestion_system.worker.webhook_worker.httpx.patch") as mock_patch:
+            worker._on_fatal_ack("msg-3", fields, reason="some error")
+
+        mock_patch.assert_not_called()


### PR DESCRIPTION
# fail orphan runs on fatal errors dra-1222
## Sumarry
- Adds a `_on_fatal_ack` hook to `BaseWorker` so that pre-created runs are marked FAILED when the webhook script exits with a non-retryable error (e.g. 422), instead of being left stuck in PENDING.
- Refactors `WebhookWorker` to share the fail-run logic between `_on_dead_letter` and `_on_fatal_ack`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of fatal webhook failures to ensure runs are properly marked as failed and tracked.
  * Enhanced error logging and notification when webhook operations encounter non-retryable failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->