### PR TITLE
feat(tracing): propagate span context to sentry tags

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -52,6 +52,14 @@ DAG of ComponentInstances connected via FieldExpressions (JSON AST). See `ada_ba
 
 Mixpanel Python SDK (`mixpanel_analytics.py`). `non_breaking_track` decorator wraps every tracking function with try/except internally — never add try/except at call sites. Lazy init via `_refresh_client()` (thread-safe, re-checks settings on every call). Only active when `ENV == "production"` **and** `MIXPANEL_TOKEN` is set; otherwise all calls silently no-op (no errors). Events cover: identity, project/agent lifecycle, deployment, run completion, ingestion, cron, API keys, OAuth, and observability page views. New user-facing actions should get a corresponding `track_*` call in the **service layer** (not routers). Integration tests (`@pytest.mark.mixpanel`) hit the real Mixpanel API and run in CI only when `mixpanel_analytics.py` or `tests/ada_backend/test_mixpanel_analytics.py` changes.
 
+### Tracing Context and Sentry
+
+`engine/trace/span_context.py` is the canonical tracing context lifecycle hook. `set_tracing_span(**kwargs)` merges
+partial updates into the existing `TracingSpanParams` context and synchronizes `SENTRY_TAG_FIELDS` to Sentry tags on
+each update. Non-`None` values are stringified via `sentry_sdk.set_tag`; `None` values clear the tag from the current
+isolation scope (`remove_tag`) to prevent stale tags. Do not set tracing tags in routers/services directly; add new
+searchable fields in `TracingSpanParams` + `SENTRY_TAG_FIELDS` instead.
+
 ### MCP Server
 
 `mcp_server/`: standalone pod calling the backend over HTTP + Supabase directly. See `mcp_server/README.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ infra/k8s/*/secrets.yaml
 # cache
 **__pycache__**
 *checkpoint.ipynb
+.mypy_cache
 
 # logs
 logs

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -133,6 +133,22 @@ In ingestion flows, prefer reusing an existing `SQLLocalService` instance inside
 In ingestion workers, `ingestion_script.ingest_db_source.upload_db_source()` should create one source
 `SQLLocalService` per ingestion run and reuse it across the run before closing it in `finally`.
 
+## Tracing Context to Sentry Tags
+
+**File**: `engine/trace/span_context.py`
+
+`set_tracing_span(**kwargs)` is the canonical place to mutate tracing context. It merges partial updates into the
+existing `ContextVar` entry and then synchronizes selected fields to Sentry tags through `_sync_to_sentry`.
+
+- `SENTRY_TAG_FIELDS` defines the allowlist propagated to Sentry (`cron_id`, `trace_id`, `project_id`,
+  `organization_id`, `environment`, `call_type`, `graph_runner_id`, `tag_name`)
+- non-`None` values are converted to strings and sent via `sentry_sdk.set_tag`
+- `None` values remove the tag from the current Sentry isolation scope (`remove_tag`) to avoid stale tag leakage
+- calling `set_tracing_span` is safe when Sentry is disabled; tag operations are no-ops until `sentry_sdk.init` runs
+
+When introducing a new tracing field, add it to `TracingSpanParams` first. If it should be searchable in Sentry,
+also add it to `SENTRY_TAG_FIELDS` so the propagation remains centralized and endpoint-agnostic.
+
 ## Key Files
 
 | Concept | File |

--- a/engine/trace/span_context.py
+++ b/engine/trace/span_context.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 from uuid import UUID
 
+import sentry_sdk
 from e2b_code_interpreter import AsyncSandbox
 
 from ada_backend.database.models import CallType, EnvType
@@ -31,6 +32,26 @@ class TracingSpanParams:
 _tracing_context: ContextVar[Optional[TracingSpanParams]] = ContextVar("_tracing_context", default=None)
 
 _SPAN_FIELDS = {f.name for f in dataclasses.fields(TracingSpanParams)}
+SENTRY_TAG_FIELDS = (
+    "cron_id",
+    "trace_id",
+    "project_id",
+    "organization_id",
+    "environment",
+    "call_type",
+    "graph_runner_id",
+    "tag_name",
+)
+
+
+def _sync_to_sentry(params: TracingSpanParams) -> None:
+    isolation_scope = sentry_sdk.get_isolation_scope()
+    for field_name in SENTRY_TAG_FIELDS:
+        field_value = getattr(params, field_name)
+        if field_value is None:
+            isolation_scope.remove_tag(field_name)
+            continue
+        sentry_sdk.set_tag(field_name, str(field_value))
 
 
 def set_tracing_span(**kwargs) -> None:
@@ -49,6 +70,7 @@ def set_tracing_span(**kwargs) -> None:
     else:
         params = TracingSpanParams(**kwargs)
     _tracing_context.set(params)
+    _sync_to_sentry(params)
 
 
 def get_tracing_span() -> Optional[TracingSpanParams]:

--- a/tests/engine/trace/test_span_context.py
+++ b/tests/engine/trace/test_span_context.py
@@ -1,5 +1,8 @@
+from unittest.mock import Mock, call, patch
+
 import pytest
 
+from engine.trace import span_context
 from engine.trace.span_context import TracingSpanParams, get_tracing_span, set_tracing_span
 
 
@@ -58,3 +61,63 @@ class TestSetTracingSpan:
         params = get_tracing_span()
         assert params is not None
         assert isinstance(params, TracingSpanParams)
+
+    def test_set_tracing_span_syncs_tags_to_sentry(self):
+        with patch("engine.trace.span_context.sentry_sdk.set_tag") as mock_set_tag:
+            set_tracing_span(
+                project_id="proj",
+                organization_id="org",
+                organization_llm_providers=["openai"],
+                cron_id="cron-123",
+            )
+
+        mock_set_tag.assert_has_calls(
+            [
+                call("cron_id", "cron-123"),
+                call("project_id", "proj"),
+                call("organization_id", "org"),
+            ],
+            any_order=True,
+        )
+
+    def test_none_fields_not_sent_to_sentry(self):
+        mock_scope = Mock()
+        with (
+            patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope),
+            patch("engine.trace.span_context.sentry_sdk.set_tag") as mock_set_tag,
+        ):
+            set_tracing_span(project_id="proj", organization_id="org", organization_llm_providers=[], cron_id=None)
+
+        assert all(args.args[0] != "cron_id" for args in mock_set_tag.call_args_list)
+        mock_scope.remove_tag.assert_any_call("cron_id")
+
+    def test_non_whitelisted_fields_not_sent(self):
+        with patch("engine.trace.span_context.sentry_sdk.set_tag") as mock_set_tag:
+            set_tracing_span(
+                project_id="proj",
+                organization_id="org",
+                organization_llm_providers=["openai", "anthropic"],
+                uuid_for_temp_folder="temp-123",
+                conversation_id="conv-1",
+            )
+
+        sent_fields = {args.args[0] for args in mock_set_tag.call_args_list}
+        assert "organization_llm_providers" not in sent_fields
+        assert "shared_sandbox" not in sent_fields
+        assert "uuid_for_temp_folder" not in sent_fields
+
+    def test_sentry_tag_fields_extensibility(self, monkeypatch):
+        monkeypatch.setattr(
+            span_context,
+            "SENTRY_TAG_FIELDS",
+            (*span_context.SENTRY_TAG_FIELDS, "conversation_id"),
+        )
+        with patch("engine.trace.span_context.sentry_sdk.set_tag") as mock_set_tag:
+            set_tracing_span(
+                project_id="proj",
+                organization_id="org",
+                organization_llm_providers=[],
+                conversation_id="conv-1",
+            )
+
+        assert ("conversation_id", "conv-1") in [args.args for args in mock_set_tag.call_args_list]


### PR DESCRIPTION
## What changed
Added a generic bridge that automatically propagates `TracingSpanParams` fields to Sentry tags whenever the tracing span context is updated via `set_tracing_span`.

## Why
Currently, rich per-request context (`cron_id`, `trace_id`, `project_id`, `organization_id`, etc.) is available in `TracingSpanParams` and reaches logs and OTel spans, but none of it reaches Sentry. This makes Sentry events and transactions unsearchable by business-domain context (like `cron_id` or `project_id`).

## Implementation Context
- **Whitelist approach:** Defined `SENTRY_TAG_FIELDS` in `engine/trace/span_context.py` to ensure only meaningful scalar fields are propagated (excluding complex objects like `shared_sandbox` or lists).
- **Isolation Scopes:** Leverages `sentry_sdk.get_isolation_scope()` to set/remove tags. This ensures tags are correctly scoped to the current async task/request in FastAPI and don't leak across requests.
- **No-op safety:** `sentry_sdk.set_tag` is a no-op when the SDK is not initialized, making it safe to call unconditionally across all processes (API, scheduler, MCP, ingestion).
- **Stale tag prevention:** If a field is explicitly set to `None`, it is removed from the Sentry isolation scope via `remove_tag`.
- **Docs:** Updated `ada_backend/docs/engine.md` and `.cursor/rules/architecture.mdc` to document this as the canonical pattern.

## Out of Scope
- Broad Sentry observability redesign beyond tracing-context tag propagation.
- Any additional cron propagation changes (already covered by DRA-1003).

## Validation / Testing
- Added regression tests in `tests/engine/trace/test_span_context.py` to verify:
  - Sentry tag sync for whitelisted fields.
  - `None` handling (ensuring `remove_tag` is called).
  - Whitelist enforcement (non-whitelisted fields are ignored).
  - Extensibility of `SENTRY_TAG_FIELDS`.
- **Risk is low:** The changes only affect Sentry tags and do not alter existing run execution behavior, OTel spans, or logging formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architecture guidance on tracing context and Sentry integration, including how to add searchable tracing fields and tag propagation rules.

* **New Features**
  * Tracing context now automatically syncs selected fields to Sentry: non-empty values are stringified and set as tags; cleared values remove corresponding tags to avoid stale data.

* **Tests**
  * Added tests covering tracing-to-Sentry tag propagation and removal behavior.

* **Chores**
  * Updated .gitignore to exclude type-checker cache files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->