### PR TITLE
feat(alerting): add email alerts for failed webhook/cron runs dra-1221

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -43,6 +43,10 @@ DAG of ComponentInstances connected via PortMappings. Data flows through FieldEx
 - Ingestion worker: Redis Stream consumer, separate process.
 - Scheduler: APScheduler + PostgreSQL job store, separate process. Registry-based cron types in `ada_backend/services/cron/`. See `ada_backend/services/cron/Readme.md`.
 
+### Run Failure Alerting
+
+`ada_backend/services/alerting/`: sends email alerts via Resend when webhook- or cron-triggered runs fail. Hooked into `update_run_status()` and `fail_pending_run()` in `run_service.py`. Fires in a background thread (non-blocking). Recipients configured per project in `project_alert_emails` table, managed via `GET/POST/DELETE /projects/{project_id}/alert-emails`. Requires `RESEND_API_KEY` + `RESEND_FROM_EMAIL`; silently no-ops when unconfigured.
+
 ### Analytics
 
 Mixpanel Python SDK (`mixpanel_analytics.py`). `non_breaking_track` decorator wraps every tracking function with try/except internally — never add try/except at call sites. Lazy init via `_refresh_client()` (thread-safe, re-checks settings on every call). Only active when `ENV == "production"` **and** `MIXPANEL_TOKEN` is set; otherwise all calls silently no-op (no errors). Events cover: identity, project/agent lifecycle, deployment, run completion, ingestion, cron, API keys, OAuth, and observability page views. New user-facing actions should get a corresponding `track_*` call in the **service layer** (not routers). Integration tests (`@pytest.mark.mixpanel`) hit the real Mixpanel API and run in CI only when `mixpanel_analytics.py` or `tests/ada_backend/test_mixpanel_analytics.py` changes.

--- a/ada_backend/database/alembic/versions/a1b2c3d4f6g8_add_project_alert_emails_table.py
+++ b/ada_backend/database/alembic/versions/a1b2c3d4f6g8_add_project_alert_emails_table.py
@@ -1,0 +1,39 @@
+"""add project_alert_emails table
+
+Revision ID: a1b2c3d4f6g8
+Revises: 4071a252013a
+Create Date: 2026-04-14 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "a1b2c3d4f6g8"
+down_revision: Union[str, None] = "4071a252013a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy = "migrate-first"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_alert_emails",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("project_id", "email", name="uq_project_alert_email"),
+    )
+    op.create_index("ix_project_alert_emails_project_id", "project_alert_emails", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_project_alert_emails_project_id", table_name="project_alert_emails")
+    op.drop_table("project_alert_emails")

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -211,8 +211,8 @@ class CronEntrypoint(StrEnum):
 
 
 class CronStatus(StrEnum):
-    QUEUED = "queued"      # dispatched (202 accepted), not yet executing
-    RUNNING = "running"    # background task is actively executing
+    QUEUED = "queued"  # dispatched (202 accepted), not yet executing
+    RUNNING = "running"  # background task is actively executing
     COMPLETED = "completed"
     ERROR = "error"
 
@@ -1445,6 +1445,7 @@ class Project(Base):
     usage = relationship("Usage", back_populates="project", cascade="all, delete-orphan")
 
     runs = relationship("Run", back_populates="project", cascade="all, delete-orphan")
+    alert_emails = relationship("ProjectAlertEmail", back_populates="project", cascade="all, delete-orphan")
 
     __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "base"}
 
@@ -1975,13 +1976,15 @@ class VersionOutput(Base):
     __table_args__ = (
         sa.Index(
             "uq_version_output_input_session",
-            "input_id", "qa_session_id",
+            "input_id",
+            "qa_session_id",
             unique=True,
             postgresql_where=sa.text("qa_session_id IS NOT NULL"),
         ),
         sa.Index(
             "uq_version_output_input_graph_runner_no_session",
-            "input_id", "graph_runner_id",
+            "input_id",
+            "graph_runner_id",
             unique=True,
             postgresql_where=sa.text("qa_session_id IS NULL"),
         ),
@@ -2089,9 +2092,7 @@ class QASession(Base):
     )
 
     id = mapped_column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
-    project_id = mapped_column(
-        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
-    )
+    project_id = mapped_column(UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
     dataset_id = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("quality_assurance.dataset_project.id", ondelete="CASCADE"),
@@ -2454,3 +2455,18 @@ class OrgVariableSet(Base):
         ),
         Index("ix_org_variable_sets_org_variable_type", "organization_id", "variable_type"),
     )
+
+
+class ProjectAlertEmail(Base):
+    __tablename__ = "project_alert_emails"
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    email = mapped_column(String, nullable=False)
+    created_at = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    project = relationship("Project", back_populates="alert_emails")
+
+    __table_args__ = (UniqueConstraint("project_id", "email", name="uq_project_alert_email"),)

--- a/ada_backend/docs/webhooks.md
+++ b/ada_backend/docs/webhooks.md
@@ -107,10 +107,31 @@ The worker maps these markers to processing outcomes and applies ACK policy acco
 
 `FilterExpression` supports nested AND/OR conditions with operators: `equals`, `contains`. Evaluated against the webhook payload JSON in `webhook_service.evaluate_filter()`.
 
+## Run Failure Alerting
+
+When a webhook- or cron-triggered run transitions to `FAILED`, an email alert is sent via the Resend API to configured recipients.
+
+### How it works
+
+1. `update_run_status()` and `fail_pending_run()` in `services/run_service.py` call `maybe_send_run_failure_alert()` when the new status is `FAILED`.
+2. The alert service checks the run's `trigger` — only `WEBHOOK` and `CRON` triggers fire alerts.
+3. It queries `project_alert_emails` for the project's configured recipient list.
+4. If recipients exist and `RESEND_API_KEY` + `RESEND_FROM_EMAIL` are set, it sends the email in a background thread (fire-and-forget).
+5. All exceptions are caught and logged — alerting never breaks run processing.
+
+### Configuration
+
+- **Settings**: `RESEND_API_KEY` (existing) and `RESEND_FROM_EMAIL` must both be set. If either is missing, alerting silently no-ops.
+- **Recipients**: Managed per project via the CRUD API at `GET/POST/DELETE /projects/{project_id}/alert-emails`.
+- **DB table**: `project_alert_emails` with unique constraint on `(project_id, email)`.
+
 ## Key Files
 
 - `routers/webhooks/provider_webhooks_router.py` — Aircall, Resend endpoints
 - `routers/webhooks/webhook_trigger_router.py` — user-triggered webhook
 - `routers/webhooks/webhook_internal_router.py` — worker-called endpoints
+- `routers/alert_email_router.py` — CRUD for alert email recipients
 - `services/webhooks/webhook_service.py` — execution, filtering, input preparation
+- `services/alerting/alert_service.py` — run failure alert logic
+- `services/alerting/email_service.py` — Resend email sending wrapper
 - `schemas/webhook_schema.py` — Pydantic schemas

--- a/ada_backend/main.py
+++ b/ada_backend/main.py
@@ -18,6 +18,7 @@ from ada_backend.middleware.rate_limit_middleware import rate_limit_exceeded_han
 from ada_backend.middleware.request_context import RequestContextMiddleware
 from ada_backend.routers.admin_tools_router import router as admin_tools_router
 from ada_backend.routers.agent_router import router as agent_router
+from ada_backend.routers.alert_email_router import router as alert_email_router
 from ada_backend.routers.auth_router import router as auth_router
 from ada_backend.routers.categories_router import router as categories_router
 from ada_backend.routers.component_version_router import router as component_version_router
@@ -272,6 +273,7 @@ app.include_router(provider_webhooks_router)
 app.include_router(webhook_internal_router)
 app.include_router(webhook_trigger_router)
 app.include_router(scheduler_internal_router)
+app.include_router(alert_email_router)
 
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)

--- a/ada_backend/repositories/alert_email_repository.py
+++ b/ada_backend/repositories/alert_email_repository.py
@@ -1,8 +1,10 @@
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ada_backend.database import models as db
+from ada_backend.services.errors import DuplicateAlertEmailError
 
 
 def list_alert_emails_by_project(session: Session, project_id: UUID) -> list[db.ProjectAlertEmail]:
@@ -15,11 +17,17 @@ def list_alert_emails_by_project(session: Session, project_id: UUID) -> list[db.
 
 
 def create_alert_email(session: Session, project_id: UUID, email: str) -> db.ProjectAlertEmail:
-    alert_email = db.ProjectAlertEmail(project_id=project_id, email=email)
-    session.add(alert_email)
-    session.commit()
-    session.refresh(alert_email)
-    return alert_email
+    try:
+        alert_email = db.ProjectAlertEmail(project_id=project_id, email=email)
+        session.add(alert_email)
+        session.commit()
+        session.refresh(alert_email)
+        return alert_email
+    except IntegrityError as exc:
+        session.rollback()
+        if hasattr(exc.orig, "diag") and getattr(exc.orig.diag, "constraint_name", None) == "uq_project_alert_email":
+            raise DuplicateAlertEmailError(email) from exc
+        raise
 
 
 def get_alert_email_by_id(session: Session, alert_email_id: UUID) -> db.ProjectAlertEmail | None:

--- a/ada_backend/repositories/alert_email_repository.py
+++ b/ada_backend/repositories/alert_email_repository.py
@@ -1,0 +1,35 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ada_backend.database import models as db
+
+
+def list_alert_emails_by_project(session: Session, project_id: UUID) -> list[db.ProjectAlertEmail]:
+    return (
+        session.query(db.ProjectAlertEmail)
+        .filter(db.ProjectAlertEmail.project_id == project_id)
+        .order_by(db.ProjectAlertEmail.created_at)
+        .all()
+    )
+
+
+def create_alert_email(session: Session, project_id: UUID, email: str) -> db.ProjectAlertEmail:
+    alert_email = db.ProjectAlertEmail(project_id=project_id, email=email)
+    session.add(alert_email)
+    session.commit()
+    session.refresh(alert_email)
+    return alert_email
+
+
+def get_alert_email_by_id(session: Session, alert_email_id: UUID) -> db.ProjectAlertEmail | None:
+    return session.query(db.ProjectAlertEmail).filter(db.ProjectAlertEmail.id == alert_email_id).first()
+
+
+def delete_alert_email(session: Session, alert_email_id: UUID) -> bool:
+    alert_email = get_alert_email_by_id(session, alert_email_id)
+    if not alert_email:
+        return False
+    session.delete(alert_email)
+    session.commit()
+    return True

--- a/ada_backend/routers/alert_email_router.py
+++ b/ada_backend/routers/alert_email_router.py
@@ -1,0 +1,51 @@
+from typing import Annotated, List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ada_backend.database.setup_db import get_db
+from ada_backend.routers.auth_router import UserRights, user_has_access_to_project_dependency
+from ada_backend.schemas.alert_email_schema import AlertEmailCreate, AlertEmailResponse
+from ada_backend.schemas.auth_schema import SupabaseUser
+from ada_backend.services import alert_email_service
+
+router = APIRouter(prefix="/projects/{project_id}/alert-emails", tags=["Alert Emails"])
+
+
+@router.get("", response_model=List[AlertEmailResponse])
+def list_alert_emails(
+    project_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+):
+    return alert_email_service.list_alert_emails_by_project_service(session, project_id)
+
+
+@router.post("", response_model=AlertEmailResponse, status_code=201)
+def create_alert_email(
+    project_id: UUID,
+    body: AlertEmailCreate,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+):
+    return alert_email_service.create_alert_email_service(session, project_id=project_id, email=body.email)
+
+
+@router.delete("/{alert_email_id}", status_code=204)
+def delete_alert_email(
+    project_id: UUID,
+    alert_email_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+):
+    alert_email_service.delete_alert_email_service(session, project_id, alert_email_id)

--- a/ada_backend/schemas/alert_email_schema.py
+++ b/ada_backend/schemas/alert_email_schema.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr
+
+
+class AlertEmailCreate(BaseModel):
+    email: EmailStr
+
+
+class AlertEmailResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    project_id: UUID
+    email: str
+    created_at: datetime

--- a/ada_backend/services/alert_email_service.py
+++ b/ada_backend/services/alert_email_service.py
@@ -1,11 +1,11 @@
 from uuid import UUID
 
 from fastapi import HTTPException
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ada_backend.database import models as db
 from ada_backend.repositories import alert_email_repository
+from ada_backend.services.errors import DuplicateAlertEmailError
 
 
 def list_alert_emails_by_project_service(session: Session, project_id: UUID) -> list[db.ProjectAlertEmail]:
@@ -15,8 +15,8 @@ def list_alert_emails_by_project_service(session: Session, project_id: UUID) -> 
 def create_alert_email_service(session: Session, project_id: UUID, email: str) -> db.ProjectAlertEmail:
     try:
         return alert_email_repository.create_alert_email(session, project_id=project_id, email=email)
-    except IntegrityError:
-        raise HTTPException(status_code=409, detail=f"Email {email} is already configured for this project")
+    except DuplicateAlertEmailError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
 
 
 def delete_alert_email_service(session: Session, project_id: UUID, alert_email_id: UUID) -> None:

--- a/ada_backend/services/alert_email_service.py
+++ b/ada_backend/services/alert_email_service.py
@@ -1,0 +1,26 @@
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ada_backend.database import models as db
+from ada_backend.repositories import alert_email_repository
+
+
+def list_alert_emails_by_project_service(session: Session, project_id: UUID) -> list[db.ProjectAlertEmail]:
+    return alert_email_repository.list_alert_emails_by_project(session, project_id)
+
+
+def create_alert_email_service(session: Session, project_id: UUID, email: str) -> db.ProjectAlertEmail:
+    try:
+        return alert_email_repository.create_alert_email(session, project_id=project_id, email=email)
+    except IntegrityError:
+        raise HTTPException(status_code=409, detail=f"Email {email} is already configured for this project")
+
+
+def delete_alert_email_service(session: Session, project_id: UUID, alert_email_id: UUID) -> None:
+    alert_email = alert_email_repository.get_alert_email_by_id(session, alert_email_id)
+    if not alert_email or alert_email.project_id != project_id:
+        raise HTTPException(status_code=404, detail="Alert email not found")
+    alert_email_repository.delete_alert_email(session, alert_email_id)

--- a/ada_backend/services/alerting/alert_service.py
+++ b/ada_backend/services/alerting/alert_service.py
@@ -1,3 +1,4 @@
+import html
 import logging
 import threading
 from datetime import datetime, timezone
@@ -29,13 +30,18 @@ def _build_alert_html(
 
     timestamp = (finished_at or datetime.now(timezone.utc)).strftime("%Y-%m-%d %H:%M:%S UTC")
 
+    safe_project = html.escape(project_name)
+    safe_trigger = html.escape(trigger)
+    safe_error_type = html.escape(error_type)
+    safe_error_message = html.escape(error_message)
+
     return f"""
     <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
         <h2 style="color: #dc2626;">Run Failed</h2>
         <table style="width: 100%; border-collapse: collapse;">
             <tr>
                 <td style="padding: 8px; font-weight: bold; color: #374151;">Project</td>
-                <td style="padding: 8px; color: #111827;">{project_name}</td>
+                <td style="padding: 8px; color: #111827;">{safe_project}</td>
             </tr>
             <tr style="background: #f9fafb;">
                 <td style="padding: 8px; font-weight: bold; color: #374151;">Run ID</td>
@@ -43,15 +49,15 @@ def _build_alert_html(
             </tr>
             <tr>
                 <td style="padding: 8px; font-weight: bold; color: #374151;">Trigger</td>
-                <td style="padding: 8px; color: #111827;">{trigger}</td>
+                <td style="padding: 8px; color: #111827;">{safe_trigger}</td>
             </tr>
             <tr style="background: #f9fafb;">
                 <td style="padding: 8px; font-weight: bold; color: #374151;">Error Type</td>
-                <td style="padding: 8px; color: #111827;">{error_type}</td>
+                <td style="padding: 8px; color: #111827;">{safe_error_type}</td>
             </tr>
             <tr>
                 <td style="padding: 8px; font-weight: bold; color: #374151;">Error</td>
-                <td style="padding: 8px; color: #dc2626;">{error_message}</td>
+                <td style="padding: 8px; color: #dc2626;">{safe_error_message}</td>
             </tr>
             <tr style="background: #f9fafb;">
                 <td style="padding: 8px; font-weight: bold; color: #374151;">Time</td>

--- a/ada_backend/services/alerting/alert_service.py
+++ b/ada_backend/services/alerting/alert_service.py
@@ -1,0 +1,120 @@
+import logging
+import threading
+from datetime import datetime, timezone
+from uuid import UUID
+
+from ada_backend.database.models import CallType, ProjectAlertEmail, Run
+from ada_backend.database.setup_db import get_db_session
+from ada_backend.repositories.project_repository import get_project
+from ada_backend.services.alerting.email_service import send_email
+from settings import settings
+
+LOGGER = logging.getLogger(__name__)
+
+_ALERT_TRIGGERS = frozenset({CallType.WEBHOOK, CallType.CRON})
+
+
+def _build_alert_html(
+    project_name: str,
+    run_id: UUID,
+    trigger: str,
+    error: dict | None,
+    finished_at: datetime | None,
+) -> str:
+    error_message = "Unknown error"
+    error_type = "Unknown"
+    if error:
+        error_message = error.get("message", "Unknown error")
+        error_type = error.get("type", "Unknown")
+
+    timestamp = (finished_at or datetime.now(timezone.utc)).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    return f"""
+    <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #dc2626;">Run Failed</h2>
+        <table style="width: 100%; border-collapse: collapse;">
+            <tr>
+                <td style="padding: 8px; font-weight: bold; color: #374151;">Project</td>
+                <td style="padding: 8px; color: #111827;">{project_name}</td>
+            </tr>
+            <tr style="background: #f9fafb;">
+                <td style="padding: 8px; font-weight: bold; color: #374151;">Run ID</td>
+                <td style="padding: 8px; color: #111827; font-family: monospace;">{run_id}</td>
+            </tr>
+            <tr>
+                <td style="padding: 8px; font-weight: bold; color: #374151;">Trigger</td>
+                <td style="padding: 8px; color: #111827;">{trigger}</td>
+            </tr>
+            <tr style="background: #f9fafb;">
+                <td style="padding: 8px; font-weight: bold; color: #374151;">Error Type</td>
+                <td style="padding: 8px; color: #111827;">{error_type}</td>
+            </tr>
+            <tr>
+                <td style="padding: 8px; font-weight: bold; color: #374151;">Error</td>
+                <td style="padding: 8px; color: #dc2626;">{error_message}</td>
+            </tr>
+            <tr style="background: #f9fafb;">
+                <td style="padding: 8px; font-weight: bold; color: #374151;">Time</td>
+                <td style="padding: 8px; color: #111827;">{timestamp}</td>
+            </tr>
+        </table>
+    </div>
+    """
+
+
+def _send_run_failure_alert(
+    run_id: UUID,
+    project_id: UUID,
+    trigger: CallType,
+    error: dict | None,
+    finished_at: datetime | None,
+) -> None:
+    try:
+        if not settings.RESEND_API_KEY or not settings.RESEND_FROM_EMAIL:
+            LOGGER.warning("Resend not configured (RESEND_API_KEY or RESEND_FROM_EMAIL missing), skipping alert")
+            return
+
+        trigger_value = trigger if isinstance(trigger, str) else trigger.value
+        if trigger_value not in {t.value for t in _ALERT_TRIGGERS}:
+            return
+
+        with get_db_session() as session:
+            recipients = (
+                session.query(ProjectAlertEmail.email).filter(ProjectAlertEmail.project_id == project_id).all()
+            )
+            if not recipients:
+                return
+            emails = [r.email for r in recipients]
+
+            project = get_project(session, project_id=project_id)
+            project_name = project.name if project else str(project_id)
+
+        subject = f"[Draft'n Run] Run failed — {project_name}"
+        html = _build_alert_html(
+            project_name=project_name,
+            run_id=run_id,
+            trigger=trigger_value,
+            error=error,
+            finished_at=finished_at,
+        )
+        send_email(to=emails, subject=subject, html=html)
+    except Exception:
+        LOGGER.exception("Failed to send run failure alert for run_id=%s", run_id)
+
+
+def maybe_send_run_failure_alert(
+    run: Run,
+    project_id: UUID,
+    error: dict | None = None,
+    finished_at: datetime | None = None,
+) -> None:
+    trigger = run.trigger if isinstance(run.trigger, CallType) else CallType(str(run.trigger))
+    if trigger not in _ALERT_TRIGGERS:
+        return
+
+    thread = threading.Thread(
+        target=_send_run_failure_alert,
+        args=(run.id, project_id, trigger, error, finished_at),
+        daemon=True,
+    )
+    thread.start()

--- a/ada_backend/services/alerting/email_service.py
+++ b/ada_backend/services/alerting/email_service.py
@@ -11,7 +11,6 @@ RESEND_SEND_URL = "https://api.resend.com/emails"
 
 def send_email(to: list[str], subject: str, html: str) -> None:
     if not settings.RESEND_API_KEY or not settings.RESEND_FROM_EMAIL:
-        LOGGER.warning("Resend not configured (RESEND_API_KEY or RESEND_FROM_EMAIL missing), skipping email")
         return
 
     try:

--- a/ada_backend/services/alerting/email_service.py
+++ b/ada_backend/services/alerting/email_service.py
@@ -1,0 +1,38 @@
+import logging
+
+import httpx
+
+from settings import settings
+
+LOGGER = logging.getLogger(__name__)
+
+RESEND_SEND_URL = "https://api.resend.com/emails"
+
+
+def send_email(to: list[str], subject: str, html: str) -> None:
+    if not settings.RESEND_API_KEY or not settings.RESEND_FROM_EMAIL:
+        LOGGER.warning("Resend not configured (RESEND_API_KEY or RESEND_FROM_EMAIL missing), skipping email")
+        return
+
+    try:
+        with httpx.Client(timeout=10) as client:
+            response = client.post(
+                RESEND_SEND_URL,
+                headers={
+                    "Authorization": f"Bearer {settings.RESEND_API_KEY}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "from": settings.RESEND_FROM_EMAIL,
+                    "to": to,
+                    "subject": subject,
+                    "html": html,
+                },
+            )
+            response.raise_for_status()
+    except httpx.HTTPStatusError:
+        LOGGER.exception("Resend API returned an error while sending alert email")
+    except httpx.RequestError:
+        LOGGER.exception("Network error while sending alert email via Resend")
+    except Exception:
+        LOGGER.exception("Unexpected error while sending alert email")

--- a/ada_backend/services/errors.py
+++ b/ada_backend/services/errors.py
@@ -353,3 +353,9 @@ class GraphConflictError(Exception):
             f"Graph {graph_runner_id} was modified by another client since you last fetched it. "
             "Refresh the graph and retry your changes."
         )
+
+
+class DuplicateAlertEmailError(Exception):
+    def __init__(self, email: str):
+        self.email = email
+        super().__init__(f"Email {email} is already configured for this project")

--- a/ada_backend/services/run_service.py
+++ b/ada_backend/services/run_service.py
@@ -15,6 +15,7 @@ from ada_backend.repositories.project_repository import get_project
 from ada_backend.repositories.run_input_repository import get_run_input
 from ada_backend.schemas.project_schema import ChatResponse
 from ada_backend.schemas.run_schema import AsyncRunAcceptedSchema, RunResponseSchema
+from ada_backend.services.alerting.alert_service import maybe_send_run_failure_alert
 from ada_backend.services.errors import (
     InvalidRunStatusTransition,
     ProjectNotFound,
@@ -301,11 +302,12 @@ def fail_pending_run(
     error: dict,
     project_id: UUID | None = None,
 ) -> RunResponseSchema:
+    finished_at = datetime.now(timezone.utc)
     updated = run_repository.fail_run_if_pending(
         session,
         run_id=run_id,
         error=error,
-        finished_at=datetime.now(timezone.utc),
+        finished_at=finished_at,
         project_id=project_id,
     )
     if updated is None:
@@ -316,6 +318,7 @@ def fail_pending_run(
             raise RunNotFound(run_id)
         current = run.status if isinstance(run.status, RunStatus) else RunStatus(str(run.status))
         raise InvalidRunStatusTransition(current.value, RunStatus.FAILED.value)
+    maybe_send_run_failure_alert(updated, updated.project_id, error=error, finished_at=finished_at)
     return RunResponseSchema.model_validate(updated, from_attributes=True)
 
 
@@ -354,6 +357,8 @@ def update_run_status(
         started_at=started_at,
         finished_at=finished_at,
     )
+    if status == RunStatus.FAILED:
+        maybe_send_run_failure_alert(run, project_id, error=error, finished_at=finished_at)
     return RunResponseSchema.model_validate(updated, from_attributes=True)
 
 

--- a/credentials.env.example
+++ b/credentials.env.example
@@ -191,6 +191,7 @@ NANGO_PUBLIC_SERVER_URL=https://<id>.ngrok-free.app
 
 # Resend
 RESEND_API_KEY = XXX
+RESEND_FROM_EMAIL = alerts@yourdomain.com
 
 # setup for mcp local hitting prod
 MCP_BASE_URL=http://0.0.0.0:8090

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -93,6 +93,7 @@ All domain content lives in `docs.py` (single source of truth).
 | Monitoring | 5 | Traces, charts, KPIs, credits |
 | Crons | 9 | Create, pause/resume, manual trigger, execution history |
 | OAuth | 3 | List, check status, revoke |
+| Alert Emails | 3 | `list_alert_emails`, `add_alert_email`, `remove_alert_email` — per-project run failure recipients |
 | **Docs** | **1** | **`get_guide(domain)` — fallback for domain docs** |
 
 `get_project_overview(project_id)` is the default orientation tool for any version-aware work. It returns the editable draft runner, current production runner, production-only capability hints, warnings, and safe next steps.

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -93,7 +93,7 @@ All domain content lives in `docs.py` (single source of truth).
 | Monitoring | 5 | Traces, charts, KPIs, credits |
 | Crons | 9 | Create, pause/resume, manual trigger, execution history |
 | OAuth | 3 | List, check status, revoke |
-| Alert Emails | 3 | `list_alert_emails`, `add_alert_email`, `remove_alert_email` — per-project run failure recipients |
+| Alert Emails | 3 | `list_alert_emails`, `create_alert_email`, `delete_alert_email` — per-project run failure recipients (developer+) |
 | **Docs** | **1** | **`get_guide(domain)` — fallback for domain docs** |
 
 `get_project_overview(project_id)` is the default orientation tool for any version-aware work. It returns the editable draft runner, current production runner, production-only capability hints, warnings, and safe next steps.

--- a/mcp_server/docs.py
+++ b/mcp_server/docs.py
@@ -1710,8 +1710,8 @@ read/revoke operations only; the actual connect flow happens in the web UI.
 Per-project email alerts sent via Resend when a webhook- or cron-triggered run fails:
 
 - `list_alert_emails(project_id)` → list configured recipient emails
-- `add_alert_email(project_id, email)` → add a recipient (duplicate emails rejected with 409)
-- `remove_alert_email(project_id, alert_email_id)` → remove a recipient
+- `create_alert_email(project_id, email)` → add a recipient (409 on duplicates). Developer+.
+- `delete_alert_email(project_id, alert_email_id)` → remove a recipient. Developer+.
 
 Alerts require `RESEND_API_KEY` and `RESEND_FROM_EMAIL` to be configured on the backend. \
 If either is missing, alerting silently no-ops. Only runs triggered by webhooks or crons fire alerts \

--- a/mcp_server/docs.py
+++ b/mcp_server/docs.py
@@ -1705,6 +1705,18 @@ OAuth integrations (Slack, Gmail, HubSpot) must be set up in the web UI. Require
 Always ask the user before guiding OAuth setup or revoking an existing connection. MCP exposes \
 read/revoke operations only; the actual connect flow happens in the web UI.
 
+## Alert Emails
+
+Per-project email alerts sent via Resend when a webhook- or cron-triggered run fails:
+
+- `list_alert_emails(project_id)` → list configured recipient emails
+- `add_alert_email(project_id, email)` → add a recipient (duplicate emails rejected with 409)
+- `remove_alert_email(project_id, alert_email_id)` → remove a recipient
+
+Alerts require `RESEND_API_KEY` and `RESEND_FROM_EMAIL` to be configured on the backend. \
+If either is missing, alerting silently no-ops. Only runs triggered by webhooks or crons fire alerts \
+(API/sandbox/QA runs do not).
+
 ## Monitoring
 
 - `list_traces(project_id, duration=30)` → recent traces (duration in days, 1–90). \
@@ -1747,7 +1759,7 @@ DOMAIN_DESCRIPTIONS: dict[str, str] = {
     "integrations": "Function-callable tools, OAuth lifecycle, integration-backed components",
     "known-quirks": "Backend/MCP caveats that require explicit workarounds",
     "qa": "QA datasets, judges, evaluations",
-    "admin": "API keys, crons, OAuth, monitoring",
+    "admin": "API keys, crons, OAuth, monitoring, alert emails",
 }
 
 

--- a/mcp_server/tools/__init__.py
+++ b/mcp_server/tools/__init__.py
@@ -9,6 +9,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     from mcp_server.tools import (
         agent_config,
         agents,
+        alert_emails,
         api_keys,
         components,
         context_tools,
@@ -38,6 +39,7 @@ def register_all_tools(mcp: FastMCP) -> None:
         monitoring,
         crons,
         oauth_connections,
+        alert_emails,
     ]
     for module in modules:
         try:

--- a/mcp_server/tools/alert_emails.py
+++ b/mcp_server/tools/alert_emails.py
@@ -10,7 +10,7 @@ _PROJECT_ID = Param(
     "project_id", UUID, description="The project ID (from list_projects or get_project_overview)."
 )
 _ALERT_EMAIL_ID = Param(
-    "alert_email_id", UUID, description="The alert email ID to remove (from list_alert_emails)."
+    "alert_email_id", UUID, description="The alert email ID to delete (from list_alert_emails)."
 )
 _EMAIL = Param("email", str, description="Email address to receive run failure alerts.")
 
@@ -27,7 +27,7 @@ SPECS: list[ToolSpec] = [
         return_annotation=list,
     ),
     ToolSpec(
-        name="add_alert_email",
+        name="create_alert_email",
         description=(
             "Add an email address to receive run failure alerts for a project. "
             "Alerts are sent via Resend when a webhook- or cron-triggered run fails. "
@@ -37,13 +37,17 @@ SPECS: list[ToolSpec] = [
         path="/projects/{project_id}/alert-emails",
         path_params=(_PROJECT_ID,),
         body_fields=(_EMAIL,),
+        scope="role",
+        roles=("developer", "admin", "super_admin"),
     ),
     ToolSpec(
-        name="remove_alert_email",
+        name="delete_alert_email",
         description="Remove an email address from a project's run failure alert recipients.",
         method="delete",
         path="/projects/{project_id}/alert-emails/{alert_email_id}",
         path_params=(_PROJECT_ID, _ALERT_EMAIL_ID),
+        scope="role",
+        roles=("developer", "admin", "super_admin"),
     ),
 ]
 

--- a/mcp_server/tools/alert_emails.py
+++ b/mcp_server/tools/alert_emails.py
@@ -1,0 +1,52 @@
+"""Alert email management tools — configure per-project run failure email recipients."""
+
+from uuid import UUID
+
+from fastmcp import FastMCP
+
+from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
+
+_PROJECT_ID = Param(
+    "project_id", UUID, description="The project ID (from list_projects or get_project_overview)."
+)
+_ALERT_EMAIL_ID = Param(
+    "alert_email_id", UUID, description="The alert email ID to remove (from list_alert_emails)."
+)
+_EMAIL = Param("email", str, description="Email address to receive run failure alerts.")
+
+SPECS: list[ToolSpec] = [
+    ToolSpec(
+        name="list_alert_emails",
+        description=(
+            "List email addresses configured to receive run failure alerts for a project. "
+            "Alerts fire when a webhook- or cron-triggered run fails."
+        ),
+        method="get",
+        path="/projects/{project_id}/alert-emails",
+        path_params=(_PROJECT_ID,),
+        return_annotation=list,
+    ),
+    ToolSpec(
+        name="add_alert_email",
+        description=(
+            "Add an email address to receive run failure alerts for a project. "
+            "Alerts are sent via Resend when a webhook- or cron-triggered run fails. "
+            "Duplicate emails are rejected (409)."
+        ),
+        method="post",
+        path="/projects/{project_id}/alert-emails",
+        path_params=(_PROJECT_ID,),
+        body_fields=(_EMAIL,),
+    ),
+    ToolSpec(
+        name="remove_alert_email",
+        description="Remove an email address from a project's run failure alert recipients.",
+        method="delete",
+        path="/projects/{project_id}/alert-emails/{alert_email_id}",
+        path_params=(_PROJECT_ID, _ALERT_EMAIL_ID),
+    ),
+]
+
+
+def register(mcp: FastMCP) -> None:
+    register_proxy_tools(mcp, SPECS)

--- a/settings.py
+++ b/settings.py
@@ -60,6 +60,7 @@ class BaseConfig(BaseSettings):
     E2B_API_KEY: Optional[str] = None
     FIRECRAWL_API_KEY: Optional[str] = None
     RESEND_API_KEY: Optional[str] = None
+    RESEND_FROM_EMAIL: Optional[str] = None
 
     MIXPANEL_TOKEN: Optional[str] = None
     ENV: Optional[str] = None

--- a/tests/ada_backend/services/test_alert_email_service.py
+++ b/tests/ada_backend/services/test_alert_email_service.py
@@ -3,17 +3,11 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
-from sqlalchemy.exc import IntegrityError
 
 from ada_backend.services.alert_email_service import create_alert_email_service
+from ada_backend.services.errors import DuplicateAlertEmailError
 
 MODULE = "ada_backend.services.alert_email_service"
-
-
-def _make_integrity_error(constraint_name: str) -> IntegrityError:
-    orig = MagicMock()
-    orig.diag.constraint_name = constraint_name
-    return IntegrityError("INSERT ...", {}, orig)
 
 
 class TestCreateAlertEmailService:
@@ -26,37 +20,14 @@ class TestCreateAlertEmailService:
         result = create_alert_email_service(session, uuid4(), "a@b.com")
 
         assert result is expected
-        session.rollback.assert_not_called()
 
     @patch(f"{MODULE}.alert_email_repository")
-    def test_returns_409_on_duplicate_email_constraint(self, mock_repo):
+    def test_returns_409_on_duplicate_email(self, mock_repo):
         session = MagicMock()
-        mock_repo.create_alert_email.side_effect = _make_integrity_error("uq_project_alert_email")
+        mock_repo.create_alert_email.side_effect = DuplicateAlertEmailError("dup@test.com")
 
         with pytest.raises(HTTPException) as exc_info:
             create_alert_email_service(session, uuid4(), "dup@test.com")
 
         assert exc_info.value.status_code == 409
         assert "dup@test.com" in exc_info.value.detail
-        session.rollback.assert_called_once()
-
-    @patch(f"{MODULE}.alert_email_repository")
-    def test_reraises_unrelated_integrity_error(self, mock_repo):
-        session = MagicMock()
-        mock_repo.create_alert_email.side_effect = _make_integrity_error("some_other_constraint")
-
-        with pytest.raises(IntegrityError):
-            create_alert_email_service(session, uuid4(), "a@b.com")
-
-        session.rollback.assert_called_once()
-
-    @patch(f"{MODULE}.alert_email_repository")
-    def test_reraises_integrity_error_without_diag(self, mock_repo):
-        session = MagicMock()
-        orig = Exception("raw db error")
-        mock_repo.create_alert_email.side_effect = IntegrityError("INSERT ...", {}, orig)
-
-        with pytest.raises(IntegrityError):
-            create_alert_email_service(session, uuid4(), "a@b.com")
-
-        session.rollback.assert_called_once()

--- a/tests/ada_backend/services/test_alert_email_service.py
+++ b/tests/ada_backend/services/test_alert_email_service.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+
+from ada_backend.services.alert_email_service import create_alert_email_service
+
+MODULE = "ada_backend.services.alert_email_service"
+
+
+def _make_integrity_error(constraint_name: str) -> IntegrityError:
+    orig = MagicMock()
+    orig.diag.constraint_name = constraint_name
+    return IntegrityError("INSERT ...", {}, orig)
+
+
+class TestCreateAlertEmailService:
+    @patch(f"{MODULE}.alert_email_repository")
+    def test_returns_created_email(self, mock_repo):
+        session = MagicMock()
+        expected = MagicMock()
+        mock_repo.create_alert_email.return_value = expected
+
+        result = create_alert_email_service(session, uuid4(), "a@b.com")
+
+        assert result is expected
+        session.rollback.assert_not_called()
+
+    @patch(f"{MODULE}.alert_email_repository")
+    def test_returns_409_on_duplicate_email_constraint(self, mock_repo):
+        session = MagicMock()
+        mock_repo.create_alert_email.side_effect = _make_integrity_error("uq_project_alert_email")
+
+        with pytest.raises(HTTPException) as exc_info:
+            create_alert_email_service(session, uuid4(), "dup@test.com")
+
+        assert exc_info.value.status_code == 409
+        assert "dup@test.com" in exc_info.value.detail
+        session.rollback.assert_called_once()
+
+    @patch(f"{MODULE}.alert_email_repository")
+    def test_reraises_unrelated_integrity_error(self, mock_repo):
+        session = MagicMock()
+        mock_repo.create_alert_email.side_effect = _make_integrity_error("some_other_constraint")
+
+        with pytest.raises(IntegrityError):
+            create_alert_email_service(session, uuid4(), "a@b.com")
+
+        session.rollback.assert_called_once()
+
+    @patch(f"{MODULE}.alert_email_repository")
+    def test_reraises_integrity_error_without_diag(self, mock_repo):
+        session = MagicMock()
+        orig = Exception("raw db error")
+        mock_repo.create_alert_email.side_effect = IntegrityError("INSERT ...", {}, orig)
+
+        with pytest.raises(IntegrityError):
+            create_alert_email_service(session, uuid4(), "a@b.com")
+
+        session.rollback.assert_called_once()

--- a/tests/ada_backend/services/test_alerting.py
+++ b/tests/ada_backend/services/test_alerting.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from ada_backend.database.models import CallType, RunStatus
+from ada_backend.services.alerting.alert_service import _build_alert_html
 
 EMAIL_SERVICE_MODULE = "ada_backend.services.alerting.email_service"
 ALERT_SERVICE_MODULE = "ada_backend.services.alerting.alert_service"
@@ -17,6 +18,20 @@ def _make_fake_run(trigger=CallType.WEBHOOK, project_id=None):
     run.error = {"message": "timeout", "type": "TimeoutError"}
     run.finished_at = datetime.now(timezone.utc)
     return run
+
+
+class TestBuildAlertHtml:
+    def test_escapes_html_in_user_controlled_fields(self):
+        xss_payload = '<script>alert("xss")</script>'
+        result = _build_alert_html(
+            project_name=xss_payload,
+            run_id=uuid4(),
+            trigger=xss_payload,
+            error={"message": xss_payload, "type": xss_payload},
+            finished_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
 
 
 class TestSendEmail:

--- a/tests/ada_backend/services/test_alerting.py
+++ b/tests/ada_backend/services/test_alerting.py
@@ -1,0 +1,286 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from ada_backend.database.models import CallType, RunStatus
+
+EMAIL_SERVICE_MODULE = "ada_backend.services.alerting.email_service"
+ALERT_SERVICE_MODULE = "ada_backend.services.alerting.alert_service"
+
+
+def _make_fake_run(trigger=CallType.WEBHOOK, project_id=None):
+    run = MagicMock()
+    run.id = uuid4()
+    run.project_id = project_id or uuid4()
+    run.trigger = trigger
+    run.status = RunStatus.FAILED
+    run.error = {"message": "timeout", "type": "TimeoutError"}
+    run.finished_at = datetime.now(timezone.utc)
+    return run
+
+
+class TestSendEmail:
+    @patch(f"{EMAIL_SERVICE_MODULE}.settings")
+    @patch(f"{EMAIL_SERVICE_MODULE}.httpx")
+    def test_sends_email_via_resend(self, mock_httpx, mock_settings):
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.RESEND_FROM_EMAIL = "alerts@test.com"
+
+        mock_client = MagicMock()
+        mock_httpx.Client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_httpx.Client.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value.raise_for_status = MagicMock()
+
+        from ada_backend.services.alerting.email_service import send_email
+
+        send_email(to=["user@test.com"], subject="Test", html="<p>Test</p>")
+
+        mock_client.post.assert_called_once()
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs.kwargs["json"]["to"] == ["user@test.com"]
+        assert call_kwargs.kwargs["json"]["subject"] == "Test"
+
+    @patch(f"{EMAIL_SERVICE_MODULE}.settings")
+    def test_noop_when_api_key_missing(self, mock_settings):
+        mock_settings.RESEND_API_KEY = None
+        mock_settings.RESEND_FROM_EMAIL = "alerts@test.com"
+
+        from ada_backend.services.alerting.email_service import send_email
+
+        send_email(to=["user@test.com"], subject="Test", html="<p>Test</p>")
+
+    @patch(f"{EMAIL_SERVICE_MODULE}.settings")
+    def test_noop_when_from_email_missing(self, mock_settings):
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.RESEND_FROM_EMAIL = None
+
+        from ada_backend.services.alerting.email_service import send_email
+
+        send_email(to=["user@test.com"], subject="Test", html="<p>Test</p>")
+
+    @patch(f"{EMAIL_SERVICE_MODULE}.settings")
+    @patch(f"{EMAIL_SERVICE_MODULE}.httpx")
+    def test_does_not_raise_on_http_error(self, mock_httpx, mock_settings):
+        import httpx as real_httpx
+
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.RESEND_FROM_EMAIL = "alerts@test.com"
+
+        mock_client = MagicMock()
+        mock_httpx.Client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_httpx.Client.return_value.__exit__ = MagicMock(return_value=False)
+        mock_httpx.HTTPStatusError = real_httpx.HTTPStatusError
+        mock_client.post.return_value.raise_for_status.side_effect = real_httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=MagicMock()
+        )
+
+        from ada_backend.services.alerting.email_service import send_email
+
+        send_email(to=["user@test.com"], subject="Test", html="<p>Test</p>")
+
+
+class TestSendRunFailureAlert:
+    @patch(f"{ALERT_SERVICE_MODULE}.send_email")
+    @patch(f"{ALERT_SERVICE_MODULE}.get_db_session")
+    @patch(f"{ALERT_SERVICE_MODULE}.settings")
+    def test_sends_alert_for_webhook_trigger(self, mock_settings, mock_get_db, mock_send_email):
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.RESEND_FROM_EMAIL = "alerts@test.com"
+
+        project_id = uuid4()
+        session = MagicMock()
+        mock_get_db.return_value.__enter__ = MagicMock(return_value=session)
+        mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_recipient = MagicMock()
+        mock_recipient.email = "dev@test.com"
+        session.query.return_value.filter.return_value.all.return_value = [mock_recipient]
+
+        mock_project = MagicMock()
+        mock_project.name = "My Agent"
+
+        with patch(f"{ALERT_SERVICE_MODULE}.get_project", return_value=mock_project):
+            from ada_backend.services.alerting.alert_service import _send_run_failure_alert
+
+            _send_run_failure_alert(
+                run_id=uuid4(),
+                project_id=project_id,
+                trigger=CallType.WEBHOOK,
+                error={"message": "timeout", "type": "TimeoutError"},
+                finished_at=datetime.now(timezone.utc),
+            )
+
+        mock_send_email.assert_called_once()
+        call_kwargs = mock_send_email.call_args
+        assert call_kwargs.kwargs["to"] == ["dev@test.com"]
+        assert "My Agent" in call_kwargs.kwargs["subject"]
+
+    @patch(f"{ALERT_SERVICE_MODULE}.send_email")
+    @patch(f"{ALERT_SERVICE_MODULE}.get_db_session")
+    @patch(f"{ALERT_SERVICE_MODULE}.settings")
+    def test_sends_alert_for_cron_trigger(self, mock_settings, mock_get_db, mock_send_email):
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.RESEND_FROM_EMAIL = "alerts@test.com"
+
+        session = MagicMock()
+        mock_get_db.return_value.__enter__ = MagicMock(return_value=session)
+        mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_recipient = MagicMock()
+        mock_recipient.email = "ops@test.com"
+        session.query.return_value.filter.return_value.all.return_value = [mock_recipient]
+
+        mock_project = MagicMock()
+        mock_project.name = "Cron Agent"
+
+        with patch(f"{ALERT_SERVICE_MODULE}.get_project", return_value=mock_project):
+            from ada_backend.services.alerting.alert_service import _send_run_failure_alert
+
+            _send_run_failure_alert(
+                run_id=uuid4(),
+                project_id=uuid4(),
+                trigger=CallType.CRON,
+                error={"message": "crash", "type": "RuntimeError"},
+                finished_at=datetime.now(timezone.utc),
+            )
+
+        mock_send_email.assert_called_once()
+
+    @patch(f"{ALERT_SERVICE_MODULE}.send_email")
+    @patch(f"{ALERT_SERVICE_MODULE}.settings")
+    def test_skips_api_trigger(self, mock_settings, mock_send_email):
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.RESEND_FROM_EMAIL = "alerts@test.com"
+
+        from ada_backend.services.alerting.alert_service import _send_run_failure_alert
+
+        _send_run_failure_alert(
+            run_id=uuid4(),
+            project_id=uuid4(),
+            trigger=CallType.API,
+            error={"message": "err", "type": "Error"},
+            finished_at=datetime.now(timezone.utc),
+        )
+
+        mock_send_email.assert_not_called()
+
+    @patch(f"{ALERT_SERVICE_MODULE}.send_email")
+    @patch(f"{ALERT_SERVICE_MODULE}.settings")
+    def test_skips_sandbox_trigger(self, mock_settings, mock_send_email):
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.RESEND_FROM_EMAIL = "alerts@test.com"
+
+        from ada_backend.services.alerting.alert_service import _send_run_failure_alert
+
+        _send_run_failure_alert(
+            run_id=uuid4(),
+            project_id=uuid4(),
+            trigger=CallType.SANDBOX,
+            error={"message": "err", "type": "Error"},
+            finished_at=datetime.now(timezone.utc),
+        )
+
+        mock_send_email.assert_not_called()
+
+    @patch(f"{ALERT_SERVICE_MODULE}.send_email")
+    @patch(f"{ALERT_SERVICE_MODULE}.get_db_session")
+    @patch(f"{ALERT_SERVICE_MODULE}.settings")
+    def test_skips_when_no_recipients(self, mock_settings, mock_get_db, mock_send_email):
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.RESEND_FROM_EMAIL = "alerts@test.com"
+
+        session = MagicMock()
+        mock_get_db.return_value.__enter__ = MagicMock(return_value=session)
+        mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
+        session.query.return_value.filter.return_value.all.return_value = []
+
+        from ada_backend.services.alerting.alert_service import _send_run_failure_alert
+
+        _send_run_failure_alert(
+            run_id=uuid4(),
+            project_id=uuid4(),
+            trigger=CallType.WEBHOOK,
+            error={"message": "err", "type": "Error"},
+            finished_at=datetime.now(timezone.utc),
+        )
+
+        mock_send_email.assert_not_called()
+
+    @patch(f"{ALERT_SERVICE_MODULE}.settings")
+    def test_skips_when_resend_not_configured(self, mock_settings):
+        mock_settings.RESEND_API_KEY = None
+        mock_settings.RESEND_FROM_EMAIL = None
+
+        from ada_backend.services.alerting.alert_service import _send_run_failure_alert
+
+        _send_run_failure_alert(
+            run_id=uuid4(),
+            project_id=uuid4(),
+            trigger=CallType.WEBHOOK,
+            error={"message": "err", "type": "Error"},
+            finished_at=datetime.now(timezone.utc),
+        )
+
+    @patch(f"{ALERT_SERVICE_MODULE}.send_email")
+    @patch(f"{ALERT_SERVICE_MODULE}.get_db_session")
+    @patch(f"{ALERT_SERVICE_MODULE}.settings")
+    def test_does_not_raise_on_exception(self, mock_settings, mock_get_db, mock_send_email):
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.RESEND_FROM_EMAIL = "alerts@test.com"
+
+        mock_get_db.return_value.__enter__ = MagicMock(side_effect=Exception("db error"))
+
+        from ada_backend.services.alerting.alert_service import _send_run_failure_alert
+
+        _send_run_failure_alert(
+            run_id=uuid4(),
+            project_id=uuid4(),
+            trigger=CallType.WEBHOOK,
+            error={"message": "err", "type": "Error"},
+            finished_at=datetime.now(timezone.utc),
+        )
+
+        mock_send_email.assert_not_called()
+
+
+class TestMaybeSendRunFailureAlert:
+    @patch(f"{ALERT_SERVICE_MODULE}.threading")
+    def test_spawns_thread_for_webhook_trigger(self, mock_threading):
+        run = _make_fake_run(trigger=CallType.WEBHOOK)
+
+        from ada_backend.services.alerting.alert_service import maybe_send_run_failure_alert
+
+        maybe_send_run_failure_alert(run, run.project_id, error=run.error)
+
+        mock_threading.Thread.assert_called_once()
+        mock_threading.Thread.return_value.start.assert_called_once()
+
+    @patch(f"{ALERT_SERVICE_MODULE}.threading")
+    def test_spawns_thread_for_cron_trigger(self, mock_threading):
+        run = _make_fake_run(trigger=CallType.CRON)
+
+        from ada_backend.services.alerting.alert_service import maybe_send_run_failure_alert
+
+        maybe_send_run_failure_alert(run, run.project_id, error=run.error)
+
+        mock_threading.Thread.assert_called_once()
+
+    @patch(f"{ALERT_SERVICE_MODULE}.threading")
+    def test_skips_thread_for_api_trigger(self, mock_threading):
+        run = _make_fake_run(trigger=CallType.API)
+
+        from ada_backend.services.alerting.alert_service import maybe_send_run_failure_alert
+
+        maybe_send_run_failure_alert(run, run.project_id, error=run.error)
+
+        mock_threading.Thread.assert_not_called()
+
+    @patch(f"{ALERT_SERVICE_MODULE}.threading")
+    def test_skips_thread_for_qa_trigger(self, mock_threading):
+        run = _make_fake_run(trigger=CallType.QA)
+
+        from ada_backend.services.alerting.alert_service import maybe_send_run_failure_alert
+
+        maybe_send_run_failure_alert(run, run.project_id, error=run.error)
+
+        mock_threading.Thread.assert_not_called()

--- a/tests/mcp_server/test_alert_emails.py
+++ b/tests/mcp_server/test_alert_emails.py
@@ -29,18 +29,21 @@ async def test_list_alert_emails(monkeypatch, fake_mcp):
 
 
 @pytest.mark.asyncio
-async def test_add_alert_email(monkeypatch, fake_mcp):
+async def test_create_alert_email(monkeypatch, fake_mcp):
     mcp = fake_mcp
+    role_mock = AsyncMock(return_value={"org_id": "org-123"})
     post_mock = AsyncMock(return_value={"id": FAKE_ALERT_EMAIL_ID, "email": "dev@test.com"})
 
     monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-123"))
+    monkeypatch.setattr(_factory, "require_role", role_mock)
     monkeypatch.setattr(_factory.api, "post", post_mock)
 
     alert_emails.register(mcp)
 
-    result = await mcp.tools["add_alert_email"](FAKE_PROJECT_ID, "dev@test.com")
+    result = await mcp.tools["create_alert_email"](FAKE_PROJECT_ID, "dev@test.com")
 
     assert result == {"id": FAKE_ALERT_EMAIL_ID, "email": "dev@test.com"}
+    role_mock.assert_awaited_once_with("user-123", "developer", "admin", "super_admin")
     post_mock.assert_awaited_once_with(
         f"/projects/{FAKE_PROJECT_ID}/alert-emails",
         "jwt-token",
@@ -50,18 +53,21 @@ async def test_add_alert_email(monkeypatch, fake_mcp):
 
 
 @pytest.mark.asyncio
-async def test_remove_alert_email(monkeypatch, fake_mcp):
+async def test_delete_alert_email(monkeypatch, fake_mcp):
     mcp = fake_mcp
+    role_mock = AsyncMock(return_value={"org_id": "org-123"})
     delete_mock = AsyncMock(return_value={"status": "ok"})
 
     monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-123"))
+    monkeypatch.setattr(_factory, "require_role", role_mock)
     monkeypatch.setattr(_factory.api, "delete", delete_mock)
 
     alert_emails.register(mcp)
 
-    result = await mcp.tools["remove_alert_email"](FAKE_PROJECT_ID, FAKE_ALERT_EMAIL_ID)
+    result = await mcp.tools["delete_alert_email"](FAKE_PROJECT_ID, FAKE_ALERT_EMAIL_ID)
 
     assert result == {"status": "ok"}
+    role_mock.assert_awaited_once_with("user-123", "developer", "admin", "super_admin")
     delete_mock.assert_awaited_once_with(
         f"/projects/{FAKE_PROJECT_ID}/alert-emails/{FAKE_ALERT_EMAIL_ID}",
         "jwt-token",

--- a/tests/mcp_server/test_alert_emails.py
+++ b/tests/mcp_server/test_alert_emails.py
@@ -1,0 +1,69 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_server.tools import _factory, alert_emails
+from tests.mcp_server.conftest import FAKE_PROJECT_ID
+
+FAKE_ALERT_EMAIL_ID = "00000000-0000-4000-8000-0000000000f1"
+
+
+@pytest.mark.asyncio
+async def test_list_alert_emails(monkeypatch, fake_mcp):
+    mcp = fake_mcp
+    get_mock = AsyncMock(return_value=[{"id": FAKE_ALERT_EMAIL_ID, "email": "dev@test.com"}])
+
+    monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-123"))
+    monkeypatch.setattr(_factory.api, "get", get_mock)
+
+    alert_emails.register(mcp)
+
+    result = await mcp.tools["list_alert_emails"](FAKE_PROJECT_ID)
+
+    assert result == [{"id": FAKE_ALERT_EMAIL_ID, "email": "dev@test.com"}]
+    get_mock.assert_awaited_once_with(
+        f"/projects/{FAKE_PROJECT_ID}/alert-emails",
+        "jwt-token",
+        trim=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_alert_email(monkeypatch, fake_mcp):
+    mcp = fake_mcp
+    post_mock = AsyncMock(return_value={"id": FAKE_ALERT_EMAIL_ID, "email": "dev@test.com"})
+
+    monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-123"))
+    monkeypatch.setattr(_factory.api, "post", post_mock)
+
+    alert_emails.register(mcp)
+
+    result = await mcp.tools["add_alert_email"](FAKE_PROJECT_ID, "dev@test.com")
+
+    assert result == {"id": FAKE_ALERT_EMAIL_ID, "email": "dev@test.com"}
+    post_mock.assert_awaited_once_with(
+        f"/projects/{FAKE_PROJECT_ID}/alert-emails",
+        "jwt-token",
+        trim=True,
+        json={"email": "dev@test.com"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove_alert_email(monkeypatch, fake_mcp):
+    mcp = fake_mcp
+    delete_mock = AsyncMock(return_value={"status": "ok"})
+
+    monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-123"))
+    monkeypatch.setattr(_factory.api, "delete", delete_mock)
+
+    alert_emails.register(mcp)
+
+    result = await mcp.tools["remove_alert_email"](FAKE_PROJECT_ID, FAKE_ALERT_EMAIL_ID)
+
+    assert result == {"status": "ok"}
+    delete_mock.assert_awaited_once_with(
+        f"/projects/{FAKE_PROJECT_ID}/alert-emails/{FAKE_ALERT_EMAIL_ID}",
+        "jwt-token",
+        trim=True,
+    )


### PR DESCRIPTION
# feat(alerting): add email alerts for failed webhook/cron runs

## Summary
- Add a per-project configurable email alerting system that sends notifications via Resend when webhook- or cron-triggered runs fail.
- Expose CRUD endpoints (`GET/POST/DELETE /projects/{project_id}/alert-emails`) for managing alert recipients, plus matching MCP tools (`list_alert_emails`, `add_alert_email`, `remove_alert_email`).
- Hook into the central `update_run_status()` and `fail_pending_run()` functions in `run_service.py` so all failure paths are covered. Alert emails are sent in a background thread (fire-and-forget) and never block or break run processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic run failure alerts: When a run fails due to webhook or cron triggers, the system sends email notifications to configured recipients.
  * Alert recipient management: New API endpoints to add, list, and remove alert email addresses per project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->