### PR TITLE
feat(projects): Add project tag system for filtering projects dra-1233

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -36,6 +36,10 @@ DAG of ComponentInstances connected via FieldExpressions (JSON AST). See `ada_ba
 
 `draft` / `production` bound to specific GraphRunner versions via `ProjectEnvironmentBinding`.
 
+### Project Tags
+
+Free-form string tags on projects via `project_tags` table (many-to-many). Tags are lowercase, unique per project. Used for filtering/organizing projects in the UI. Git-synced projects automatically receive a `"github"` tag. Management endpoints: `POST /projects/{id}/tags`, `DELETE /projects/{id}/tags/{tag}`. List endpoint supports `?tags=foo&tags=bar` filter (AND semantics). Org-level autocomplete: `GET /projects/org/{org_id}/tags`.
+
 ### Workers
 
 - Queue workers share a `BaseQueueWorker` ABC in `ada_backend/workers/base_queue_worker.py` (heartbeat, per-worker processing list, orphan recovery with capped follow-up scans, drain). Orphan recovery runs at startup plus up to `_MAX_ORPHAN_FOLLOW_UPS` (2) follow-up scans spaced by `_ORPHAN_FOLLOW_UP_DELAY` (= heartbeat TTL) to catch dead workers whose heartbeat hadn't expired during the startup scan; after that, no more scans run. On graceful shutdown the heartbeat key is deleted eagerly before returning items to the main queue. Concrete subclasses only implement payload processing and entity recovery.

--- a/ada_backend/database/alembic/versions/i1j2k3l4m5n6_create_project_tags_table.py
+++ b/ada_backend/database/alembic/versions/i1j2k3l4m5n6_create_project_tags_table.py
@@ -1,0 +1,37 @@
+"""Create project_tags table.
+
+deploy_strategy = "migrate-first"
+
+Revision ID: i1j2k3l4m5n6
+Revises: h7i8j9k0l1m2
+Create Date: 2026-04-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "i1j2k3l4m5n6"
+down_revision = "h7i8j9k0l1m2"
+branch_labels = None
+depends_on = None
+
+deploy_strategy = "migrate-first"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_tags",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("project_id", sa.UUID(), nullable=False),
+        sa.Column("tag", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("project_id", "tag", name="uq_project_tags_project_id_tag"),
+    )
+    op.create_index("ix_project_tags_project_id", "project_tags", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_project_tags_project_id", table_name="project_tags")
+    op.drop_table("project_tags")

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -1369,6 +1369,7 @@ class Project(Base):
 
     runs = relationship("Run", back_populates="project", cascade="all, delete-orphan")
     alert_emails = relationship("ProjectAlertEmail", back_populates="project", cascade="all, delete-orphan")
+    tags = relationship("ProjectTag", back_populates="project", cascade="all, delete-orphan")
 
     __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "base"}
 
@@ -1388,6 +1389,22 @@ class AgentProject(Project):
     id = mapped_column(UUID(as_uuid=True), ForeignKey("projects.id"), primary_key=True)
 
     __mapper_args__ = {"polymorphic_identity": ProjectType.AGENT.value}
+
+
+class ProjectTag(Base):
+    __tablename__ = "project_tags"
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id = mapped_column(UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
+    tag = mapped_column(String, nullable=False)
+    created_at = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    project = relationship("Project", back_populates="tags")
+
+    __table_args__ = (
+        UniqueConstraint("project_id", "tag", name="uq_project_tags_project_id_tag"),
+        Index("ix_project_tags_project_id", "project_id"),
+    )
 
 
 class Run(Base):

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -1397,7 +1397,7 @@ class ProjectTag(Base):
     id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     project_id = mapped_column(UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
     tag = mapped_column(String, nullable=False)
-    created_at = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     project = relationship("Project", back_populates="tags")
 

--- a/ada_backend/docs/git-sync.md
+++ b/ada_backend/docs/git-sync.md
@@ -68,8 +68,8 @@ This happens automatically on each webhook — no user interaction needed.
 2. The installation ID is provided to Draft'n Run (from the GitHub App install page or via API)
 3. User calls `POST /organizations/{org_id}/git-sync` (or MCP tool `configure_git_sync`) with `github_owner`, `github_repo_name`, `branch`, `github_installation_id`, and optionally `project_type`
 4. Backend scans the repo tree (Git Trees API, recursive) for all `graph.json` files
-5. For each folder containing a `graph.json` that doesn't already have a sync config, the backend creates a new project (named after the folder, or the repo name for root-level) and a `GitSyncConfig` row
-6. Backend enqueues an initial sync job for each new config — the existing graph payload is deployed immediately using the standard deploy flow (best-effort: if enqueue fails, subsequent pushes will trigger syncs normally)
+5. For each folder containing a `graph.json` that doesn't already have a sync config, the backend creates a new project (named after the folder, or the repo name for root-level) with a `"github"` tag and a `GitSyncConfig` row
+6. Backend enqueues an initial sync job for each new config — the existing `graph.json` is deployed immediately using the standard deploy flow (best-effort: if enqueue fails, subsequent pushes will trigger syncs normally)
 
 MCP tools: `configure_git_sync`, `list_git_sync_configs`, `get_git_sync_config`, `disconnect_git_sync` (see `docs://admin`).
 

--- a/ada_backend/repositories/project_repository.py
+++ b/ada_backend/repositories/project_repository.py
@@ -245,8 +245,9 @@ def insert_project(
         raise ValueError(f"Invalid project_type: {project_type!r}")
     session.add(project)
     if tags:
-        for tag in tags:
-            session.add(db.ProjectTag(project_id=project_id, tag=tag.lower().strip()))
+        normalized_tags = {t.lower().strip() for t in tags if t.strip()}
+        for tag in normalized_tags:
+            session.add(db.ProjectTag(project_id=project_id, tag=tag))
     session.commit()
     session.refresh(project)
     return project
@@ -275,8 +276,9 @@ def update_project(
         project.icon_color = icon_color
     if tags is not None:
         session.query(db.ProjectTag).filter(db.ProjectTag.project_id == project_id).delete()
-        for tag in tags:
-            session.add(db.ProjectTag(project_id=project_id, tag=tag.lower().strip()))
+        normalized_tags = {t.lower().strip() for t in tags if t.strip()}
+        for tag in normalized_tags:
+            session.add(db.ProjectTag(project_id=project_id, tag=tag))
     session.commit()
     session.refresh(project)
     return project

--- a/ada_backend/repositories/project_repository.py
+++ b/ada_backend/repositories/project_repository.py
@@ -3,6 +3,7 @@ from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import and_, distinct, exists, or_, select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session, joinedload
 
 from ada_backend.database import models as db
@@ -13,6 +14,10 @@ from ada_backend.schemas.project_schema import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _normalize_tags(tags: list[str]) -> set[str]:
+    return {t.lower().strip() for t in tags if t.strip()}
 
 
 def _extract_tags(project: db.Project) -> list[str]:
@@ -157,8 +162,7 @@ def get_projects_by_organization_with_details(
         query = query.filter(db.Project.type == type)
 
     if tags:
-        for tag in tags:
-            normalized = tag.lower().strip()
+        for normalized in _normalize_tags(tags):
             query = query.filter(
                 exists().where(
                     and_(
@@ -245,8 +249,7 @@ def insert_project(
         raise ValueError(f"Invalid project_type: {project_type!r}")
     session.add(project)
     if tags:
-        normalized_tags = {t.lower().strip() for t in tags if t.strip()}
-        for tag in normalized_tags:
+        for tag in _normalize_tags(tags):
             session.add(db.ProjectTag(project_id=project_id, tag=tag))
     session.commit()
     session.refresh(project)
@@ -276,8 +279,7 @@ def update_project(
         project.icon_color = icon_color
     if tags is not None:
         session.query(db.ProjectTag).filter(db.ProjectTag.project_id == project_id).delete()
-        normalized_tags = {t.lower().strip() for t in tags if t.strip()}
-        for tag in normalized_tags:
+        for tag in _normalize_tags(tags):
             session.add(db.ProjectTag(project_id=project_id, tag=tag))
     session.commit()
     session.refresh(project)
@@ -290,17 +292,17 @@ def add_tags_to_project(
     project_id: UUID,
     tags: list[str],
 ) -> list[str]:
-    existing = {
-        row.tag
-        for row in session.query(db.ProjectTag.tag).filter(db.ProjectTag.project_id == project_id).all()
-    }
-    for tag in tags:
-        normalized = tag.lower().strip()
-        if normalized and normalized not in existing:
-            session.add(db.ProjectTag(project_id=project_id, tag=normalized))
-            existing.add(normalized)
+    normalized = _normalize_tags(tags)
+    if normalized:
+        stmt = (
+            insert(db.ProjectTag)
+            .values([{"project_id": project_id, "tag": t} for t in normalized])
+            .on_conflict_do_nothing(index_elements=["project_id", "tag"])
+        )
+        session.execute(stmt)
     session.commit()
-    return sorted(existing)
+    rows = session.query(db.ProjectTag.tag).filter(db.ProjectTag.project_id == project_id).all()
+    return sorted(row.tag for row in rows)
 
 
 def remove_tag_from_project(

--- a/ada_backend/repositories/project_repository.py
+++ b/ada_backend/repositories/project_repository.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy import and_, exists, or_
+from sqlalchemy import and_, distinct, exists, or_, select
 from sqlalchemy.orm import Session, joinedload
 
 from ada_backend.database import models as db
@@ -13,6 +13,10 @@ from ada_backend.schemas.project_schema import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _extract_tags(project: db.Project) -> list[str]:
+    return sorted(pt.tag for pt in project.tags) if project.tags else []
 
 
 # --- READ operations ---
@@ -54,7 +58,8 @@ def get_project_with_details(
                 db.GraphRunner.version_name,
                 db.GraphRunner.change_log,
                 db.GraphRunner.created_at,
-            )
+            ),
+            joinedload(db.Project.tags),
         )
         .filter(db.Project.id == project_id)
         .first()
@@ -79,7 +84,6 @@ def get_project_with_details(
         if env_binding.graph_runner
     ]
 
-    # Sort by GraphRunner.created_at, ProjectEnvironmentBinding.created_at, GraphRunner.id
     graph_runners_data.sort(
         key=lambda x: (x[0].created_at, x[1].created_at, x[0].id)
     )
@@ -97,6 +101,7 @@ def get_project_with_details(
         organization_id=project.organization_id,
         created_at=str(project.created_at),
         updated_at=str(project.updated_at),
+        tags=_extract_tags(project),
     )
 
 
@@ -113,9 +118,11 @@ def get_projects_by_organization_with_details(
     organization_id: UUID,
     type: Optional[db.ProjectType] = db.ProjectType.WORKFLOW,
     include_templates: bool = False,
+    tags: Optional[list[str]] = None,
 ) -> list[ProjectWithGraphRunnersSchema]:
     """
     Get projects (both workflow and agent) by organization with graph runners and templates.
+    When tags is provided, only projects that have ALL specified tags are returned.
     """
 
     query = session.query(db.Project).options(
@@ -126,11 +133,11 @@ def get_projects_by_organization_with_details(
             db.GraphRunner.tag_version,
             db.GraphRunner.version_name,
             db.GraphRunner.change_log,
-        )
+        ),
+        joinedload(db.Project.tags),
     )
 
     if include_templates:
-        # Include own projects + production templates from template org
         has_production = exists().where(
             and_(
                 db.ProjectEnvironmentBinding.project_id == db.Project.id,
@@ -149,17 +156,27 @@ def get_projects_by_organization_with_details(
     if type:
         query = query.filter(db.Project.type == type)
 
+    if tags:
+        for tag in tags:
+            normalized = tag.lower().strip()
+            query = query.filter(
+                exists().where(
+                    and_(
+                        db.ProjectTag.project_id == db.Project.id,
+                        db.ProjectTag.tag == normalized,
+                    )
+                )
+            )
+
     projects = query.order_by(db.Project.created_at).all()
 
     project_schemas = []
     for project in projects:
-        # Context-aware: templates only when viewed from other orgs
         is_template = (
             str(organization_id) != TEMPLATE_ORGANIZATION_ID
             and str(project.organization_id) == TEMPLATE_ORGANIZATION_ID
         )
 
-        # For templates, only include production graph runners
         graph_runners = [
             GraphRunnerEnvDTO(
                 graph_runner_id=env_binding.graph_runner.id,
@@ -185,6 +202,7 @@ def get_projects_by_organization_with_details(
                 updated_at=str(project.updated_at),
                 graph_runners=graph_runners,
                 is_template=is_template,
+                tags=_extract_tags(project),
             )
         )
 
@@ -201,6 +219,7 @@ def insert_project(
     project_type: Optional[db.ProjectType] = db.ProjectType.WORKFLOW,
     icon: Optional[str] = None,
     icon_color: Optional[str] = None,
+    tags: Optional[list[str]] = None,
 ) -> db.Project:
     if project_type == db.ProjectType.WORKFLOW:
         project = db.WorkflowProject(
@@ -225,6 +244,9 @@ def insert_project(
     else:
         raise ValueError(f"Invalid project_type: {project_type!r}")
     session.add(project)
+    if tags:
+        for tag in tags:
+            session.add(db.ProjectTag(project_id=project_id, tag=tag.lower().strip()))
     session.commit()
     session.refresh(project)
     return project
@@ -238,6 +260,7 @@ def update_project(
     description: Optional[str] = None,
     icon: Optional[str] = None,
     icon_color: Optional[str] = None,
+    tags: Optional[list[str]] = None,
 ) -> db.Project:
     project = get_project(session, project_id=project_id)
     if not project:
@@ -250,9 +273,63 @@ def update_project(
         project.icon = icon
     if icon_color is not None:
         project.icon_color = icon_color
+    if tags is not None:
+        session.query(db.ProjectTag).filter(db.ProjectTag.project_id == project_id).delete()
+        for tag in tags:
+            session.add(db.ProjectTag(project_id=project_id, tag=tag.lower().strip()))
     session.commit()
     session.refresh(project)
     return project
+
+
+# --- TAG operations ---
+def add_tags_to_project(
+    session: Session,
+    project_id: UUID,
+    tags: list[str],
+) -> list[str]:
+    existing = {
+        row.tag
+        for row in session.query(db.ProjectTag.tag).filter(db.ProjectTag.project_id == project_id).all()
+    }
+    for tag in tags:
+        normalized = tag.lower().strip()
+        if normalized and normalized not in existing:
+            session.add(db.ProjectTag(project_id=project_id, tag=normalized))
+            existing.add(normalized)
+    session.commit()
+    return sorted(existing)
+
+
+def remove_tag_from_project(
+    session: Session,
+    project_id: UUID,
+    tag: str,
+) -> list[str]:
+    session.query(db.ProjectTag).filter(
+        db.ProjectTag.project_id == project_id,
+        db.ProjectTag.tag == tag.lower().strip(),
+    ).delete()
+    session.commit()
+    remaining = session.query(db.ProjectTag.tag).filter(db.ProjectTag.project_id == project_id).all()
+    return sorted(row.tag for row in remaining)
+
+
+def get_tags_for_organization(
+    session: Session,
+    organization_id: UUID,
+) -> list[str]:
+    rows = (
+        session.execute(
+            select(distinct(db.ProjectTag.tag))
+            .join(db.Project, db.ProjectTag.project_id == db.Project.id)
+            .where(db.Project.organization_id == organization_id)
+            .order_by(db.ProjectTag.tag)
+        )
+        .scalars()
+        .all()
+    )
+    return list(rows)
 
 
 # --- DELETE operations ---

--- a/ada_backend/routers/project_router.py
+++ b/ada_backend/routers/project_router.py
@@ -206,8 +206,8 @@ def add_tags_endpoint(
 ):
     try:
         return add_tags_to_project_service(session, project_id, body.tags)
-    except ProjectNotFound:
-        raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
+    except ProjectNotFound as e:
+        raise HTTPException(status_code=404, detail=f"Project {project_id} not found") from e
     except Exception as e:
         LOGGER.error(f"Failed to add tags to project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error") from e
@@ -225,8 +225,8 @@ def remove_tag_endpoint(
 ):
     try:
         return remove_tag_from_project_service(session, project_id, tag)
-    except ProjectNotFound:
-        raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
+    except ProjectNotFound as e:
+        raise HTTPException(status_code=404, detail=f"Project {project_id} not found") from e
     except Exception as e:
         LOGGER.error(f"Failed to remove tag from project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/ada_backend/routers/project_router.py
+++ b/ada_backend/routers/project_router.py
@@ -24,6 +24,7 @@ from ada_backend.schemas.project_schema import (
     ProjectCreateSchema,
     ProjectDeleteResponse,
     ProjectSchema,
+    ProjectTagsInput,
     ProjectUpdateSchema,
     ProjectWithGraphRunnersSchema,
 )
@@ -43,10 +44,13 @@ from ada_backend.services.errors import (
 )
 from ada_backend.services.metrics.monitor_kpis_service import get_monitoring_kpis_by_projects
 from ada_backend.services.project_service import (
+    add_tags_to_project_service,
     create_workflow,
     delete_project_service,
     get_project_service,
     get_projects_by_organization_with_details_service,
+    get_tags_for_organization_service,
+    remove_tag_from_project_service,
     update_project_service,
 )
 from ada_backend.services.run_service import create_run, run_with_tracking, update_run_status
@@ -80,9 +84,12 @@ def get_projects_by_organization_endpoint(
     session: Session = Depends(get_db),
     type: Optional[ProjectType] = ProjectType.WORKFLOW,
     include_templates: Optional[bool] = False,
+    tags: Optional[List[str]] = Query(None),
 ):
     try:
-        return get_projects_by_organization_with_details_service(session, organization_id, type, include_templates)
+        return get_projects_by_organization_with_details_service(
+            session, organization_id, type, include_templates, tags=tags
+        )
     except ValueError as e:
         LOGGER.error(
             f"Failed to list workflows for organization {organization_id} user_id={auth.user_id}: {str(e)}",
@@ -92,6 +99,29 @@ def get_projects_by_organization_endpoint(
     except Exception as e:
         LOGGER.error(
             f"Failed to list workflows for organization {organization_id} user_id={auth.user_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.get("/org/{organization_id}/tags", response_model=List[str], tags=["Projects"])
+def get_organization_tags_endpoint(
+    organization_id: UUID,
+    auth: Annotated[
+        AuthenticatedEntity,
+        Depends(
+            user_has_access_to_organization_xor_verify_api_key(
+                allowed_roles=UserRights.MEMBER.value,
+            )
+        ),
+    ],
+    session: Session = Depends(get_db),
+):
+    try:
+        return get_tags_for_organization_service(session, organization_id)
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to list tags for organization {organization_id} user_id={auth.user_id}: {str(e)}",
             exc_info=True,
         )
         raise HTTPException(status_code=500, detail="Internal server error") from e
@@ -161,6 +191,44 @@ def update_project_endpoint(
         raise HTTPException(status_code=400, detail="Bad request") from e
     except Exception as e:
         LOGGER.error(f"Failed to update project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post("/{project_id}/tags", response_model=List[str], tags=["Projects"])
+def add_tags_endpoint(
+    project_id: UUID,
+    body: ProjectTagsInput,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+):
+    try:
+        return add_tags_to_project_service(session, project_id, body.tags)
+    except ProjectNotFound:
+        raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
+    except Exception as e:
+        LOGGER.error(f"Failed to add tags to project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete("/{project_id}/tags/{tag}", response_model=List[str], tags=["Projects"])
+def remove_tag_endpoint(
+    project_id: UUID,
+    tag: str,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+):
+    try:
+        return remove_tag_from_project_service(session, project_id, tag)
+    except ProjectNotFound:
+        raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
+    except Exception as e:
+        LOGGER.error(f"Failed to remove tag from project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 

--- a/ada_backend/schemas/agent_schema.py
+++ b/ada_backend/schemas/agent_schema.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from ada_backend.schemas.parameter_schema import PipelineParameterReadSchema, PipelineParameterSchema
 from ada_backend.schemas.pipeline.base import ComponentInstanceSchema
@@ -18,6 +18,7 @@ class ProjectAgentSchema(BaseModel):
     icon: Optional[str] = None
     icon_color: Optional[str] = None
     template: Optional[InputTemplate] = None
+    tags: list[str] = Field(default_factory=list)
 
 
 class AgentInfoSchema(BaseModel):

--- a/ada_backend/schemas/project_schema.py
+++ b/ada_backend/schemas/project_schema.py
@@ -80,4 +80,4 @@ class ProjectDeleteResponse(BaseModel):
 
 
 class ProjectTagsInput(BaseModel):
-    tags: list[str] = Field(default_factory=list, min_length=1)
+    tags: list[str] = Field(min_length=1)

--- a/ada_backend/schemas/project_schema.py
+++ b/ada_backend/schemas/project_schema.py
@@ -33,6 +33,7 @@ class ProjectSchema(BaseModel):
 
 class ProjectCreateSchema(ProjectSchema):
     template: Optional[InputTemplate] = None
+    tags: list[str] = Field(default_factory=list)
 
 
 class ProjectUpdateSchema(BaseModel):
@@ -40,12 +41,14 @@ class ProjectUpdateSchema(BaseModel):
     description: Optional[str] = None
     icon: Optional[str] = None
     icon_color: Optional[str] = None
+    tags: Optional[list[str]] = None
 
 
 class ProjectResponse(ProjectSchema):
     organization_id: UUID
     created_at: str
     updated_at: str
+    tags: list[str] = Field(default_factory=list)
 
 
 class GraphRunnerEnvDTO(BaseModel):
@@ -74,3 +77,7 @@ class ChatResponse(BaseModel):
 class ProjectDeleteResponse(BaseModel):
     project_id: UUID
     graph_runner_ids: list[UUID] = Field(default_factory=list)
+
+
+class ProjectTagsInput(BaseModel):
+    tags: list[str] = Field(default_factory=list, min_length=1)

--- a/ada_backend/services/agents_service.py
+++ b/ada_backend/services/agents_service.py
@@ -203,7 +203,7 @@ def create_new_agent_service(
         user_id, organization_id, project.id, project.name, from_template=agent_data.template is not None,
     )
 
-    tags = sorted(pt.tag for pt in project.tags) if project.tags else []
+    tags = sorted(pt.tag for pt in project.tags)
     return ProjectWithGraphRunnersSchema(
         project_id=project.id,
         project_name=project.name,

--- a/ada_backend/services/agents_service.py
+++ b/ada_backend/services/agents_service.py
@@ -186,6 +186,7 @@ def create_new_agent_service(
         add_input=False,
         icon=agent_data.icon,
         icon_color=agent_data.icon_color,
+        tags=agent_data.tags,
     )
 
     if agent_data.template is None:
@@ -202,6 +203,7 @@ def create_new_agent_service(
         user_id, organization_id, project.id, project.name, from_template=agent_data.template is not None,
     )
 
+    tags = sorted(pt.tag for pt in project.tags) if project.tags else []
     return ProjectWithGraphRunnersSchema(
         project_id=project.id,
         project_name=project.name,
@@ -218,6 +220,7 @@ def create_new_agent_service(
                 env=db.EnvType.DRAFT,
             )
         ],
+        tags=tags,
     )
 
 

--- a/ada_backend/services/git_sync_service.py
+++ b/ada_backend/services/git_sync_service.py
@@ -129,6 +129,7 @@ async def import_from_github(
             template=None,
             graph_id=uuid4(),
             add_input=True,
+            tags=["github"],
         )
 
         try:

--- a/ada_backend/services/project_service.py
+++ b/ada_backend/services/project_service.py
@@ -14,12 +14,15 @@ from ada_backend.repositories.graph_runner_repository import (
     insert_graph_runner,
 )
 from ada_backend.repositories.project_repository import (
+    add_tags_to_project,
     delete_project,
     get_project,
     get_project_with_details,
     get_projects_by_organization_with_details,
+    get_tags_for_organization,
     get_workflows_by_organization,
     insert_project,
+    remove_tag_from_project,
     update_project,
 )
 from ada_backend.schemas.project_schema import (
@@ -85,8 +88,9 @@ def get_projects_by_organization_with_details_service(
     organization_id: UUID,
     type: Optional[ProjectType] = ProjectType.WORKFLOW,
     include_templates: Optional[bool] = False,
+    tags: Optional[list[str]] = None,
 ) -> list[ProjectWithGraphRunnersSchema]:
-    return get_projects_by_organization_with_details(session, organization_id, type, include_templates)
+    return get_projects_by_organization_with_details(session, organization_id, type, include_templates, tags=tags)
 
 
 def delete_project_service(session: Session, project_id: UUID) -> ProjectDeleteResponse:
@@ -113,6 +117,7 @@ def create_project_with_graph_runner(
     add_input: bool,
     icon: Optional[str] = None,
     icon_color: Optional[str] = None,
+    tags: Optional[list[str]] = None,
 ) -> tuple:
     """
     Shared helper function to create a project with a graph runner.
@@ -150,6 +155,7 @@ def create_project_with_graph_runner(
         project_type=project_type,
         icon=icon,
         icon_color=icon_color,
+        tags=tags,
     )
 
     bind_graph_runner_to_project(
@@ -182,12 +188,14 @@ def create_workflow(
         add_input=True,
         icon=project_schema.icon,
         icon_color=project_schema.icon_color,
+        tags=project_schema.tags,
     )
 
     track_project_created(
         user_id, organization_id, project.id, project.name,
         project_type="workflow", from_template=project_schema.template is not None,
     )
+    tags = sorted(pt.tag for pt in project.tags) if project.tags else []
     return ProjectWithGraphRunnersSchema(
         project_id=project.id,
         project_name=project.name,
@@ -204,6 +212,7 @@ def create_workflow(
                 env=EnvType.DRAFT,
             )
         ],
+        tags=tags,
     )
 
 
@@ -220,6 +229,7 @@ def update_project_service(
         description=project_schema.description,
         icon=project_schema.icon,
         icon_color=project_schema.icon_color,
+        tags=project_schema.tags,
     )
     if not project:
         raise ProjectNotFound(project_id)
@@ -231,3 +241,32 @@ def update_project_service(
         icon=project.icon,
         icon_color=project.icon_color,
     )
+
+
+def add_tags_to_project_service(
+    session: Session,
+    project_id: UUID,
+    tags: list[str],
+) -> list[str]:
+    project = get_project(session, project_id=project_id)
+    if not project:
+        raise ProjectNotFound(project_id)
+    return add_tags_to_project(session, project_id, tags)
+
+
+def remove_tag_from_project_service(
+    session: Session,
+    project_id: UUID,
+    tag: str,
+) -> list[str]:
+    project = get_project(session, project_id=project_id)
+    if not project:
+        raise ProjectNotFound(project_id)
+    return remove_tag_from_project(session, project_id, tag)
+
+
+def get_tags_for_organization_service(
+    session: Session,
+    organization_id: UUID,
+) -> list[str]:
+    return get_tags_for_organization(session, organization_id)

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -3,12 +3,18 @@ import { $api } from '@/utils/api'
 export const workflowsApi = {
   getAll: () => $api('/projects'),
   getById: (projectId: string) => $api(`/projects/${projectId}`),
-  getByOrgId: (organizationId: string, type?: 'AGENT' | 'WORKFLOW', includeTemplates?: boolean) => {
+  getByOrgId: (
+    organizationId: string,
+    type?: 'AGENT' | 'WORKFLOW',
+    includeTemplates?: boolean,
+    tags?: string[]
+  ) => {
     const params: Record<string, any> = {}
     if (type) {
       params.type = type.toLowerCase()
     }
     if (includeTemplates !== undefined) params.include_templates = includeTemplates
+    if (tags && tags.length > 0) params.tags = tags
 
     return $api(`/projects/org/${organizationId}`, { query: params })
   },
@@ -22,9 +28,16 @@ export const workflowsApi = {
       companion_image_url?: string
       icon?: string
       icon_color?: string
+      tags?: string[]
     }
   ) => $api(`/projects/${projectId}`, { method: 'PATCH', body: data }),
   delete: (projectId: string) => $api(`/projects/${projectId}`, { method: 'DELETE' }),
+  getOrgTags: (organizationId: string): Promise<string[]> =>
+    $api(`/projects/org/${organizationId}/tags`),
+  addTags: (projectId: string, tags: string[]): Promise<string[]> =>
+    $api(`/projects/${projectId}/tags`, { method: 'POST', body: { tags } }),
+  removeTag: (projectId: string, tag: string): Promise<string[]> =>
+    $api(`/projects/${projectId}/tags/${encodeURIComponent(tag)}`, { method: 'DELETE' }),
 }
 
 export const templatesApi = {

--- a/frontend/src/components/projects/ProjectCard.vue
+++ b/frontend/src/components/projects/ProjectCard.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 import ProjectAvatar from './ProjectAvatar.vue'
 import { useTextTruncated } from '@/composables/useTextTruncated'
+import { tagColor } from '@/utils/tagColor'
 
 interface GraphRunner {
   graph_runner_id: string
@@ -20,6 +21,7 @@ interface Project {
   graph_runners?: GraphRunner[]
   project_type?: 'AGENT' | 'WORKFLOW'
   is_template?: boolean
+  tags?: string[]
 }
 
 interface Props {
@@ -79,9 +81,20 @@ const versionCount = computed(() => {
 })
 
 const canDuplicate = computed(() => {
-  // Check projectType prop first, then fall back to project.project_type
   const type = props.projectType || props.project.project_type
   return props.canEdit && type === 'WORKFLOW'
+})
+
+const visibleTags = computed(() => {
+  const tags = props.project.tags
+  if (!tags || tags.length === 0) return []
+  return tags.slice(0, 3)
+})
+
+const hiddenTagCount = computed(() => {
+  const tags = props.project.tags
+  if (!tags) return 0
+  return Math.max(0, tags.length - 3)
 })
 </script>
 
@@ -158,8 +171,25 @@ const canDuplicate = computed(() => {
         </div>
       </div>
 
-      <div class="d-flex align-center justify-end">
-        <VChip size="x-small" variant="tonal" color="primary">
+      <div class="d-flex align-center justify-space-between gap-2">
+        <div v-if="visibleTags.length > 0" class="d-flex align-center gap-1 min-width-0 tags-row">
+          <VChip
+            v-for="tag in visibleTags"
+            :key="tag"
+            size="x-small"
+            variant="tonal"
+            :color="tagColor(tag)"
+            label
+            class="tag-chip"
+          >
+            {{ tag }}
+          </VChip>
+          <VChip v-if="hiddenTagCount > 0" size="x-small" variant="text" color="secondary" class="tag-chip">
+            +{{ hiddenTagCount }}
+          </VChip>
+        </div>
+        <VSpacer v-else />
+        <VChip size="x-small" variant="tonal" color="primary" class="flex-shrink-0">
           <VIcon icon="tabler-versions" size="12" class="me-1" />
           {{ versionCount }} {{ versionCount === 1 ? 'version' : 'versions' }}
         </VChip>
@@ -209,5 +239,18 @@ const canDuplicate = computed(() => {
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.tags-row {
+  overflow: hidden;
+}
+
+.tag-chip {
+  max-inline-size: 80px;
+  :deep(.v-chip__content) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 </style>

--- a/frontend/src/components/projects/ProjectListView.vue
+++ b/frontend/src/components/projects/ProjectListView.vue
@@ -510,7 +510,7 @@ defineExpose({
           Your {{ type === 'AGENT' ? 'agents' : 'workflows' }}
         </span>
         <VAutocomplete
-          v-if="orgTags && orgTags.length > 0"
+          v-if="(orgTags && orgTags.length > 0) || selectedTags.length > 0"
           v-model="selectedTags"
           :items="orgTags"
           placeholder="Filter by tags…"

--- a/frontend/src/components/projects/ProjectListView.vue
+++ b/frontend/src/components/projects/ProjectListView.vue
@@ -6,10 +6,12 @@ import { useRouter } from 'vue-router'
 import ProjectCard from './ProjectCard.vue'
 import TemplateCard from './TemplateCard.vue'
 import { logger } from '@/utils/logger'
+import { tagColor } from '@/utils/tagColor'
 import {
   fetchProject,
   useDeleteProjectMutation,
   useDuplicateProjectMutation,
+  useOrgTagsQuery,
   useProjectsQuery,
 } from '@/composables/queries/useProjectsQuery'
 import { fetchAgentDetail, useDeleteAgentMutation } from '@/composables/queries/useAgentsQuery'
@@ -31,6 +33,7 @@ interface Project {
   graph_runners?: GraphRunner[]
   project_type?: 'AGENT' | 'WORKFLOW'
   is_template?: boolean
+  tags?: string[]
 }
 
 interface Props {
@@ -58,15 +61,19 @@ const duplicateProjectMutation = useDuplicateProjectMutation()
 const deleteProjectMutation = useDeleteProjectMutation()
 const deleteAgentMutation = useDeleteAgentMutation()
 
-// Use TanStack Query for caching and data fetching
 const projectType = computed(() => props.type)
+const selectedTags = ref<string[]>([])
+
+const { data: orgTags } = useOrgTagsQuery(selectedOrgId)
+
+const selectedTagsRef = computed(() => (selectedTags.value.length > 0 ? selectedTags.value : undefined))
 
 const {
   data: allProjects,
   isLoading: loading,
   error: queryError,
   refetch,
-} = useProjectsQuery(selectedOrgId, projectType, true)
+} = useProjectsQuery(selectedOrgId, projectType, true, selectedTagsRef)
 
 const projects = ref<Project[]>([])
 const templates = ref<Project[]>([])
@@ -495,14 +502,43 @@ defineExpose({
       </div>
 
       <!-- Projects Grid -->
-      <div v-if="projects.length > 0">
+      <div v-if="projects.length > 0 || selectedTags.length > 0">
         <span
           class="text-body-2 text-medium-emphasis font-weight-medium text-uppercase d-block mb-3"
           style="letter-spacing: 0.05em"
         >
           Your {{ type === 'AGENT' ? 'agents' : 'workflows' }}
         </span>
-        <div class="projects-grid">
+        <VAutocomplete
+          v-if="orgTags && orgTags.length > 0"
+          v-model="selectedTags"
+          :items="orgTags"
+          placeholder="Filter by tags…"
+          variant="solo-filled"
+          flat
+          density="compact"
+          multiple
+          chips
+          closable-chips
+          hide-details
+          clearable
+          single-line
+          class="tags-filter mb-4"
+        >
+          <template #prepend-inner>
+            <VIcon icon="tabler-filter" size="14" class="me-1 text-medium-emphasis" />
+          </template>
+          <template #chip="{ props: chipProps, item }">
+            <VChip v-bind="chipProps" size="x-small" variant="tonal" :color="tagColor(item.raw)" label closable>
+              {{ item.raw }}
+            </VChip>
+          </template>
+        </VAutocomplete>
+
+        <div v-if="projects.length === 0 && selectedTags.length > 0" class="text-body-2 text-medium-emphasis pa-4">
+          No {{ type === 'AGENT' ? 'agents' : 'workflows' }} match the selected tags.
+        </div>
+        <div v-else class="projects-grid">
           <ProjectCard
             v-for="project in projects"
             :key="project.project_id"
@@ -586,6 +622,24 @@ defineExpose({
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+
+.tags-filter {
+  max-inline-size: 220px;
+
+  :deep(.v-field) {
+    --v-field-padding-start: 8px;
+    --v-field-padding-end: 4px;
+    --v-input-padding-top: 4px;
+    min-block-size: 32px;
+    font-size: 0.8125rem;
+    border-radius: 8px;
+  }
+
+  :deep(.v-field__input) {
+    padding-block: 2px;
+    min-block-size: unset;
+  }
 }
 
 .create-blank-card {

--- a/frontend/src/components/shared/EditEntityModal.vue
+++ b/frontend/src/components/shared/EditEntityModal.vue
@@ -1,47 +1,52 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { logger } from '@/utils/logger'
+import { tagColor } from '@/utils/tagColor'
 
 interface Props {
   entityId: string
   entityName: string
   entityDescription?: string
+  entityTags?: string[]
+  availableTags?: string[]
   modelValue: boolean
-  entityType: 'agent' | 'project' // For display purposes
+  entityType: 'agent' | 'project'
   saveFunction: (id: string, data: any) => Promise<void>
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  entityTags: () => [],
+  availableTags: () => [],
+})
 
 const emit = defineEmits<{
   'update:modelValue': [value: boolean]
-  updated: [data: { name: string; description: string }]
+  updated: [data: { name: string; description: string; tags: string[] }]
 }>()
 
 const editedName = ref('')
 const editedDescription = ref('')
+const editedTags = ref<string[]>([])
 const nameError = ref('')
 const isSaving = ref(false)
 
-// Watch for prop changes
 watch(
   () => props.modelValue,
   isOpen => {
     if (isOpen) {
       editedName.value = props.entityName
       editedDescription.value = props.entityDescription || ''
+      editedTags.value = [...(props.entityTags || [])]
       nameError.value = ''
     }
   },
   { immediate: true }
 )
 
-// Close dialog
 const closeDialog = () => {
   emit('update:modelValue', false)
 }
 
-// Save changes
 const saveEntity = async () => {
   if (!editedName.value.trim()) {
     nameError.value = `${props.entityType === 'agent' ? 'Agent' : 'Project'} name cannot be empty`
@@ -52,14 +57,18 @@ const saveEntity = async () => {
   nameError.value = ''
 
   try {
+    const normalizedTags = [...new Set(editedTags.value.map(t => t.toLowerCase().trim()).filter(Boolean))]
+
     await props.saveFunction(props.entityId, {
       name: editedName.value.trim(),
       description: editedDescription.value.trim(),
+      tags: normalizedTags,
     })
 
     emit('updated', {
       name: editedName.value.trim(),
       description: editedDescription.value.trim(),
+      tags: normalizedTags,
     })
     closeDialog()
   } catch (error) {
@@ -70,7 +79,6 @@ const saveEntity = async () => {
   }
 }
 
-// Entity type display
 const entityTypeDisplay = computed(() => (props.entityType === 'agent' ? 'Agent' : 'Project'))
 </script>
 
@@ -108,7 +116,27 @@ const entityTypeDisplay = computed(() => (props.entityType === 'agent' ? 'Agent'
           rows="4"
           :disabled="isSaving"
           :placeholder="`Brief description of what this ${entityType} does...`"
+          class="mb-4"
         />
+
+        <VCombobox
+          v-model="editedTags"
+          :items="availableTags"
+          label="Tags"
+          variant="outlined"
+          multiple
+          chips
+          closable-chips
+          :disabled="isSaving"
+          placeholder="Type to add a tag…"
+          hide-details
+        >
+          <template #chip="{ props: chipProps, item }">
+            <VChip v-bind="chipProps" size="small" variant="tonal" :color="tagColor(item.raw)" label closable>
+              {{ item.raw }}
+            </VChip>
+          </template>
+        </VCombobox>
       </VCardText>
 
       <VDivider />

--- a/frontend/src/composables/queries/useProjectsQuery.ts
+++ b/frontend/src/composables/queries/useProjectsQuery.ts
@@ -24,7 +24,8 @@ export interface Project {
   is_template?: boolean
   created_at?: string
   updated_at?: string
-  graph_runners?: GraphRunner[] // Optional: only present when fetching individual project details
+  graph_runners?: GraphRunner[]
+  tags?: string[]
 }
 
 // Interface for project creation data
@@ -59,14 +60,15 @@ const playgroundConfig = ref<{
 async function fetchProjects(
   organizationId: string,
   type?: 'AGENT' | 'WORKFLOW',
-  includeTemplates?: boolean
+  includeTemplates?: boolean,
+  tags?: string[]
 ): Promise<Project[]> {
   logNetworkCall(
-    ['projects', organizationId, type, includeTemplates],
+    ['projects', organizationId, type, includeTemplates, tags],
     `/projects/org/${organizationId}?type=${type}&include_templates=${includeTemplates}`
   )
 
-  const data = await scopeoApi.projects.getByOrgId(organizationId, type, includeTemplates)
+  const data = await scopeoApi.projects.getByOrgId(organizationId, type, includeTemplates, tags)
   return data || []
 }
 
@@ -89,7 +91,8 @@ export async function fetchProject(projectId: string): Promise<Project> {
 export function useProjectsQuery(
   orgId: Ref<string | undefined>,
   type?: Ref<'AGENT' | 'WORKFLOW' | undefined> | 'AGENT' | 'WORKFLOW',
-  includeTemplates?: Ref<boolean | undefined> | boolean
+  includeTemplates?: Ref<boolean | undefined> | boolean,
+  tags?: Ref<string[] | undefined>
 ) {
   const typeValue = computed(() => (typeof type === 'object' ? type.value : type))
 
@@ -97,7 +100,15 @@ export function useProjectsQuery(
     typeof includeTemplates === 'object' ? includeTemplates.value : includeTemplates
   )
 
-  const queryKey = computed(() => ['projects', orgId.value, typeValue.value, includeTemplatesValue.value])
+  const tagsValue = computed(() => tags?.value)
+
+  const queryKey = computed(() => [
+    'projects',
+    orgId.value,
+    typeValue.value,
+    includeTemplatesValue.value,
+    tagsValue.value,
+  ])
 
   logQueryStart(queryKey.value, 'useProjectsQuery')
 
@@ -105,12 +116,27 @@ export function useProjectsQuery(
     queryKey,
     queryFn: () => {
       if (!orgId.value) throw new Error('No organization ID provided')
-      return fetchProjects(orgId.value, typeValue.value, includeTemplatesValue.value)
+      return fetchProjects(orgId.value, typeValue.value, includeTemplatesValue.value, tagsValue.value)
     },
     enabled: computed(() => !!orgId.value),
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 30,
     refetchOnMount: true,
+  })
+}
+
+/**
+ * Fetch all distinct tags for an organization (autocomplete)
+ */
+export function useOrgTagsQuery(orgId: Ref<string | undefined>) {
+  return useQuery({
+    queryKey: computed(() => ['org-tags', orgId.value]),
+    queryFn: () => {
+      if (!orgId.value) throw new Error('No organization ID provided')
+      return scopeoApi.projects.getOrgTags(orgId.value)
+    },
+    enabled: computed(() => !!orgId.value),
+    staleTime: 1000 * 60 * 2,
   })
 }
 
@@ -248,7 +274,7 @@ export function useUpdateProjectMutation() {
       data,
     }: {
       projectId: string
-      data: { name?: string; description?: string; icon?: string; icon_color?: string }
+      data: { name?: string; description?: string; icon?: string; icon_color?: string; tags?: string[] }
     }) => {
       const updateData: any = {}
       if (data.name !== undefined) {
@@ -263,11 +289,13 @@ export function useUpdateProjectMutation() {
       if (data.icon_color !== undefined) {
         updateData.icon_color = data.icon_color
       }
+      if (data.tags !== undefined) {
+        updateData.tags = data.tags
+      }
 
       logNetworkCall(['update-project', projectId], `/projects/${projectId}`)
       await scopeoApi.projects.updateProject(projectId, updateData)
 
-      // Update the current project if it matches
       if (currentProject.value?.project_id === projectId) {
         if (data.name !== undefined) {
           currentProject.value.project_name = data.name
@@ -281,13 +309,18 @@ export function useUpdateProjectMutation() {
         if (data.icon_color !== undefined) {
           currentProject.value.icon_color = data.icon_color
         }
+        if (data.tags !== undefined) {
+          currentProject.value.tags = data.tags
+        }
       }
     },
     onSuccess: (_data, variables) => {
-      // Invalidate both the single project and projects list
       queryClient.invalidateQueries({ queryKey: ['project', variables.projectId] })
       queryClient.invalidateQueries({ queryKey: ['projects'] })
       queryClient.invalidateQueries({ queryKey: ['agents'] })
+      if (variables.data.tags !== undefined) {
+        queryClient.invalidateQueries({ queryKey: ['org-tags'] })
+      }
     },
   })
 }

--- a/frontend/src/composables/useProjectEntityEditor.ts
+++ b/frontend/src/composables/useProjectEntityEditor.ts
@@ -1,8 +1,10 @@
 import { type Ref, ref } from 'vue'
+import { useQueryClient } from '@tanstack/vue-query'
 import { useRouter } from 'vue-router'
 import { generateProjectNameAndAvatar } from '@/utils/randomNameGenerator'
 import { scopeoApi } from '@/api'
 import { DEFAULT_PROJECT_COLOR } from '@/composables/useProjectDefaults'
+import { useOrgTagsQuery } from '@/composables/queries/useProjectsQuery'
 import { logger } from '@/utils/logger'
 
 type ProjectListViewInstance = InstanceType<(typeof import('@/components/projects/ProjectListView.vue'))['default']>
@@ -13,6 +15,7 @@ export interface ProjectEntity {
   description?: string | null
   icon?: string
   icon_color?: string
+  tags?: string[]
   graph_runners?: Array<{ graph_runner_id: string; env: string | null; tag_name: string | null }>
 }
 
@@ -33,6 +36,7 @@ export interface UseProjectEntityEditorOptions {
 
 export function useProjectEntityEditor(options: UseProjectEntityEditorOptions) {
   const router = useRouter()
+  const queryClient = useQueryClient()
   const { entityType, defaultIcon, routePrefix, createMutation, projectListRef, selectedOrgId, onError } = options
 
   const isEditDialogVisible = ref(false)
@@ -40,10 +44,13 @@ export function useProjectEntityEditor(options: UseProjectEntityEditorOptions) {
   const editedName = ref('')
   const editedDescription = ref('')
   const editedIconSelection = ref<IconSelection>({ icon: defaultIcon, iconColor: DEFAULT_PROJECT_COLOR })
+  const editedTags = ref<string[]>([])
   const isUpdating = ref(false)
   const isCreating = ref(false)
   const editError = ref<string | null>(null)
   const createError = ref<string | null>(null)
+
+  const { data: orgTags } = useOrgTagsQuery(selectedOrgId)
 
   const showError = (message: string) => {
     createError.value = message
@@ -151,8 +158,15 @@ export function useProjectEntityEditor(options: UseProjectEntityEditorOptions) {
       icon: entity.icon || defaultIcon,
       iconColor: entity.icon_color || DEFAULT_PROJECT_COLOR,
     }
+    editedTags.value = [...(entity.tags || [])]
     editError.value = null
     isEditDialogVisible.value = true
+  }
+
+  const tagsChanged = () => {
+    const original = [...(entityToEdit.value?.tags || [])].sort()
+    const current = [...editedTags.value].sort()
+    return JSON.stringify(original) !== JSON.stringify(current)
   }
 
   const saveEntity = async () => {
@@ -161,12 +175,14 @@ export function useProjectEntityEditor(options: UseProjectEntityEditorOptions) {
       return
     }
 
-    if (
-      editedName.value === entityToEdit.value.project_name &&
-      editedDescription.value === (entityToEdit.value.description || '') &&
-      editedIconSelection.value.icon === entityToEdit.value.icon &&
-      editedIconSelection.value.iconColor === entityToEdit.value.icon_color
-    ) {
+    const hasChanges =
+      editedName.value !== entityToEdit.value.project_name ||
+      editedDescription.value !== (entityToEdit.value.description || '') ||
+      editedIconSelection.value.icon !== entityToEdit.value.icon ||
+      editedIconSelection.value.iconColor !== entityToEdit.value.icon_color ||
+      tagsChanged()
+
+    if (!hasChanges) {
       isEditDialogVisible.value = false
       return
     }
@@ -175,12 +191,19 @@ export function useProjectEntityEditor(options: UseProjectEntityEditorOptions) {
       isUpdating.value = true
       editError.value = null
 
+      const normalizedTags = editedTags.value.map(t => t.toLowerCase().trim()).filter(Boolean)
+
       await scopeoApi.projects.updateProject(entityToEdit.value.project_id, {
         project_name: editedName.value.trim(),
         description: editedDescription.value.trim() || undefined,
         icon: editedIconSelection.value.icon,
         icon_color: editedIconSelection.value.iconColor,
+        tags: normalizedTags,
       })
+
+      if (tagsChanged()) {
+        queryClient.invalidateQueries({ queryKey: ['org-tags'] })
+      }
 
       isEditDialogVisible.value = false
       await projectListRef.value?.refreshProjects(true)
@@ -198,6 +221,8 @@ export function useProjectEntityEditor(options: UseProjectEntityEditorOptions) {
     editedName,
     editedDescription,
     editedIconSelection,
+    editedTags,
+    orgTags,
     isUpdating,
     isCreating,
     editError,

--- a/frontend/src/composables/useProjectEntityEditor.ts
+++ b/frontend/src/composables/useProjectEntityEditor.ts
@@ -191,7 +191,7 @@ export function useProjectEntityEditor(options: UseProjectEntityEditorOptions) {
       isUpdating.value = true
       editError.value = null
 
-      const normalizedTags = editedTags.value.map(t => t.toLowerCase().trim()).filter(Boolean)
+      const normalizedTags = [...new Set(editedTags.value.map(t => t.toLowerCase().trim()).filter(Boolean))]
 
       await scopeoApi.projects.updateProject(entityToEdit.value.project_id, {
         project_name: editedName.value.trim(),

--- a/frontend/src/pages/org/[orgId]/agents/[id].vue
+++ b/frontend/src/pages/org/[orgId]/agents/[id].vue
@@ -20,6 +20,7 @@ import {
   useUpdateAgentMutation,
 } from '@/composables/queries/useAgentsQuery'
 import { useComponentDefinitionsQuery } from '@/composables/queries/useComponentDefinitionsQuery'
+import { useOrgTagsQuery } from '@/composables/queries/useProjectsQuery'
 import { clearAllChatStates } from '@/composables/usePlaygroundChat'
 import { useSaveVersion } from '@/composables/useSaveVersion'
 import { useSelectedOrg } from '@/composables/useSelectedOrg'
@@ -39,9 +40,8 @@ onMounted(() => {
 })
 
 const { selectedOrgId, orgChangeCounter } = useSelectedOrg()
+const { data: orgTags } = useOrgTagsQuery(selectedOrgId)
 
-// Get component definitions and categories - these are needed for graph rendering
-// They load in parallel with agent data and are cached for 5 minutes
 const {
   components: componentDefinitions,
   categories,
@@ -309,17 +309,24 @@ watch(orgChangeCounter, () => {
 })
 
 // Save agent name/description using the correct API endpoint
-const saveAgentNameAndDescription = async (agentId: string, data: { name: string; description: string }) => {
+const saveAgentNameAndDescription = async (
+  agentId: string,
+  data: { name: string; description: string; tags?: string[] }
+) => {
   if (!agent.value) return
 
-  // Use the projects API to update agent name and description (agents are projects in the backend)
-  await scopeoApi.projects.updateProject(agentId, {
+  const updatePayload: Record<string, any> = {
     project_name: data.name,
     description: data.description,
-  })
+  }
+  if (data.tags !== undefined) {
+    updatePayload.tags = data.tags
+  }
+
+  await scopeoApi.projects.updateProject(agentId, updatePayload)
 }
 
-const handleAgentUpdate = (data: { name: string; description: string }) => {
+const handleAgentUpdate = (data: { name: string; description: string; tags: string[] }) => {
   if (agent.value) {
     agent.value = { ...agent.value, name: data.name, description: data.description }
   }
@@ -518,6 +525,8 @@ definePage({
         :entity-id="(agent as any).project_id || agent.id"
         :entity-name="agent.name"
         :entity-description="agent.description"
+        :entity-tags="agent.tags || []"
+        :available-tags="orgTags || []"
         entity-type="agent"
         :save-function="saveAgentNameAndDescription"
         @updated="handleAgentUpdate"

--- a/frontend/src/pages/org/[orgId]/agents/index.vue
+++ b/frontend/src/pages/org/[orgId]/agents/index.vue
@@ -6,6 +6,7 @@ import { useCreateAgentMutation } from '@/composables/queries/useAgentsQuery'
 import { useSelectedOrg } from '@/composables/useSelectedOrg'
 import { useProjectEntityEditor } from '@/composables/useProjectEntityEditor'
 import { DEFAULT_PROJECT_ICON } from '@/composables/useProjectDefaults'
+import { tagColor } from '@/utils/tagColor'
 
 const { selectedOrgId } = useSelectedOrg()
 
@@ -20,6 +21,8 @@ const {
   editedName: editedAgentName,
   editedDescription: editedAgentDescription,
   editedIconSelection,
+  editedTags,
+  orgTags,
   isUpdating: isUpdatingAgent,
   isCreating,
   editError,
@@ -93,6 +96,25 @@ definePage({
         />
 
         <IconPicker v-model="editedIconSelection" />
+
+        <VCombobox
+          v-model="editedTags"
+          :items="orgTags || []"
+          label="Tags"
+          variant="outlined"
+          multiple
+          chips
+          closable-chips
+          class="mt-4"
+          placeholder="Type to add a tag…"
+          hide-details
+        >
+          <template #chip="{ props: chipProps, item }">
+            <VChip v-bind="chipProps" size="small" variant="tonal" :color="tagColor(item.raw)" label closable>
+              {{ item.raw }}
+            </VChip>
+          </template>
+        </VCombobox>
       </VCardText>
 
       <VCardActions class="justify-end pa-4">

--- a/frontend/src/pages/org/[orgId]/projects/[id].vue
+++ b/frontend/src/pages/org/[orgId]/projects/[id].vue
@@ -10,7 +10,12 @@ import ModificationHistoryDialog from '@/components/shared/ModificationHistoryDi
 import SharedTabContent from '@/components/shared/SharedTabContent.vue'
 import VersionSelectorContainer from '@/components/shared/VersionSelectorContainer.vue'
 import { useComponentDefinitionsQuery } from '@/composables/queries/useComponentDefinitionsQuery'
-import { useCurrentProject, useProjectQuery, useUpdateProjectMutation } from '@/composables/queries/useProjectsQuery'
+import {
+  useCurrentProject,
+  useOrgTagsQuery,
+  useProjectQuery,
+  useUpdateProjectMutation,
+} from '@/composables/queries/useProjectsQuery'
 import { getCurrentOrgReleaseStage, useOrgReleaseStagesQuery } from '@/composables/queries/useReleaseStagesQuery'
 import { useSelectedOrg } from '@/composables/useSelectedOrg'
 import { PANEL_SIZES } from '@/config/panelSizes'
@@ -48,6 +53,7 @@ const {
 } = useCurrentProject()
 
 const updateProjectMutation = useUpdateProjectMutation()
+const { data: orgTags } = useOrgTagsQuery(selectedOrgId)
 
 // Modification history dialog props
 const historyProjectId = computed(() => project.value?.project_id)
@@ -105,14 +111,18 @@ watch(orgChangeCounter, () => {
 })
 
 // Manual save function for EditEntityModal
-const manualSave = async (projectId: string, data: { name?: string; description?: string }) => {
+const manualSave = async (
+  projectId: string,
+  data: { name?: string; description?: string; tags?: string[] }
+) => {
   await updateProjectMutation.mutateAsync({ projectId, data })
 }
 
-const handleProjectUpdate = (data: { name: string; description: string }) => {
+const handleProjectUpdate = (data: { name: string; description: string; tags: string[] }) => {
   if (project.value) {
     project.value.project_name = data.name
     project.value.description = data.description
+    project.value.tags = data.tags
   }
 }
 
@@ -324,6 +334,8 @@ definePage({
         :entity-id="project.project_id"
         :entity-name="project.project_name"
         :entity-description="project.description"
+        :entity-tags="project.tags || []"
+        :available-tags="orgTags || []"
         entity-type="project"
         :save-function="manualSave"
         @updated="handleProjectUpdate"

--- a/frontend/src/pages/org/[orgId]/projects/index.vue
+++ b/frontend/src/pages/org/[orgId]/projects/index.vue
@@ -42,6 +42,10 @@ const {
   selectedOrgId,
 })
 
+function onTagsUpdate(value: string[]) {
+  editedTags.value = [...new Set(value.map(t => t.toLowerCase().trim()).filter(Boolean))]
+}
+
 const showCreateError = computed(() => createError.value !== null)
 
 definePage({
@@ -98,7 +102,7 @@ definePage({
         <IconPicker v-model="editedIconSelection" />
 
         <VCombobox
-          v-model="editedTags"
+          :model-value="editedTags"
           :items="orgTags || []"
           label="Tags"
           variant="outlined"
@@ -108,9 +112,10 @@ definePage({
           class="mt-4"
           placeholder="Type to add a tag…"
           hide-details
+          @update:model-value="onTagsUpdate"
         >
-          <template #chip="{ props: chipProps, item }">
-            <VChip v-bind="chipProps" size="small" variant="tonal" :color="tagColor(item.raw)" label closable>
+          <template #chip="{ props: chipProps, item, index }">
+            <VChip v-bind="chipProps" size="small" variant="tonal" :color="tagColor(item.raw)" label closable @click:close="editedTags.splice(index, 1)">
               {{ item.raw }}
             </VChip>
           </template>

--- a/frontend/src/pages/org/[orgId]/projects/index.vue
+++ b/frontend/src/pages/org/[orgId]/projects/index.vue
@@ -6,6 +6,7 @@ import { useCreateProjectMutation } from '@/composables/queries/useProjectsQuery
 import { useSelectedOrg } from '@/composables/useSelectedOrg'
 import { useProjectEntityEditor } from '@/composables/useProjectEntityEditor'
 import { DEFAULT_PROJECT_ICON } from '@/composables/useProjectDefaults'
+import { tagColor } from '@/utils/tagColor'
 
 const { selectedOrgId } = useSelectedOrg()
 
@@ -20,6 +21,8 @@ const {
   editedName: editedProjectName,
   editedDescription: editedProjectDescription,
   editedIconSelection,
+  editedTags,
+  orgTags,
   isUpdating: isUpdatingProject,
   isCreating,
   editError,
@@ -93,6 +96,25 @@ definePage({
         />
 
         <IconPicker v-model="editedIconSelection" />
+
+        <VCombobox
+          v-model="editedTags"
+          :items="orgTags || []"
+          label="Tags"
+          variant="outlined"
+          multiple
+          chips
+          closable-chips
+          class="mt-4"
+          placeholder="Type to add a tag…"
+          hide-details
+        >
+          <template #chip="{ props: chipProps, item }">
+            <VChip v-bind="chipProps" size="small" variant="tonal" :color="tagColor(item.raw)" label closable>
+              {{ item.raw }}
+            </VChip>
+          </template>
+        </VCombobox>
       </VCardText>
 
       <VCardActions class="justify-end pa-4">

--- a/frontend/src/utils/tagColor.ts
+++ b/frontend/src/utils/tagColor.ts
@@ -1,0 +1,22 @@
+const TAG_COLORS = [
+  'primary',
+  'success',
+  'info',
+  'warning',
+  'pink',
+  'purple',
+  'deep-purple',
+  'indigo',
+  'teal',
+  'cyan',
+  'orange',
+  'blue-grey',
+]
+
+export function tagColor(tag: string): string {
+  let hash = 0
+  for (let i = 0; i < tag.length; i++) {
+    hash = (hash * 31 + tag.charCodeAt(i)) | 0
+  }
+  return TAG_COLORS[Math.abs(hash) % TAG_COLORS.length]
+}

--- a/tests/ada_backend/services/test_git_sync_service.py
+++ b/tests/ada_backend/services/test_git_sync_service.py
@@ -388,6 +388,8 @@ class TestImportFromGithub:
         assert imported[0].status == "created"
         assert len(skipped) == 0
         create_proj_mock.assert_called_once()
+        _, kwargs = create_proj_mock.call_args
+        assert kwargs["tags"] == ["github"]
 
     @pytest.mark.asyncio
     async def test_imports_with_agent_project_type(self):
@@ -452,18 +454,10 @@ class TestImportFromGithub:
             "agent-b": self._make_config(org_id, uuid4(), "agent-b"),
         }
 
-        def fake_create(
-            session,
-            organization_id,
-            project_id,
-            project_name,
-            description,
-            project_type,
-            template,
-            graph_id,
-            add_input,
-        ):
-            return SimpleNamespace(id=project_id, name=project_name, organization_id=org_id), uuid4()
+        def fake_create(**kwargs):
+            return SimpleNamespace(
+                id=kwargs["project_id"], name=kwargs["project_name"], organization_id=org_id
+            ), uuid4()
 
         def fake_create_config(**kwargs):
             return configs[kwargs["graph_folder"]]

--- a/tests/ada_backend/test_project_tags.py
+++ b/tests/ada_backend/test_project_tags.py
@@ -1,0 +1,173 @@
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from ada_backend.database import models as db
+from ada_backend.repositories.project_repository import (
+    add_tags_to_project,
+    get_project_with_details,
+    get_projects_by_organization_with_details,
+    get_tags_for_organization,
+    insert_project,
+    remove_tag_from_project,
+    update_project,
+)
+
+pytestmark = pytest.mark.skip(
+    reason="Tests require PostgreSQL - SQLite doesn't support regex operators (~) used in GraphRunner constraints"
+)
+
+
+@pytest.fixture
+def org_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def make_project(ada_backend_mock_session: Session, org_id):
+    def _make(name="Test Project", tags=None):
+        project_id = uuid.uuid4()
+        return insert_project(
+            ada_backend_mock_session,
+            project_id=project_id,
+            project_name=name,
+            organization_id=org_id,
+            project_type=db.ProjectType.WORKFLOW,
+            tags=tags,
+        )
+    return _make
+
+
+class TestInsertProjectWithTags:
+    def test_create_project_without_tags(self, ada_backend_mock_session, make_project):
+        project = make_project()
+        assert project.tags == []
+
+    def test_create_project_with_tags(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["foo", "bar"])
+        tag_names = sorted(pt.tag for pt in project.tags)
+        assert tag_names == ["bar", "foo"]
+
+    def test_tags_are_lowercased(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["GitHub", "CI"])
+        tag_names = sorted(pt.tag for pt in project.tags)
+        assert tag_names == ["ci", "github"]
+
+
+class TestUpdateProjectTags:
+    def test_replace_tags(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["old"])
+        updated = update_project(ada_backend_mock_session, project.id, tags=["new1", "new2"])
+        tag_names = sorted(pt.tag for pt in updated.tags)
+        assert tag_names == ["new1", "new2"]
+
+    def test_clear_tags(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["keep"])
+        updated = update_project(ada_backend_mock_session, project.id, tags=[])
+        assert updated.tags == []
+
+    def test_none_tags_leaves_unchanged(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["keep"])
+        updated = update_project(ada_backend_mock_session, project.id, project_name="New Name")
+        tag_names = [pt.tag for pt in updated.tags]
+        assert "keep" in tag_names
+
+
+class TestAddRemoveTags:
+    def test_add_tags(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["existing"])
+        result = add_tags_to_project(ada_backend_mock_session, project.id, ["new1", "new2"])
+        assert result == ["existing", "new1", "new2"]
+
+    def test_add_duplicate_tags_skipped(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["existing"])
+        result = add_tags_to_project(ada_backend_mock_session, project.id, ["existing", "new"])
+        assert result == ["existing", "new"]
+
+    def test_remove_tag(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["a", "b", "c"])
+        result = remove_tag_from_project(ada_backend_mock_session, project.id, "b")
+        assert result == ["a", "c"]
+
+    def test_remove_nonexistent_tag(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["a"])
+        result = remove_tag_from_project(ada_backend_mock_session, project.id, "nonexistent")
+        assert result == ["a"]
+
+
+class TestFilterByTags:
+    def test_filter_single_tag(self, ada_backend_mock_session, org_id, make_project):
+        make_project(name="P1", tags=["github"])
+        make_project(name="P2", tags=["manual"])
+        results = get_projects_by_organization_with_details(
+            ada_backend_mock_session, org_id, type=None, tags=["github"]
+        )
+        names = [p.project_name for p in results]
+        assert "P1" in names
+        assert "P2" not in names
+
+    def test_filter_multiple_tags_and_semantics(self, ada_backend_mock_session, org_id, make_project):
+        make_project(name="P1", tags=["github", "production"])
+        make_project(name="P2", tags=["github"])
+        make_project(name="P3", tags=["production"])
+        results = get_projects_by_organization_with_details(
+            ada_backend_mock_session, org_id, type=None, tags=["github", "production"]
+        )
+        names = [p.project_name for p in results]
+        assert names == ["P1"]
+
+    def test_no_tags_filter_returns_all(self, ada_backend_mock_session, org_id, make_project):
+        make_project(name="P1", tags=["a"])
+        make_project(name="P2")
+        results = get_projects_by_organization_with_details(
+            ada_backend_mock_session, org_id, type=None
+        )
+        assert len(results) == 2
+
+
+class TestGetProjectWithDetailsTags:
+    def test_includes_tags(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["alpha", "beta"])
+        result = get_project_with_details(ada_backend_mock_session, project.id)
+        assert result.tags == ["alpha", "beta"]
+
+
+class TestGetTagsForOrganization:
+    def test_returns_distinct_tags(self, ada_backend_mock_session, org_id, make_project):
+        make_project(name="P1", tags=["github", "shared"])
+        make_project(name="P2", tags=["shared", "manual"])
+        tags = get_tags_for_organization(ada_backend_mock_session, org_id)
+        assert tags == ["github", "manual", "shared"]
+
+    def test_empty_org(self, ada_backend_mock_session):
+        tags = get_tags_for_organization(ada_backend_mock_session, uuid.uuid4())
+        assert tags == []
+
+    def test_does_not_include_other_org_tags(self, ada_backend_mock_session, org_id, make_project):
+        make_project(tags=["mine"])
+        other_org = uuid.uuid4()
+        insert_project(
+            ada_backend_mock_session,
+            project_id=uuid.uuid4(),
+            project_name="Other",
+            organization_id=other_org,
+            project_type=db.ProjectType.WORKFLOW,
+            tags=["theirs"],
+        )
+        tags = get_tags_for_organization(ada_backend_mock_session, org_id)
+        assert tags == ["mine"]
+
+
+class TestProjectDeleteCascadesTags:
+    def test_tags_deleted_with_project(self, ada_backend_mock_session, make_project):
+        project = make_project(tags=["doomed"])
+        project_id = project.id
+        ada_backend_mock_session.delete(project)
+        ada_backend_mock_session.commit()
+        remaining = (
+            ada_backend_mock_session.query(db.ProjectTag)
+            .filter(db.ProjectTag.project_id == project_id)
+            .all()
+        )
+        assert remaining == []


### PR DESCRIPTION
# Add project tag system for filtering and organizing projects

## Summary
- Introduces a `project_tags` table (many-to-many) allowing users to assign free-form, lowercase string tags to projects, with dedicated CRUD endpoints (`POST /projects/{id}/tags`, `DELETE /projects/{id}/tags/{tag}`).
- The project list endpoint (`GET /projects/org/{org_id}`) now supports a `?tags= query` parameter for filtering projects that match ALL specified tags (AND semantics), and a new `GET /projects/org/{org_id}/tags` endpoint returns all distinct tags in an org for autocomplete.
- Projects imported via GitHub git sync automatically receive a "github" tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project tags: add/remove tags on projects; tags are returned in project views and APIs
  * Tag filtering: filter organization project lists by multiple tags (AND semantics)
  * Org-level tag autocomplete for tag entry

* **UI**
  * Tag chips on project cards, tag filter control in project list, tag editing in entity modal
  * Deterministic tag colors for consistent chip coloring
  * Imported repos automatically tagged "github"

* **Documentation**
  * Updated architecture and git-sync docs describing tagging and import behavior

* **Tests**
  * Added comprehensive project-tag test coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->