### PR TITLE
feat(git-sync): use same save logic dra-1232

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -2,6 +2,8 @@
 alwaysApply: true
 ---
 
+# Architecture Rules
+
 ## Architecture Overview
 
 ### Repo Structure
@@ -39,7 +41,7 @@ DAG of ComponentInstances connected via FieldExpressions (JSON AST). See `ada_ba
 - Queue workers share a `BaseQueueWorker` ABC in `ada_backend/workers/base_queue_worker.py` (heartbeat, per-worker processing list, orphan recovery, drain). Concrete subclasses only implement payload processing and entity recovery.
 - Run queue: `RunQueueWorker` in `ada_backend/workers/run_queue_worker.py`, daemon thread in API process. Run input data is durably persisted in the `run_inputs` table (keyed by `retry_group_id` with a unique constraint) so async processing can recover canonical input from Postgres instead of relying only on Redis payloads. New runs initialize a dedicated `retry_group_id` on first attempt (distinct from `run.id`), and retries keep that same group id. `run_inputs.created_at` is non-null and indexed for retention cleanup scans.
 - QA queue: `QAQueueWorker` in `ada_backend/workers/qa_queue_worker.py`, daemon thread in API process. See `ada_backend/docs/qa-system.md`.
-- Git sync queue: `GitSyncQueueWorker` in `ada_backend/workers/git_sync_queue_worker.py`, daemon thread in API process. Processes `sync_graph_from_github` jobs enqueued by the GitHub webhook handler. See `ada_backend/docs/git-sync.md`.
+- Git sync queue: `GitSyncQueueWorker` in `ada_backend/workers/git_sync_queue_worker.py`, daemon thread in API process. Processes `sync_graph_from_github` jobs enqueued by the GitHub webhook handler. Git sync deploys now reuse the same deploy service path as frontend publish (production promotion + fresh draft clone). See `ada_backend/docs/git-sync.md`.
 - Webhook worker: Redis Stream consumer, separate process. Three patterns: provider webhooks (external → backend), user-triggered, internal (worker → API). Provider-triggered executions create runs and enqueue to the run queue; if enqueue fails after run creation, webhook service marks the run `FAILED` immediately to avoid orphan `PENDING` runs. Direct triggers persist input to `run_inputs` before webhook-stream enqueue, then call the internal run endpoint (reusing the pre-created run) and execute via FastAPI background task. Scheduler-triggered internal runs must always include `cron_id` (job id) in the internal webhook body so API-side tracing can keep the cron correlation after the process boundary; include `cron_run_id` (execution id) only for the top-level scheduler-owned execution that updates CronRun state. Endpoint-polling fan-out runs forward `cron_id` without reusing the parent `cron_run_id`. Stream ACK is outcome-based: retryable failures stay pending (no ACK), success and fatal outcomes are ACKed, with dead-letter after `MAX_DELIVERY_ATTEMPTS`. See `ada_backend/docs/webhooks.md`.
 - Ingestion worker: Redis Stream consumer, separate process.
 - Scheduler: APScheduler + PostgreSQL job store, separate process. Registry-based cron types in `ada_backend/services/cron/`. See `ada_backend/services/cron/Readme.md`.

--- a/ada_backend/docs/git-sync.md
+++ b/ada_backend/docs/git-sync.md
@@ -1,15 +1,16 @@
 # Git Sync
 
-One-way sync from a GitHub repository to Draft'n Run. When a user pushes to the configured branch (default `main`), the backend receives a webhook from the GitHub App, fetches the updated `graph.json`, creates a new versioned graph runner, and promotes it directly to production — without touching the user's draft.
+One-way sync from a GitHub repository to Draft'n Run. When a user pushes to the configured branch (default `main`), the backend receives a webhook from the GitHub App, fetches the updated `graph.json`, creates a new versioned graph runner, and deploys it through the same publish path as the frontend: promote to production, then create a fresh draft clone from that promoted graph.
 
 ## Architecture
 
 Uses a **GitHub App** (not an OAuth App). The app:
+
 - Receives push webhooks automatically for all repos it's installed on (one global webhook URL)
 - Authenticates via JWT + installation access tokens (no Nango, no user OAuth tokens)
 - Requires `contents: read` permission only
 
-```
+```text
 GitHub repo (push to main)
   → GitHub App fires webhook to POST /webhooks/github
   → Backend verifies HMAC with GITHUB_APP_WEBHOOK_SECRET
@@ -20,8 +21,8 @@ GitHub repo (push to main)
     → Generates an installation token (JWT → installation access token)
     → Fetches graph.json via GitHub Contents API
     → Creates a new graph runner, populates it with the graph JSON
-    → Tags with the next version and binds to production
-    → User's draft is never touched
+    → Calls the standard deploy service used by frontend publish
+    → Deployed runner becomes production (tagged), and a new draft clone is created from it
 ```
 
 ## Data Model
@@ -68,7 +69,7 @@ This happens automatically on each webhook — no user interaction needed.
 3. User calls `POST /organizations/{org_id}/git-sync` (or MCP tool `configure_git_sync`) with `github_owner`, `github_repo_name`, `branch`, `github_installation_id`, and optionally `project_type`
 4. Backend scans the repo tree (Git Trees API, recursive) for all `graph.json` files
 5. For each folder containing a `graph.json` that doesn't already have a sync config, the backend creates a new project (named after the folder, or the repo name for root-level) and a `GitSyncConfig` row
-6. Backend enqueues an initial sync job for each new config — the existing `graph.json` is deployed to production immediately (best-effort: if enqueue fails, subsequent pushes will trigger syncs normally)
+6. Backend enqueues an initial sync job for each new config — the existing `graph.json` is deployed immediately using the standard deploy flow (best-effort: if enqueue fails, subsequent pushes will trigger syncs normally)
 
 MCP tools: `configure_git_sync`, `list_git_sync_configs`, `get_git_sync_config`, `disconnect_git_sync` (see `docs://admin`).
 
@@ -84,11 +85,12 @@ MCP tools: `configure_git_sync`, `list_git_sync_configs`, `get_git_sync_config`,
 3. Looks up matching `git_sync_configs` by `(github_owner, github_repo_name, branch)`
 4. For each matching config where `{graph_folder}/graph.json` changed, enqueues a job to the `ada_git_sync_queue` Redis queue and returns immediately. Enqueue is idempotent per `(config_id, commit_sha)` via a Redis `SET NX` dedup key (TTL 1 hour), so webhook retries (e.g. on partial enqueue failure returning 502) never produce duplicate queue entries
 5. The `GitSyncQueueWorker` (daemon thread in the API process) picks up each job and:
+
    - Loads the config from DB
    - Generates an installation token
    - Fetches graph.json from GitHub
    - Creates a new graph runner and populates it from the JSON
-   - Tags with the next version and promotes to production (draft untouched)
+   - Calls the canonical deploy flow (tag + production promotion + fresh draft clone)
    - Updates `last_sync_status` and `last_sync_error` (human-readable error message on failure, cleared on success)
 
 ## Graph JSON Format
@@ -114,7 +116,7 @@ The `graph.json` file must be in the **write format** (`GraphUpdateSchema`), not
 ## Env Vars
 
 | Var | Description |
-|-----|-------------|
+| --- | --- |
 | `GITHUB_APP_ID` | App ID from the GitHub App settings page |
 | `GITHUB_APP_PRIVATE_KEY` | PEM private key (contents, not file path) |
 | `GITHUB_APP_WEBHOOK_SECRET` | Webhook secret configured on the GitHub App |

--- a/ada_backend/services/git_sync_service.py
+++ b/ada_backend/services/git_sync_service.py
@@ -6,21 +6,18 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ada_backend.database import models as db
-from ada_backend.database.models import EnvType, ProjectType
+from ada_backend.database.models import ProjectType
 from ada_backend.mixpanel_analytics import track_deployed_to_production
 from ada_backend.repositories import git_sync_repository
-from ada_backend.repositories.env_repository import update_graph_runner_env
 from ada_backend.repositories.graph_runner_repository import (
-    get_graph_runner_for_env,
     insert_graph_runner_and_bind_to_project,
 )
-from ada_backend.repositories.tag_repository import update_graph_runner_tag_fields
 from ada_backend.schemas.git_sync_schemas import GitSyncImportResult
 from ada_backend.schemas.pipeline.graph_schema import GraphUpdateSchema
 from ada_backend.services import github_client
+from ada_backend.services.graph.deploy_graph_service import deploy_graph_service
 from ada_backend.services.graph.update_graph_service import update_graph_service
 from ada_backend.services.project_service import create_project_with_graph_runner
-from ada_backend.services.tag_service import compute_next_tag_version
 from ada_backend.utils.redis_client import push_git_sync_task
 
 LOGGER = logging.getLogger(__name__)
@@ -215,14 +212,11 @@ async def sync_graph_from_github(
         raise GitSyncError(f"Graph update failed: {e}") from e
 
     try:
-        previous_prod = get_graph_runner_for_env(session, project_id=config.project_id, env=EnvType.PRODUCTION)
-        if previous_prod:
-            update_graph_runner_env(session, previous_prod.id, env=None, commit=False)
-
-        version_tag = compute_next_tag_version(session, config.project_id)
-        update_graph_runner_tag_fields(session, graph_runner_id=new_runner_id, tag_version=version_tag, commit=False)
-        update_graph_runner_env(session, new_runner_id, env=EnvType.PRODUCTION, commit=False)
-        session.commit()
+        deploy_graph_service(
+            session=session,
+            graph_runner_id=new_runner_id,
+            project_id=config.project_id,
+        )
     except Exception as e:
         LOGGER.error("Failed to deploy graph for project %s: %s", config.project_id, e)
         git_sync_repository.update_sync_status(

--- a/tests/ada_backend/services/test_git_sync_service.py
+++ b/tests/ada_backend/services/test_git_sync_service.py
@@ -68,7 +68,6 @@ class TestSyncGraphFromGithub:
             "edges": [],
             "port_mappings": [],
         })
-        prev_prod = MagicMock(id=uuid4())
 
         session = MagicMock()
         with (
@@ -85,12 +84,8 @@ class TestSyncGraphFromGithub:
                 new_callable=AsyncMock,
             ) as update_mock,
             patch(
-                "ada_backend.services.git_sync_service.get_graph_runner_for_env",
-                return_value=prev_prod,
-            ) as get_prod_mock,
-            patch("ada_backend.services.git_sync_service.update_graph_runner_env") as env_mock,
-            patch("ada_backend.services.git_sync_service.compute_next_tag_version", return_value="v2") as tag_mock,
-            patch("ada_backend.services.git_sync_service.update_graph_runner_tag_fields") as tag_fields_mock,
+                "ada_backend.services.git_sync_service.deploy_graph_service",
+            ) as deploy_mock,
             patch("ada_backend.services.git_sync_service.track_deployed_to_production") as track_mock,
             patch("ada_backend.services.git_sync_service.git_sync_repository") as repo_mock,
         ):
@@ -105,10 +100,9 @@ class TestSyncGraphFromGithub:
         insert_mock.assert_called_once()
         update_mock.assert_called_once()
         assert update_mock.call_args.kwargs["bypass_validation"] is True
-        get_prod_mock.assert_called_once()
-        env_mock.assert_any_call(session, prev_prod.id, env=None, commit=False)
-        tag_mock.assert_called_once_with(session, config.project_id)
-        tag_fields_mock.assert_called_once()
+        deploy_mock.assert_called_once()
+        assert deploy_mock.call_args.kwargs["session"] is session
+        assert deploy_mock.call_args.kwargs["project_id"] == config.project_id
         track_mock.assert_called_once_with(config.created_by_user_id, config.organization_id, config.project_id)
         repo_mock.update_sync_status.assert_called_once_with(
             session=session, config_id=config.id, status="success", commit_sha="abc123def456"
@@ -204,7 +198,7 @@ class TestSyncGraphFromGithub:
                 new_callable=AsyncMock,
             ),
             patch(
-                "ada_backend.services.git_sync_service.get_graph_runner_for_env",
+                "ada_backend.services.git_sync_service.deploy_graph_service",
                 side_effect=Exception("DB connection lost"),
             ),
             patch("ada_backend.services.git_sync_service.git_sync_repository") as repo_mock,
@@ -224,7 +218,6 @@ class TestSyncGraphFromGithub:
             "relationships": [],
             "edges": [],
         })
-        prev_prod = MagicMock(id=uuid4())
         session = MagicMock()
         with (
             patch(
@@ -234,10 +227,7 @@ class TestSyncGraphFromGithub:
             ),
             patch("ada_backend.services.git_sync_service.insert_graph_runner_and_bind_to_project"),
             patch("ada_backend.services.git_sync_service.update_graph_service", new_callable=AsyncMock),
-            patch("ada_backend.services.git_sync_service.get_graph_runner_for_env", return_value=prev_prod),
-            patch("ada_backend.services.git_sync_service.update_graph_runner_env"),
-            patch("ada_backend.services.git_sync_service.compute_next_tag_version", return_value="v1"),
-            patch("ada_backend.services.git_sync_service.update_graph_runner_tag_fields"),
+            patch("ada_backend.services.git_sync_service.deploy_graph_service"),
             patch("ada_backend.services.git_sync_service.track_deployed_to_production"),
             patch("ada_backend.services.git_sync_service.git_sync_repository") as repo_mock,
         ):


### PR DESCRIPTION
## Summary
- Aligns Git Sync deployment with the same backend publish flow used by the frontend by removing Git Sync-specific deploy logic and delegating to `deploy_graph_service(...)`.
- Ensures deploy semantics stay centralized: production is promoted via the canonical path and draft is refreshed as the clone/image created by that same deploy flow.

## Why
- Eliminates duplicate deploy logic and prevents drift between Git Sync and frontend publish behavior.
- Keeps env/tag/deploy semantics in one authoritative code path.
- Reduces maintenance risk and improves consistency.