### PR TITLE
feat(components): fix scorer and categorizer output format dra-1236

### DIFF
--- a/engine/components/categorizer.py
+++ b/engine/components/categorizer.py
@@ -57,27 +57,18 @@ def _build_output_format(categories: dict[str, str]) -> str:
     category_names = list(categories.keys())
 
     return json.dumps({
-        "name": "categorization_result",
-        "strict": True,
-        "schema": {
-            "type": "object",
-            "properties": {
-                "category": {
-                    "type": "string",
-                    "description": "The selected category",
-                    "enum": category_names,
-                },
-                "score": {
-                    "type": "number",
-                    "description": "Confidence score between 0 and 1",
-                },
-                "reason": {
-                    "type": "string",
-                    "description": "Brief explanation for why this category was selected",
-                },
-            },
-            "additionalProperties": False,
-            "required": ["category", "score", "reason"],
+        "category": {
+            "type": "string",
+            "description": "The selected category",
+            "enum": category_names,
+        },
+        "score": {
+            "type": "number",
+            "description": "Confidence score between 0 and 1",
+        },
+        "reason": {
+            "type": "string",
+            "description": "Brief explanation for why this category was selected",
         },
     })
 

--- a/engine/components/scorer.py
+++ b/engine/components/scorer.py
@@ -56,22 +56,13 @@ PROMPT_TEMPLATE = (
 )
 
 OUTPUT_FORMAT = {
-    "name": "scoring_result",
-    "strict": True,
-    "schema": {
-        "type": "object",
-        "properties": {
-            "score": {
-                "type": "number",
-                "description": "Score from 0 to 100",
-            },
-            "reason": {
-                "type": "string",
-                "description": "Brief explanation for the assigned score",
-            },
-        },
-        "additionalProperties": False,
-        "required": ["score", "reason"],
+    "score": {
+        "type": "number",
+        "description": "Score from 0 to 100",
+    },
+    "reason": {
+        "type": "string",
+        "description": "Brief explanation for the assigned score",
     },
 }
 

--- a/tests/components/test_categorizer.py
+++ b/tests/components/test_categorizer.py
@@ -1,0 +1,90 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from engine.components.categorizer import Categorizer, CategorizerInputs, _build_output_format
+from engine.components.llm_call import _convert_properties_to_openai_format
+from engine.components.types import ComponentAttributes
+from engine.llm_services.constrained_output_models import OutputFormatModel
+from tests.components.test_llm_call import make_capability_resolver
+
+CATEGORIES = {
+    "Positive": "Content expressing positive sentiment",
+    "Negative": "Content expressing negative sentiment",
+    "Neutral": "Content with neutral sentiment",
+}
+
+
+@pytest.fixture
+def mock_completion_service():
+    service = MagicMock()
+    service._provider = "openai"
+    service._model_name = "gpt-4.1-mini"
+    service._model_id = None
+    service._invocation_parameters = {}
+    service.constrained_complete_with_json_schema_async = AsyncMock(
+        return_value=json.dumps({"category": "Positive", "score": 0.95, "reason": "Upbeat tone"})
+    )
+    return service
+
+
+@pytest.fixture
+def categorizer(mock_completion_service):
+    trace_manager = MagicMock()
+    return Categorizer(
+        completion_service=mock_completion_service,
+        trace_manager=trace_manager,
+        component_attributes=ComponentAttributes(component_instance_name="test_categorizer"),
+        capability_resolver=make_capability_resolver(mock_completion_service),
+    )
+
+
+class TestCategorizerOutputFormat:
+    def test_output_format_is_flat_properties(self):
+        raw = json.loads(_build_output_format(CATEGORIES))
+        assert "name" not in raw
+        assert "strict" not in raw
+        assert "schema" not in raw
+        assert "category" in raw
+        assert "score" in raw
+        assert "reason" in raw
+
+    def test_output_format_passes_openai_conversion_and_validation(self):
+        raw = json.loads(_build_output_format(CATEGORIES))
+        openai_format = _convert_properties_to_openai_format(raw)
+        openai_format["strict"] = True
+        openai_format["type"] = "json_schema"
+        OutputFormatModel(**openai_format)
+
+    def test_category_enum_matches_input(self):
+        raw = json.loads(_build_output_format(CATEGORIES))
+        assert raw["category"]["enum"] == list(CATEGORIES.keys())
+
+
+@pytest.mark.anyio
+async def test_categorizer_run(categorizer, mock_completion_service):
+    inputs = CategorizerInputs(
+        content_to_categorize="I love this product!",
+        categories=CATEGORIES,
+    )
+    outputs = await categorizer._run_without_io_trace(inputs, ctx={})
+
+    assert outputs.category == "Positive"
+    assert outputs.score == 0.95
+    assert outputs.reason == "Upbeat tone"
+    assert json.loads(outputs.output) == {"category": "Positive", "score": 0.95, "reason": "Upbeat tone"}
+    mock_completion_service.constrained_complete_with_json_schema_async.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_categorizer_run_with_additional_context(categorizer, mock_completion_service):
+    inputs = CategorizerInputs(
+        content_to_categorize="I love this product!",
+        categories=CATEGORIES,
+        additional_context="Focus on emotional language",
+    )
+    outputs = await categorizer._run_without_io_trace(inputs, ctx={})
+
+    assert outputs.category == "Positive"
+    mock_completion_service.constrained_complete_with_json_schema_async.assert_awaited_once()

--- a/tests/components/test_scorer.py
+++ b/tests/components/test_scorer.py
@@ -1,0 +1,73 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from engine.components.llm_call import _convert_properties_to_openai_format
+from engine.components.scorer import OUTPUT_FORMAT, Scorer, ScorerInputs
+from engine.components.types import ComponentAttributes
+from engine.llm_services.constrained_output_models import OutputFormatModel
+from tests.components.test_llm_call import make_capability_resolver
+
+
+@pytest.fixture
+def mock_completion_service():
+    service = MagicMock()
+    service._provider = "openai"
+    service._model_name = "gpt-4.1-mini"
+    service._model_id = None
+    service._invocation_parameters = {}
+    service.constrained_complete_with_json_schema_async = AsyncMock(
+        return_value=json.dumps({"score": 85, "reason": "Clear and well-structured"})
+    )
+    return service
+
+
+@pytest.fixture
+def scorer(mock_completion_service):
+    trace_manager = MagicMock()
+    return Scorer(
+        completion_service=mock_completion_service,
+        trace_manager=trace_manager,
+        component_attributes=ComponentAttributes(component_instance_name="test_scorer"),
+        capability_resolver=make_capability_resolver(mock_completion_service),
+    )
+
+
+class TestScorerOutputFormat:
+    def test_output_format_is_flat_properties(self):
+        assert "name" not in OUTPUT_FORMAT
+        assert "strict" not in OUTPUT_FORMAT
+        assert "schema" not in OUTPUT_FORMAT
+        assert "score" in OUTPUT_FORMAT
+        assert "reason" in OUTPUT_FORMAT
+
+    def test_output_format_passes_openai_conversion_and_validation(self):
+        openai_format = _convert_properties_to_openai_format(OUTPUT_FORMAT)
+        openai_format["strict"] = True
+        openai_format["type"] = "json_schema"
+        OutputFormatModel(**openai_format)
+
+
+@pytest.mark.anyio
+async def test_scorer_run(scorer, mock_completion_service):
+    inputs = ScorerInputs(input="The sky is blue.", criteria="Factual accuracy")
+    outputs = await scorer._run_without_io_trace(inputs, ctx={})
+
+    assert outputs.score == 85
+    assert outputs.reason == "Clear and well-structured"
+    assert json.loads(outputs.output) == {"score": 85, "reason": "Clear and well-structured"}
+    mock_completion_service.constrained_complete_with_json_schema_async.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_scorer_run_with_additional_context(scorer, mock_completion_service):
+    inputs = ScorerInputs(
+        input="The sky is blue.",
+        criteria="Factual accuracy",
+        additional_context="Scientific context expected",
+    )
+    outputs = await scorer._run_without_io_trace(inputs, ctx={})
+
+    assert outputs.score == 85
+    mock_completion_service.constrained_complete_with_json_schema_async.assert_awaited_once()


### PR DESCRIPTION
# Fix Scorer and Categorizer output format double-wrapping

## Summary
- Fix a Pydantic validation error (OutputFormatModel) in both the Scorer and Categorizer components caused by their output format dicts being double-wrapped into the OpenAI structured output shape.
- Add regression tests for both components.

## Problem
Both `Scorer.OUTPUT_FORMAT` and `Categorizer._build_output_format()` produced the full OpenAI response format (name, strict, schema with nested properties). This dict was then passed through `_convert_properties_to_openai_format(`), which assumes a flat properties dict and wraps it again. The result was a doubly-nested schema where name (a string) and strict (a bool) appeared as property definitions, causing OutputFormatModel validation to fail.