### PR TITLE
feat(components): Add sender alias support to Gmail Sender dra-1229

### DIFF
--- a/engine/integrations/gmail/gmail_sender.py
+++ b/engine/integrations/gmail/gmail_sender.py
@@ -31,6 +31,13 @@ GMAIL_SENDER_TOOL_DESCRIPTION = ToolDescription(
     name="Gmail Sender",
     description="A tool to send emails using Gmail API.",
     tool_properties={
+        "from_email": {
+            "type": "string",
+            "description": (
+                "Optional sender alias email address. Must be a verified 'Send mail as' alias "
+                "on the connected Gmail account. When omitted, sends from the account's primary address."
+            ),
+        },
         "mail_subject": {
             "type": "string",
             "description": "The subject of the email to be sent.",
@@ -72,6 +79,19 @@ GMAIL_SENDER_TOOL_DESCRIPTION = ToolDescription(
 
 
 class GmailSenderInputs(BaseModel):
+    from_email: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional sender alias email address. Must be a verified 'Send mail as' alias "
+            "on the connected Gmail account. When omitted, sends from the account's primary address."
+        ),
+        json_schema_extra={
+            "is_tool_input": True,
+            "display_order": 0,
+            "parameter_group_id": GMAIL_GROUP_EMAIL_CONTENT_ID,
+            "parameter_order_within_group": 0,
+        },
+    )
     mail_subject: str = Field(
         description="The subject of the email to be sent.",
         json_schema_extra={

--- a/engine/integrations/gmail/gmail_sender_v2.py
+++ b/engine/integrations/gmail/gmail_sender_v2.py
@@ -90,12 +90,13 @@ class GmailSenderV2(Component):
         bcc: Optional[list[str]] = None,
         attachments: Optional[Iterable[str | Path]] = None,
         html_body: Optional[str] = None,
+        sender_email: Optional[str] = None,
     ):
         try:
             raw_email_message = create_raw_mail_message(
                 subject=email_subject,
                 body=email_body,
-                sender_email_address=self.email_address,
+                sender_email_address=sender_email or self.email_address,
                 recipients=email_recipients,
                 cc=cc,
                 bcc=bcc,
@@ -119,12 +120,13 @@ class GmailSenderV2(Component):
         bcc: Optional[list[str]] = None,
         attachments: Optional[Iterable[str | Path]] = None,
         html_body: Optional[str] = None,
+        sender_email: Optional[str] = None,
     ):
         try:
             create_message = create_raw_mail_message(
                 subject=email_subject,
                 body=email_body,
-                sender_email_address=self.email_address,
+                sender_email_address=sender_email or self.email_address,
                 recipients=email_recipients,
                 cc=cc,
                 bcc=bcc,
@@ -145,6 +147,7 @@ class GmailSenderV2(Component):
         span.set_attributes({
             SpanAttributes.INPUT_VALUE: serialize_to_json(
                 {
+                    "from_email": inputs.from_email,
                     "mail_subject": inputs.mail_subject,
                     "mail_body": inputs.mail_body,
                     "email_recipients": inputs.email_recipients,
@@ -165,6 +168,7 @@ class GmailSenderV2(Component):
                 bcc=inputs.bcc,
                 attachments=inputs.email_attachments,
                 html_body=inputs.mail_html_body,
+                sender_email=inputs.from_email,
             )
             if not draft:
                 raise RuntimeError("Failed to create draft email")
@@ -179,6 +183,7 @@ class GmailSenderV2(Component):
                 bcc=inputs.bcc,
                 attachments=inputs.email_attachments,
                 html_body=inputs.mail_html_body,
+                sender_email=inputs.from_email,
             )
             status = f"Email sent successfully with ID: {sent_message['id']}"
             message_id = sent_message["id"]

--- a/tests/engine/integrations/test_gmail_sender.py
+++ b/tests/engine/integrations/test_gmail_sender.py
@@ -1,4 +1,9 @@
+import base64
+from email import message_from_bytes
+from unittest.mock import patch
+
 from engine.integrations.gmail.gmail_sender import GmailSenderInputs
+from engine.integrations.gmail.gmail_utils import create_raw_mail_message
 from engine.integrations.utils import normalize_str_list
 
 
@@ -33,3 +38,29 @@ class TestGmailSenderInputsValidation:
     def test_none_stays_none(self):
         inputs = GmailSenderInputs(mail_subject="test", email_attachments=None)
         assert inputs.email_attachments is None
+
+
+class TestFromEmailField:
+    def test_defaults_to_none(self):
+        inputs = GmailSenderInputs(mail_subject="test")
+        assert inputs.from_email is None
+
+    def test_accepts_alias_email(self):
+        inputs = GmailSenderInputs(mail_subject="test", from_email="alias@example.com")
+        assert inputs.from_email == "alias@example.com"
+
+
+class TestCreateRawMailMessageFromHeader:
+    def _decode_from(self, raw: dict) -> str:
+        msg_bytes = base64.urlsafe_b64decode(raw["raw"])
+        return message_from_bytes(msg_bytes)["From"]
+
+    @patch("engine.integrations.gmail.gmail_utils._ensure_paths", return_value=[])
+    def test_from_header_uses_sender_email_address(self, _mock):
+        raw = create_raw_mail_message(subject="hi", sender_email_address="primary@example.com", body="body")
+        assert self._decode_from(raw) == "primary@example.com"
+
+    @patch("engine.integrations.gmail.gmail_utils._ensure_paths", return_value=[])
+    def test_from_header_uses_alias_when_provided(self, _mock):
+        raw = create_raw_mail_message(subject="hi", sender_email_address="alias@example.com", body="body")
+        assert self._decode_from(raw) == "alias@example.com"


### PR DESCRIPTION
# Add sender alias support to Gmail Sender

## Summary
- Add an optional f`rom_email` input port to the Gmail sender component, allowing users to send emails from a verified "Send mail as" alias on their Google account instead of always using the primary address.
- Wire the field through GmailSenderV2 (v2/v3) only; legacy v1 is left untouched.

## Details
Currently the Gmail sender always derives the sender address from the OAuth token via `get_google_user_email()`. Users with multiple aliases configured in Gmail ("Send mail as") had no way to choose which address appears in the From header.

This adds `from_email` as an optional string input. When provided, it overrides the default sender address in the MIME message. When omitted, behavior is unchanged. Gmail validates server-side that the alias is a verified send-as address on the account, so no extra OAuth scope is needed.
