### PR TITLE
Fix RefNode expr stringifying list values passed to components dra-1223

### DIFF
--- a/engine/graph_runner/field_expression_management.py
+++ b/engine/graph_runner/field_expression_management.py
@@ -110,6 +110,11 @@ def evaluate_expression(
             LOGGER.debug(f"Evaluated variable expression for {target_field_name}: {result}")
             return result
 
+        case RefNode() as ref:
+            result = evaluate_ref_as_object(ref)
+            LOGGER.debug(f"Evaluated ref expression for {target_field_name}: {result}")
+            return result
+
         case JsonBuildNode(template=template, refs=ref_nodes):
             evaluated_refs = {}
             for placeholder, ref_node in ref_nodes.items():

--- a/engine/integrations/gmail/gmail_sender.py
+++ b/engine/integrations/gmail/gmail_sender.py
@@ -12,7 +12,12 @@ from ada_backend.database.setup_db import get_db_session
 from engine.components.component import Component
 from engine.components.types import ComponentAttributes, ToolDescription
 from engine.integrations.gmail.gmail_utils import create_raw_mail_message
-from engine.integrations.utils import get_gmail_sender_service, get_google_user_email, get_oauth_access_token
+from engine.integrations.utils import (
+    get_gmail_sender_service,
+    get_google_user_email,
+    get_oauth_access_token,
+    normalize_str_list,
+)
 from engine.trace.trace_manager import TraceManager
 from settings import settings
 
@@ -144,6 +149,11 @@ class GmailSenderInputs(BaseModel):
         if isinstance(v, str):
             return [v]
         return v
+
+    @field_validator("email_attachments", mode="before")
+    @classmethod
+    def validate_email_attachments(cls, v):
+        return normalize_str_list(v)
 
 
 class GmailSenderOutputs(BaseModel):

--- a/engine/integrations/outlook/outlook_sender.py
+++ b/engine/integrations/outlook/outlook_sender.py
@@ -12,6 +12,7 @@ from engine.components.component import Component
 from engine.components.types import ComponentAttributes, ToolDescription
 from engine.integrations.outlook.errors import OutlookAPIError
 from engine.integrations.outlook.outlook_utils import GRAPH_API_BASE, build_graph_mail_payload
+from engine.integrations.utils import normalize_str_list
 from engine.trace.serializer import serialize_to_json
 from engine.trace.trace_manager import TraceManager
 
@@ -143,6 +144,11 @@ class OutlookSenderInputs(BaseModel):
         if isinstance(v, str):
             return [v]
         return v
+
+    @field_validator("email_attachments", mode="before")
+    @classmethod
+    def validate_email_attachments(cls, v):
+        return normalize_str_list(v)
 
 
 class OutlookSenderOutputs(BaseModel):

--- a/engine/integrations/utils.py
+++ b/engine/integrations/utils.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -14,6 +15,23 @@ from ada_backend.database import models as db
 from ada_backend.repositories.integration_repository import get_integration_secret, update_integration_secret
 
 LOGGER = logging.getLogger(__name__)
+
+
+def normalize_str_list(v: Any) -> Any:
+    """Pydantic pre-validator helper: ensure a value destined for a list[str] field
+    is actually a flat list of strings. Handles bare strings, nested lists, and
+    non-string items."""
+    if isinstance(v, str):
+        return [v]
+    if isinstance(v, list):
+        flattened: list[str] = []
+        for item in v:
+            if isinstance(item, list):
+                flattened.extend(str(i) for i in item)
+            else:
+                flattened.append(str(item))
+        return flattened
+    return v
 
 
 def is_url(value: str) -> bool:

--- a/tests/engine/integrations/test_gmail_sender.py
+++ b/tests/engine/integrations/test_gmail_sender.py
@@ -1,0 +1,35 @@
+from engine.integrations.gmail.gmail_sender import GmailSenderInputs
+from engine.integrations.utils import normalize_str_list
+
+
+class TestNormalizeStrList:
+    def test_single_string_wrapped_in_list(self):
+        assert normalize_str_list("file.pdf") == ["file.pdf"]
+
+    def test_list_of_strings_passes_through(self):
+        assert normalize_str_list(["a.pdf", "b.docx"]) == ["a.pdf", "b.docx"]
+
+    def test_nested_list_is_flattened(self):
+        assert normalize_str_list([["a.pdf", "b.docx"]]) == ["a.pdf", "b.docx"]
+
+    def test_none_passes_through(self):
+        assert normalize_str_list(None) is None
+
+    def test_empty_list_passes_through(self):
+        assert normalize_str_list([]) == []
+
+
+class TestGmailSenderInputsValidation:
+    """Regression: email_attachments uses normalize_str_list via field_validator."""
+
+    def test_single_string_wrapped_in_list(self):
+        inputs = GmailSenderInputs(mail_subject="test", email_attachments="file.pdf")
+        assert inputs.email_attachments == ["file.pdf"]
+
+    def test_nested_list_is_flattened(self):
+        inputs = GmailSenderInputs(mail_subject="test", email_attachments=[["a.pdf", "b.docx"]])
+        assert inputs.email_attachments == ["a.pdf", "b.docx"]
+
+    def test_none_stays_none(self):
+        inputs = GmailSenderInputs(mail_subject="test", email_attachments=None)
+        assert inputs.email_attachments is None

--- a/tests/engine/test_graph_runner_expressions.py
+++ b/tests/engine/test_graph_runner_expressions.py
@@ -1026,3 +1026,110 @@ class TestStartNodeIntegration:
         }))
 
         assert result.messages[0].content == "echo[runtime_value]"
+
+
+class ListStrSink(Component):
+    """Accepts list[str] input and echoes it back as JSON."""
+
+    migrated = True
+
+    class Inputs(BaseModel):
+        items: list[str]
+
+    class Outputs(BaseModel):
+        output: str
+
+    @classmethod
+    def get_inputs_schema(cls):
+        return ListStrSink.Inputs
+
+    @classmethod
+    def get_outputs_schema(cls):
+        return ListStrSink.Outputs
+
+    def __init__(self, trace_manager: TraceManager, name: str = "list_sink"):
+        super().__init__(
+            trace_manager=trace_manager,
+            tool_description=ToolDescription(
+                name=f"ListStrSink_{name}",
+                description="List str sink",
+                tool_properties={},
+                required_tool_properties=[],
+            ),
+            component_attributes=ComponentAttributes(component_instance_name=name),
+        )
+
+    async def _run_without_io_trace(self, inputs: Inputs, ctx: dict) -> Outputs:  # type: ignore
+        return ListStrSink.Outputs(output=json.dumps(inputs.items))
+
+
+class ListStrSource(Component):
+    """Produces a fixed list[str] output."""
+
+    migrated = True
+
+    class Inputs(BaseModel):
+        input: str | None = None
+
+    class Outputs(BaseModel):
+        files: list[str]
+
+    @classmethod
+    def get_inputs_schema(cls):
+        return ListStrSource.Inputs
+
+    @classmethod
+    def get_outputs_schema(cls):
+        return ListStrSource.Outputs
+
+    def __init__(self, trace_manager: TraceManager, value: list[str], name: str):
+        super().__init__(
+            trace_manager=trace_manager,
+            tool_description=ToolDescription(
+                name=f"ListStrSource_{name}",
+                description="List str source",
+                tool_properties={},
+                required_tool_properties=[],
+            ),
+            component_attributes=ComponentAttributes(component_instance_name=name),
+        )
+        self._value = value
+
+    async def _run_without_io_trace(self, inputs: Inputs, ctx: dict) -> Outputs:  # type: ignore
+        return ListStrSource.Outputs(files=self._value)
+
+
+class TestRefExpressionPreservesListType:
+    """Regression: a RefNode expression targeting a list[str] field must preserve the list
+    rather than stringifying it via str(). Previously, top-level RefNodes fell through to
+    evaluate_node() which called to_string(), turning ["a", "b"] into "['a', 'b']" and then
+    coercion wrapped it as ["['a', 'b']"]."""
+
+    def test_pure_ref_preserves_list_str(self):
+        tm = TraceManager(project_name="test")
+        set_tracing_span(project_id="test_proj", organization_id="org", organization_llm_providers=["mock"])
+
+        source = ListStrSource(tm, value=["file1.pdf", "file2.docx"], name="A")
+        sink = ListStrSink(tm, name="B")
+        runnables = {"A": source, "B": sink}
+
+        g = nx.DiGraph()
+        g.add_nodes_from(["A", "B"])
+
+        expressions = [
+            {
+                "target_instance_id": "B",
+                "field_name": "items",
+                "expression_ast": expr_from_json({"type": "ref", "instance": "A", "port": "files"}),
+            }
+        ]
+
+        gr = GraphRunner(
+            graph=g,
+            runnables=runnables,
+            start_nodes=["A"],
+            trace_manager=tm,
+            expressions=expressions,
+        )
+        result = asyncio.run(gr.run({"input": "seed"}))
+        assert result.messages[0].content == '["file1.pdf", "file2.docx"]'


### PR DESCRIPTION
# Fix RefNode expression stringifying list values passed to downstream components

## Summary
- Root cause fix: Top-level RefNode expressions in `evaluate_expression()` fell through to the default `_` case, which called `evaluate_node()` — a function that always returns `str.` This turned list values like` ["file1.pdf", "file2.docx"]` into the string "`['file1.pdf', 'file2.docx']"`, which coercion then wrapped as `["['file1.pdf', 'file2.docx']"]`. Added an explicit `RefNode` case that calls `evaluate_ref_as_object()` to preserve the raw value (list, dict, etc.), matching how `VarNode` and `JsonBuildNode` were already handled.
- Defense-in-depth: Added `field_validator("email_attachments")` on `GmailSenderInputs` and `OutlookSenderInputs` to flatten nested lists and wrap bare strings, mirroring the existing email_recipients validator.

## Context
Users wiring file-producing components (e.g. DOCX template, PDF generation) into Gmail/Outlook via field expressions hit:
```
FileNotFoundError: Attachment not found or not a file:
  089e5d94-…/['Rapport_Pre-Instruction_Kheoos_2026-04-14.pdf', 'kheoos_PreInstruction_filled.docx']
```
The stringified Python list was concatenated as a single filename instead of being iterated as individual attachment paths.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Email attachment inputs now support flexible formats and are automatically normalized across email integrations for more consistent processing
  * Expression evaluation capabilities have been enhanced to support reference expressions at the top level, providing greater flexibility for complex expression scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->