### PR TITLE
feat(components): unify LLM Call output_format with AI Agent dra-1226

### DIFF
--- a/ada_backend/database/alembic/versions/h7i8j9k0l1m2_migrate_llm_call_output_format_to_flat_properties.py
+++ b/ada_backend/database/alembic/versions/h7i8j9k0l1m2_migrate_llm_call_output_format_to_flat_properties.py
@@ -1,0 +1,157 @@
+"""Migrate LLM Call output_format from OpenAI structured output format to flat properties.
+
+Unifies the output_format parameter between LLM Call and AI Agent. Existing
+LLM Call output_format values stored as OpenAI format
+({"name": ..., "schema": {"properties": {...}}}) are rewritten to just the
+flat properties dict ({"answer": {"type": "string"}, ...}).
+
+deploy_strategy = "migrate-first"
+
+Revision ID: h7i8j9k0l1m2
+Revises: g1h2i3j4k5l6
+Create Date: 2026-04-15
+"""
+
+import json
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+LOGGER = logging.getLogger(__name__)
+
+revision: str = "h7i8j9k0l1m2"
+down_revision: Union[str, None] = "g1h2i3j4k5l6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy = "migrate-first"
+
+LLM_CALL_COMPONENT_VERSION_ID = "7a039611-49b3-4bfd-b09b-c0f93edf3b79"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    rows = bind.execute(
+        sa.text("""
+            SELECT fe.id, fe.expression_json
+            FROM field_expressions fe
+            JOIN input_port_instances ipi ON ipi.field_expression_id = fe.id
+            JOIN port_instances pi ON pi.id = ipi.id
+            WHERE pi.name = 'output_format'
+              AND pi.component_instance_id IN (
+                  SELECT id FROM component_instances
+                  WHERE component_version_id = CAST(:version_id AS uuid)
+              )
+              AND fe.expression_json->>'type' = 'literal'
+        """),
+        {"version_id": LLM_CALL_COMPONENT_VERSION_ID},
+    ).fetchall()
+
+    migrated = 0
+    for fe_id, expression_json in rows:
+        literal_value_str = expression_json.get("value") if isinstance(expression_json, dict) else None
+        if not literal_value_str:
+            continue
+
+        try:
+            parsed = json.loads(literal_value_str)
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+        if not isinstance(parsed, dict):
+            continue
+
+        properties = _extract_flat_properties(parsed)
+        if properties is None:
+            continue
+
+        new_literal_value = json.dumps(properties)
+        new_expression = {"type": "literal", "value": new_literal_value}
+
+        bind.execute(
+            sa.text("UPDATE field_expressions SET expression_json = :expr WHERE id = :fe_id"),
+            {"expr": json.dumps(new_expression), "fe_id": fe_id},
+        )
+        migrated += 1
+
+    LOGGER.info(f"[h7i8j9k0l1m2] Migrated {migrated} LLM Call output_format values to flat properties format.")
+
+
+def _extract_flat_properties(parsed: dict) -> dict | None:
+    """Extract flat properties from an OpenAI structured output format dict.
+
+    Returns the properties dict if the input is in OpenAI format, None otherwise
+    (already flat or unrecognised).
+    """
+    if "schema" not in parsed or "name" not in parsed:
+        return None
+
+    schema = parsed.get("schema")
+    if not isinstance(schema, dict):
+        return None
+
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return None
+
+    return properties
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    rows = bind.execute(
+        sa.text("""
+            SELECT fe.id, fe.expression_json
+            FROM field_expressions fe
+            JOIN input_port_instances ipi ON ipi.field_expression_id = fe.id
+            JOIN port_instances pi ON pi.id = ipi.id
+            WHERE pi.name = 'output_format'
+              AND pi.component_instance_id IN (
+                  SELECT id FROM component_instances
+                  WHERE component_version_id = CAST(:version_id AS uuid)
+              )
+              AND fe.expression_json->>'type' = 'literal'
+        """),
+        {"version_id": LLM_CALL_COMPONENT_VERSION_ID},
+    ).fetchall()
+
+    reverted = 0
+    for fe_id, expression_json in rows:
+        literal_value_str = expression_json.get("value") if isinstance(expression_json, dict) else None
+        if not literal_value_str:
+            continue
+
+        try:
+            parsed = json.loads(literal_value_str)
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+        if not isinstance(parsed, dict):
+            continue
+
+        if "schema" in parsed and "name" in parsed:
+            continue
+
+        openai_format = {
+            "name": "output_schema",
+            "schema": {
+                "type": "object",
+                "properties": parsed,
+                "required": list(parsed.keys()),
+                "additionalProperties": False,
+            },
+        }
+        new_literal_value = json.dumps(openai_format)
+        new_expression = {"type": "literal", "value": new_literal_value}
+
+        bind.execute(
+            sa.text("UPDATE field_expressions SET expression_json = :expr WHERE id = :fe_id"),
+            {"expr": json.dumps(new_expression), "fe_id": fe_id},
+        )
+        reverted += 1
+
+    LOGGER.info(f"[h7i8j9k0l1m2] Reverted {reverted} LLM Call output_format values to OpenAI format.")

--- a/engine/components/llm_call.py
+++ b/engine/components/llm_call.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from ada_backend.database.models import UIComponent, UIComponentProperties
 from engine.components.component import Component
 from engine.components.types import ChatMessage, ComponentAttributes, ToolDescription
-from engine.components.utils import merge_constrained_output_to_root, parse_openai_message_format
+from engine.components.utils import load_str_to_json, merge_constrained_output_to_root, parse_openai_message_format
 from engine.components.utils_prompt import fill_prompt_template
 from engine.llm_services.llm_service import CompletionService
 from engine.trace.serializer import serialize_to_json
@@ -18,6 +18,32 @@ from engine.trace.trace_manager import TraceManager
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PROMPT_TEMPLATE = "Answer this question: {{input}}"
+
+
+def _convert_properties_to_openai_format(output_format: str | dict) -> dict:
+    """Convert flat properties dict to the OpenAI structured output format.
+
+    Accepts the same flat properties format used by AI Agent, e.g.:
+        {"answer": {"type": "string"}, "score": {"type": "number"}}
+
+    Returns the full OpenAI json_schema response_format dict expected by
+    CompletionService.constrained_complete_with_json_schema_async.
+    """
+    if isinstance(output_format, str):
+        properties = load_str_to_json(output_format)
+    else:
+        properties = output_format
+
+    return {
+        "name": "output_schema",
+        "schema": {
+            "type": "object",
+            "properties": properties,
+            "required": list(properties.keys()),
+            "additionalProperties": False,
+        },
+    }
+
 
 DEFAULT_LLM_CALL_TOOL_DESCRIPTION = ToolDescription(
     name="LLM Call",
@@ -84,8 +110,9 @@ class LLMCallInputs(BaseModel):
     output_format: Optional[str | dict] = Field(
         default=None,
         description=(
-            "Enter the output format here using this documentation from OpenAI: "
-            "https://platform.openai.com/docs/guides/structured-outputs#supported-schemas"
+            "JSON schema defining the properties of the structured output. "
+            'Example: {"answer": {"type": "string", "description": "The answer content"}, '
+            '"score": {"type": "number", "description": "Confidence score"}}'
         ),
         json_schema_extra={
             "is_tool_input": False,
@@ -94,8 +121,7 @@ class LLMCallInputs(BaseModel):
                 label="Output Format",
             ).model_dump(exclude_unset=True, exclude_none=True),
             "is_advanced": True,
-            # TODO: Set to “True” once the output schema is unified to match the AI agent’s format.
-            "drives_output_schema": False,
+            "drives_output_schema": True,
         },
     )
     # Allow extra fields for backward compatibility
@@ -249,9 +275,10 @@ class LLMCallAgent(Component):
             ),
         })
         if output_format:
+            openai_response_format = _convert_properties_to_openai_format(output_format)
             response = await self._completion_service.constrained_complete_with_json_schema_async(
                 messages=[{"role": "user", "content": content}],
-                response_format=output_format,
+                response_format=openai_response_format,
             )
         else:
             response = await self._completion_service.complete_async(

--- a/engine/llm_services/llm_service.py
+++ b/engine/llm_services/llm_service.py
@@ -203,7 +203,7 @@ class CompletionService(LLMService):
     def constrained_complete_with_json_schema(
         self,
         messages: list[dict] | str,
-        response_format: str,
+        response_format: str | dict,
         stream: bool = False,
     ) -> str:
         return asyncio.run(self.constrained_complete_with_json_schema_async(messages, response_format, stream))
@@ -211,10 +211,12 @@ class CompletionService(LLMService):
     async def constrained_complete_with_json_schema_async(
         self,
         messages: list[dict] | str,
-        response_format: str,
+        response_format: str | dict,
         stream: bool = False,
     ) -> str:
-        response_format_dict = load_str_to_json(response_format)
+        response_format_dict = (
+            response_format if isinstance(response_format, dict) else load_str_to_json(response_format)
+        )
         response_format_dict["strict"] = True
         response_format_dict["type"] = "json_schema"
         response_format_dict = OutputFormatModel(**response_format_dict).model_dump(

--- a/mcp_server/docs.py
+++ b/mcp_server/docs.py
@@ -439,7 +439,7 @@ update_component_parameters(project_id, graph_runner_id, component_instance_id,
 ```
 
 ⚠️ Do NOT use `update_component_parameters` on `drives_output_schema` fields \
-(`payload_schema` on Start, `output_format` on AI Agent) unless you intend to change dynamic \
+(`payload_schema` on Start, `output_format` on AI Agent and AI/LLM Call) unless you intend to change dynamic \
 output ports — modifying those fields deletes and recreates `OutputPortInstance` rows, which \
 may break downstream field expressions.
 
@@ -1575,8 +1575,8 @@ for the full workflow.
 
 ## `drives_output_schema` Fields Control Dynamic Output Ports
 
-Some component parameters (e.g. `payload_schema` on Start, `output_format` on AI Agent) have \
-`drives_output_schema: true`. Changing these fields deletes **all** existing `OutputPortInstance` \
+Some component parameters (e.g. `payload_schema` on Start, `output_format` on AI Agent and AI/LLM Call) \
+have `drives_output_schema: true`. Changing these fields deletes **all** existing `OutputPortInstance` \
 rows for that component and recreates them from the new schema's top-level keys.
 
 Consequences:

--- a/tests/components/test_llm_call_constrained.py
+++ b/tests/components/test_llm_call_constrained.py
@@ -3,46 +3,32 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from engine.components.llm_call import LLMCallAgent, LLMCallInputs
+from engine.components.llm_call import LLMCallAgent, LLMCallInputs, _convert_properties_to_openai_format
 from engine.components.types import ComponentAttributes
-from engine.components.utils import load_str_to_json
 from engine.llm_services.utils import chat_completion_to_response
 from tests.components.test_llm_call import make_capability_resolver
 
 base64_string = base64.b64encode(b"dummy pdf content").decode("utf-8")
 QUESTION = "What is the ideal weather for a pool party?"
 PROMPT_TEMPLATE = "{{input}}"
-OUTPUT_FORMAT = load_str_to_json(
-    """{
-    "name": "weather_data",
-    "type": "json_schema",
-    "strict": true,
-    "schema": {
-        "type": "object",
-        "properties": {
-            "location": {
-                "type": "string",
-                "description": "The location to get the weather for"
-            },
-            "unit": {
-                "type": ["string", "null"],
-                "description": "The unit to return the temperature in",
-                "enum": ["F", "C"]
-            },
-            "value": {
-                "type": "number",
-                "description": "The actual temperature value in the location",
-                "minimum": -130,
-                "maximum": 130
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "location", "unit", "value"
-        ]
-    }
-}"""
-)
+
+OUTPUT_FORMAT = {
+    "location": {
+        "type": "string",
+        "description": "The location to get the weather for",
+    },
+    "unit": {
+        "type": ["string", "null"],
+        "description": "The unit to return the temperature in",
+        "enum": ["F", "C"],
+    },
+    "value": {
+        "type": "number",
+        "description": "The actual temperature value in the location",
+        "minimum": -130,
+        "maximum": 130,
+    },
+}
 
 
 @pytest.fixture
@@ -86,8 +72,8 @@ def llm_call_with_output_format():
     trace_manager = MagicMock()
 
     llm_service = MagicMock()
-    llm_service._provider = "openai"  # Set the provider to openai to support file content
-    llm_service._model_name = "gpt-4.1-mini"  # Set a model that supports files
+    llm_service._provider = "openai"
+    llm_service._model_name = "gpt-4.1-mini"
     llm_service.constrained_complete_with_json_schema_async = AsyncMock(
         return_value='{"location": "Miami", "unit": "F", "value": 85}'
     )
@@ -107,9 +93,32 @@ def llm_call_with_output_format():
     return agent
 
 
+class TestConvertPropertiesToOpenAIFormat:
+    def test_converts_flat_properties_dict(self):
+        result = _convert_properties_to_openai_format({"answer": {"type": "string"}})
+        assert result == {
+            "name": "output_schema",
+            "schema": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+                "additionalProperties": False,
+            },
+        }
+
+    def test_converts_json_string(self):
+        result = _convert_properties_to_openai_format('{"score": {"type": "number"}}')
+        assert result["schema"]["properties"] == {"score": {"type": "number"}}
+        assert result["schema"]["required"] == ["score"]
+
+    def test_preserves_all_property_keys_as_required(self):
+        props = {"a": {"type": "string"}, "b": {"type": "number"}, "c": {"type": "boolean"}}
+        result = _convert_properties_to_openai_format(props)
+        assert sorted(result["schema"]["required"]) == ["a", "b", "c"]
+
+
 @pytest.mark.anyio
-async def test_agent_input_combinations(llm_call_with_output_format, input_payload):
-    # Convert dict to LLMCallInputs Pydantic model
+async def test_structured_output_with_flat_properties(llm_call_with_output_format, input_payload):
     inputs = LLMCallInputs.model_validate({
         **input_payload,
         "prompt_template": PROMPT_TEMPLATE,
@@ -117,26 +126,41 @@ async def test_agent_input_combinations(llm_call_with_output_format, input_paylo
     })
     response = await llm_call_with_output_format._run_without_io_trace(inputs, ctx={})
 
-    # Check that the response is the correct type
     assert isinstance(response.output, str)
 
-    # Check that response_format was passed
-    assert OUTPUT_FORMAT is not None
-    assert OUTPUT_FORMAT["name"] == "weather_data"
-    assert OUTPUT_FORMAT["type"] == "json_schema"
-    assert isinstance(OUTPUT_FORMAT["strict"], bool) and OUTPUT_FORMAT["strict"] is True
+    call_kwargs = (
+        llm_call_with_output_format._completion_service.constrained_complete_with_json_schema_async.call_args[1]
+    )
+    passed_format = call_kwargs["response_format"]
+    assert passed_format["name"] == "output_schema"
+    assert passed_format["schema"]["type"] == "object"
+    assert passed_format["schema"]["properties"] == OUTPUT_FORMAT
+    assert set(passed_format["schema"]["required"]) == {"location", "unit", "value"}
+    assert passed_format["schema"]["additionalProperties"] is False
+
+
+@pytest.mark.anyio
+async def test_dynamic_output_ports_merged(llm_call_with_output_format, input_payload):
+    inputs = LLMCallInputs.model_validate({
+        **input_payload,
+        "prompt_template": PROMPT_TEMPLATE,
+        "output_format": OUTPUT_FORMAT,
+    })
+    response = await llm_call_with_output_format._run_without_io_trace(inputs, ctx={})
+
+    assert response.location == "Miami"
+    assert response.unit == "F"
+    assert response.value == 85
 
 
 @pytest.mark.anyio
 async def test_chat_completion_to_response(llm_call_with_output_format, input_payload_with_file):
-    # Convert dict to LLMCallInputs Pydantic model
     inputs = LLMCallInputs.model_validate({
         **input_payload_with_file,
         "prompt_template": PROMPT_TEMPLATE,
         "output_format": OUTPUT_FORMAT,
     })
     response = await llm_call_with_output_format._run_without_io_trace(inputs, ctx={})
-    # Check that the response is the correct type
     assert isinstance(response.output, str)
 
     llm_service_input_messages = (


### PR DESCRIPTION
# Unify LLM Call output_format with AI Agent

## Summary
- Align the LLM Call output_format parameter to use the same flat properties format as AI Agent (e.g. `{"answer": {"type": "string"}}`), replacing the previous full OpenAI structured output format
- Enable `drives_output_schema: True` on LLM Call, so setting output_format now creates dynamic output ports that downstream components can reference via field expressions
- Add an Alembic migration to convert existing stored output_format values from the old OpenAI format to flat properties

## Motivation
Until now, LLM Call and AI Agent used different formats for output_format:
- AI Agent: flat properties dict (`drives_output_schema: True`) -- dynamic output ports created
- LLM Call: full OpenAI `json_schema` format (`drives_output_schema: False`) -- no dynamic output ports
This inconsistency meant LLM Call users couldn't wire individual structured output fields to downstream components. With this change, both components accept the same format and both produce dynamic output ports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM Call output_format now drives dynamic output schema and creates structured response ports for flat property definitions.

* **Bug Fixes**
  * Improved conversion of flat output-format specifications into OpenAI-style structured response format so structured outputs are produced reliably.

* **Documentation**
  * Updated docs to note that certain fields (including LLM Call output_format) affect dynamic output port recreation.

* **Tests**
  * Added/updated tests covering conversion, structured outputs, and dynamic output port behavior.

* **Chores**
  * Migration applied to update stored output-format representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->