### PR TITLE
feat(ci): add integration tests dra-1095

### DIFF
--- a/.github/workflows/test-project-flow.yml
+++ b/.github/workflows/test-project-flow.yml
@@ -1,0 +1,50 @@
+name: E2E Project Flow Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-project-flow:
+    runs-on: ubuntu-latest
+
+    env:
+      STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+      SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+      E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
+      E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
+      PROJECT_TEST_MATRIX: ${{ secrets.PROJECT_TEST_MATRIX }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install requests pytest
+
+      - name: Run E2E flow tests
+        run: >
+          pytest scripts/test_project_flow.py
+          -v
+          --tb=short
+          --junitxml=report.xml
+
+      - name: Upload JUnit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-flow-report
+          path: report.xml
+
+      - name: Publish test results
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: E2E Flow Results
+          path: report.xml
+          reporter: java-junit

--- a/scripts/test_project_flow.py
+++ b/scripts/test_project_flow.py
@@ -1,0 +1,186 @@
+"""
+E2E test: save-version -> deploy -> run for a list of projects.
+
+Authenticates against Supabase with a real test user, then hits the standard
+API endpoints with the resulting JWT. No backend code changes required.
+
+The project list is read from the PROJECT_TEST_MATRIX env var, expected as JSON:
+[
+  {"project_id": "<uuid>", "input": {"messages": [{"role": "user", "content": "Hello"}]}},
+  ...
+]
+
+Required env vars:
+  PROJECT_TEST_MATRIX   – JSON array (see above)
+  STAGING_BASE_URL      – Backend base URL (e.g. https://staging.example.com)
+  SUPABASE_URL          – Supabase project URL (e.g. https://xyz.supabase.co)
+  SUPABASE_ANON_KEY     – Supabase anon/public key
+  E2E_USER_EMAIL        – Test user email
+  E2E_USER_PASSWORD     – Test user password
+"""
+
+import json
+import os
+from typing import Any
+
+import pytest
+import requests
+
+# ---------------------------------------------------------------------------
+# Env-var helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise EnvironmentError(f"Missing required environment variable: {name}")
+    return value
+
+
+_REQUIRED_ENTRY_KEYS = {"project_id", "input"}
+
+
+def _load_project_matrix() -> list[dict[str, Any]]:
+    raw = _require_env("PROJECT_TEST_MATRIX")
+    matrix = json.loads(raw)
+    if not isinstance(matrix, list) or len(matrix) == 0:
+        raise ValueError("PROJECT_TEST_MATRIX must be a non-empty JSON array")
+    for entry in matrix:
+        missing = _REQUIRED_ENTRY_KEYS - entry.keys()
+        if missing:
+            raise ValueError(f"Matrix entry missing keys {missing}. Each entry needs: {_REQUIRED_ENTRY_KEYS}")
+    return matrix
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    return _require_env("STAGING_BASE_URL").rstrip("/")
+
+
+@pytest.fixture(scope="session")
+def auth_headers() -> dict[str, str]:
+    """Authenticate against Supabase and return a Bearer header with a real JWT."""
+    supabase_url = _require_env("SUPABASE_URL").rstrip("/")
+    anon_key = _require_env("SUPABASE_ANON_KEY")
+    email = _require_env("E2E_USER_EMAIL")
+    password = _require_env("E2E_USER_PASSWORD")
+
+    resp = requests.post(
+        f"{supabase_url}/auth/v1/token?grant_type=password",
+        json={"email": email, "password": password},
+        headers={"apikey": anon_key, "Content-Type": "application/json"},
+        timeout=15,
+    )
+    resp.raise_for_status()
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Per-project parametrization
+# ---------------------------------------------------------------------------
+
+
+def _matrix_ids() -> list[str]:
+    try:
+        matrix = _load_project_matrix()
+    except Exception:
+        return ["matrix-load-error"]
+    return [entry["project_id"] for entry in matrix]
+
+
+def _matrix_params() -> list[dict[str, Any]]:
+    try:
+        return _load_project_matrix()
+    except Exception:
+        return [{}]
+
+
+@pytest.fixture(params=_matrix_params(), ids=_matrix_ids(), scope="class")
+def project_entry(request) -> dict[str, Any]:
+    """Yields one {project_id, input} entry from the matrix."""
+    return request.param
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve draft graph_runner_id
+# ---------------------------------------------------------------------------
+
+
+def _get_draft_graph_runner_id(base_url: str, project_id: str, headers: dict[str, str]) -> str:
+    resp = requests.get(
+        f"{base_url}/projects/{project_id}",
+        headers=headers,
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+    data = resp.json()
+    for gr in data.get("graph_runners", []):
+        if gr.get("env") == "draft":
+            return gr["graph_runner_id"]
+
+    raise RuntimeError(
+        f"No draft graph runner found for project {project_id}. Available: {data.get('graph_runners', [])}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProjectFlow:
+    """Save-version, deploy, and run for each project in the matrix."""
+
+    def test_save_version(self, base_url, auth_headers, project_entry):
+        project_id = project_entry["project_id"]
+        graph_runner_id = _get_draft_graph_runner_id(base_url, project_id, auth_headers)
+
+        resp = requests.post(
+            f"{base_url}/projects/{project_id}/graph/{graph_runner_id}/save-version",
+            headers=auth_headers,
+            timeout=60,
+        )
+        resp.raise_for_status()
+
+        body = resp.json()
+        assert "saved_graph_runner_id" in body
+        assert "tag_version" in body
+
+    def test_deploy(self, base_url, auth_headers, project_entry):
+        project_id = project_entry["project_id"]
+        graph_runner_id = _get_draft_graph_runner_id(base_url, project_id, auth_headers)
+
+        resp = requests.post(
+            f"{base_url}/projects/{project_id}/graph/{graph_runner_id}/deploy",
+            headers=auth_headers,
+            timeout=60,
+        )
+        resp.raise_for_status()
+
+        body = resp.json()
+        assert "prod_graph_runner_id" in body
+        assert "draft_graph_runner_id" in body
+
+    def test_run(self, base_url, auth_headers, project_entry):
+        project_id = project_entry["project_id"]
+        input_data = project_entry["input"]
+
+        resp = requests.post(
+            f"{base_url}/projects/{project_id}/production/chat",
+            headers={**auth_headers, "Content-Type": "application/json"},
+            json=input_data,
+            timeout=120,
+        )
+        resp.raise_for_status()
+
+        body = resp.json()
+        assert "message" in body, f"Response missing 'message' field: {body}"
+        assert body.get("error") is None, f"Run returned an error: {body['error']}"


### PR DESCRIPTION
# Add E2E integration tests for project flow (save / deploy / run)

## Summary
- Add a pytest E2E suite (`scripts/test_project_flow.py`) that exercises the critical save-version -> deploy -> run path against staging for a configurable list of projects.
- Add a manually-triggered GitHub Actions workflow (`test-project-flow.yml`) to run the suite on demand via workflow_dispatch.

## Motivation
We have no automated way to verify that the core project lifecycle works end-to-end on staging after a deploy. This gives us a one-click smoke test that can catch regressions before they reach production.

## How it works
- The test authenticates against Supabase with a dedicated test user (email + password) to obtain a real JWT — no auth bypass or backend code changes needed.
- For each project in the `PROJECT_TEST_MATRIX`, three tests run sequentially: `test_save_version`, `test_deploy, test_run`.
Results are published as a JUnit report artifact.