### PR TITLE
feat(Qdrant): Remove check qdrant collection type DRA-1237

### DIFF
--- a/engine/qdrant_service.py
+++ b/engine/qdrant_service.py
@@ -157,8 +157,6 @@ class QdrantService:
 
         self.default_schema = default_schema
         self._schemas: dict[str, QdrantCollectionSchema] = {}
-        # TODO Remove when production all collections are hybrid
-        self._hybrid_cache: dict[str, bool] = {}
 
     def register_schema(self, collection_name: str, schema: QdrantCollectionSchema):
         """
@@ -281,11 +279,10 @@ class QdrantService:
     ) -> list[tuple[str, float, dict]]:
         payload: dict[str, Any] = {
             "query": query_vector,
+            "using": "dense",
             "with_payload": True,
             "limit": search_params.pop("limit", DEFAULT_MAX_CHUNKS),
         }
-        if await self.is_hybrid_collection_async(collection_name):
-            payload["using"] = "dense"
         if filter:
             payload["filter"] = filter
         return await self._query_points_async(collection_name, payload)
@@ -313,9 +310,7 @@ class QdrantService:
         limit: int = DEFAULT_MAX_CHUNKS,
     ) -> list[tuple[str, float, dict]]:
         prefetch_limit = limit * 2
-        dense_prefetch: dict[str, Any] = {"query": query_vector, "limit": prefetch_limit}
-        if await self.is_hybrid_collection_async(collection_name):
-            dense_prefetch["using"] = "dense"
+        dense_prefetch: dict[str, Any] = {"query": query_vector, "using": "dense", "limit": prefetch_limit}
         payload: dict[str, Any] = {
             "prefetch": [
                 {
@@ -343,11 +338,10 @@ class QdrantService:
     ) -> list[tuple[str, float, dict]]:
         payload: dict[str, Any] = {
             "query": query_vector,
+            "using": "dense",
             "limit": limit,
             "with_payload": True,
         }
-        if await self.is_hybrid_collection_async(collection_name):
-            payload["using"] = "dense"
         if filter:
             payload["filter"] = filter
         return await self._query_points_async(collection_name, payload)
@@ -739,8 +733,6 @@ class QdrantService:
         Add chunks to the Qdrant collection asynchronously.
         """
         schema = self._get_schema(collection_name)
-        # TODO: Remove old-collection branch once all production collections are migrated to hybrid
-        is_hybrid = await self.is_hybrid_collection_async(collection_name)
 
         for i in range(0, len(list_chunks), self._max_chunks_to_add):
             current_chunk_batch = list_chunks[i : i + self._max_chunks_to_add]
@@ -763,13 +755,10 @@ class QdrantService:
 
             list_payloads = []
             for chunk, vector in zip(current_chunk_batch, list_embeddings, strict=False):
-                if is_hybrid:
-                    point_vector = {
-                        "dense": vector,
-                        "sparse": {"text": chunk[schema.content_field], "model": BM25_MODEL},
-                    }
-                else:
-                    point_vector = vector
+                point_vector = {
+                    "dense": vector,
+                    "sparse": {"text": chunk[schema.content_field], "model": BM25_MODEL},
+                }
                 point = {
                     "id": self.get_uuid(self._build_point_id_seed(chunk, schema)),
                     "payload": {field: chunk[field] for field in chunk.keys()},
@@ -1061,15 +1050,6 @@ class QdrantService:
         response = await self._send_request_async(method="GET", endpoint=f"collections/{collection_name}")
         return response.get("result", {})
 
-    async def is_hybrid_collection_async(self, collection_name: str) -> bool:
-        if collection_name in self._hybrid_cache:
-            return self._hybrid_cache[collection_name]
-        info = await self.get_collection_info_async(collection_name)
-        sparse_vectors = info.get("config", {}).get("params", {}).get("sparse_vectors", {})
-        result = bool(sparse_vectors and "sparse" in sparse_vectors)
-        self._hybrid_cache[collection_name] = result
-        return result
-
     def create_collection(
         self,
         collection_name: str,
@@ -1119,7 +1099,6 @@ class QdrantService:
         )
         if "result" in response:
             LOGGER.info(f"Status of collection creation {collection_name} : {response['result']}")
-            self._hybrid_cache[collection_name] = True
             # TODO: Remove when production qdrant collections have proper indexes
             await self._create_indexes_from_schema(collection_name=collection_name, schema=schema)
             return True
@@ -1142,7 +1121,6 @@ class QdrantService:
         response = await self._send_request_async(method="DELETE", endpoint=f"collections/{collection_name}?wait=true")
         if "result" in response:
             LOGGER.info(f"Status of collection deletion {collection_name} : {response['result']}")
-            self._hybrid_cache.pop(collection_name, None)
             return True
         LOGGER.error(f"Problem with status of collection deletion {collection_name} : {response}")
         return False

--- a/scripts/migrate_collection_to_hybrid.py
+++ b/scripts/migrate_collection_to_hybrid.py
@@ -121,7 +121,9 @@ async def migrate_collection(service: QdrantService, name: str) -> bool:
         print(f"[{name}] Not found, skipping.")
         return False
 
-    if await service.is_hybrid_collection_async(name):
+    info = await service.get_collection_info_async(name)
+    sparse_vectors = info.get("config", {}).get("params", {}).get("sparse_vectors", {})
+    if sparse_vectors and "sparse" in sparse_vectors:
         print(f"[{name}] Already hybrid, skipping.")
         return True
 

--- a/tests/qdrant/test_qdrant_service.py
+++ b/tests/qdrant/test_qdrant_service.py
@@ -910,61 +910,6 @@ def _make_qdrant_service_with_mock_http() -> tuple[QdrantService, AsyncMock]:
     return service, mock_send
 
 
-class TestIsHybridCollection:
-    @pytest.mark.asyncio
-    async def test_hybrid_collection_detected(self):
-        service, mock_send = _make_qdrant_service_with_mock_http()
-        mock_send.return_value = {
-            "result": {
-                "config": {
-                    "params": {
-                        "vectors": {"dense": {"size": 3072, "distance": "Cosine"}},
-                        "sparse_vectors": {"sparse": {"modifier": "idf"}},
-                    }
-                }
-            }
-        }
-        assert await service.is_hybrid_collection_async("test") is True
-
-    @pytest.mark.asyncio
-    async def test_dense_only_collection_detected(self):
-        service, mock_send = _make_qdrant_service_with_mock_http()
-        mock_send.return_value = {
-            "result": {
-                "config": {
-                    "params": {
-                        "vectors": {"size": 3072, "distance": "Cosine"},
-                        "sparse_vectors": {},
-                    }
-                }
-            }
-        }
-        assert await service.is_hybrid_collection_async("test") is False
-
-    @pytest.mark.asyncio
-    async def test_missing_sparse_vectors_key(self):
-        service, mock_send = _make_qdrant_service_with_mock_http()
-        mock_send.return_value = {"result": {"config": {"params": {"vectors": {"size": 3072, "distance": "Cosine"}}}}}
-        assert await service.is_hybrid_collection_async("test") is False
-
-    @pytest.mark.asyncio
-    async def test_result_is_cached(self):
-        service, mock_send = _make_qdrant_service_with_mock_http()
-        mock_send.return_value = {
-            "result": {
-                "config": {
-                    "params": {
-                        "vectors": {"dense": {"size": 3072, "distance": "Cosine"}},
-                        "sparse_vectors": {"sparse": {"modifier": "idf"}},
-                    }
-                }
-            }
-        }
-        assert await service.is_hybrid_collection_async("test") is True
-        assert await service.is_hybrid_collection_async("test") is True
-        assert mock_send.call_count == 1
-
-
 class TestCreateCollectionHybrid:
     @pytest.mark.asyncio
     async def test_always_creates_hybrid_collection(self):
@@ -980,16 +925,14 @@ class TestCreateCollectionHybrid:
         payload = create_call.kwargs["payload"]
         assert "dense" in payload["vectors"]
         assert "sparse" in payload["sparse_vectors"]
-        assert service._hybrid_cache["test_col"] is True
 
 
 class TestAddChunksHybrid:
     @pytest.mark.asyncio
-    async def test_sends_named_vectors_for_hybrid_collection(self):
+    async def test_always_sends_named_vectors(self):
         service, mock_send = _make_qdrant_service_with_mock_http()
         service._build_vectors_async = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
         service.insert_points_in_collection_async = AsyncMock(return_value=True)
-        service._hybrid_cache["test_col"] = True
 
         chunks = [{"chunk_id": "1", "content": "hello world", "file_id": "f1", "url": "http://x"}]
         await service.add_chunks_async(chunks, "test_col")
@@ -1000,21 +943,6 @@ class TestAddChunksHybrid:
         assert "sparse" in vector
         assert vector["sparse"]["model"] == BM25_MODEL
         assert vector["sparse"]["text"] == "hello world"
-
-    @pytest.mark.asyncio
-    async def test_sends_flat_vector_for_old_collection(self):
-        service, mock_send = _make_qdrant_service_with_mock_http()
-        service._build_vectors_async = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
-        service.insert_points_in_collection_async = AsyncMock(return_value=True)
-        service._hybrid_cache["test_col"] = False
-
-        chunks = [{"chunk_id": "1", "content": "hello world", "file_id": "f1", "url": "http://x"}]
-        await service.add_chunks_async(chunks, "test_col")
-
-        inserted_points = service.insert_points_in_collection_async.call_args.kwargs["points"]
-        vector = inserted_points[0]["vector"]
-        assert isinstance(vector, list)
-        assert vector == [0.1, 0.2, 0.3]
 
 
 class TestSearchRouting:
@@ -1080,7 +1008,6 @@ class TestQueryPointsAsync:
     @pytest.mark.asyncio
     async def test_hybrid_search_sends_prefetch_and_fusion(self):
         service, mock_send = _make_qdrant_service_with_mock_http()
-        service._hybrid_cache["col"] = True
         mock_send.return_value = {"result": {"points": []}}
 
         await service._search_hybrid_async(
@@ -1096,24 +1023,8 @@ class TestQueryPointsAsync:
         assert call_payload["query"] == {"fusion": "rrf"}
 
     @pytest.mark.asyncio
-    async def test_hybrid_search_omits_dense_using_for_old_collection(self):
-        service, mock_send = _make_qdrant_service_with_mock_http()
-        service._hybrid_cache["col"] = False
-        mock_send.return_value = {"result": {"points": []}}
-
-        await service._search_hybrid_async(
-            query_text="test query",
-            query_vector=[0.1, 0.2],
-            collection_name="col",
-            limit=5,
-        )
-        call_payload = mock_send.call_args.kwargs["payload"]
-        assert "using" not in call_payload["prefetch"][1]
-
-    @pytest.mark.asyncio
     async def test_hybrid_search_propagates_filter_to_both_prefetches(self):
         service, mock_send = _make_qdrant_service_with_mock_http()
-        service._hybrid_cache["col"] = True
         mock_send.return_value = {"result": {"points": []}}
         test_filter = {"must": [{"key": "source_id", "match": {"value": "src-1"}}]}
 
@@ -1131,7 +1042,6 @@ class TestQueryPointsAsync:
     @pytest.mark.asyncio
     async def test_hybrid_search_omits_filter_when_none(self):
         service, mock_send = _make_qdrant_service_with_mock_http()
-        service._hybrid_cache["col"] = True
         mock_send.return_value = {"result": {"points": []}}
 
         await service._search_hybrid_async(
@@ -1145,9 +1055,8 @@ class TestQueryPointsAsync:
         assert "filter" not in call_payload["prefetch"][1]
 
     @pytest.mark.asyncio
-    async def test_search_vectors_sends_using_for_hybrid_collection(self):
+    async def test_search_vectors_always_sends_using_dense(self):
         service, mock_send = _make_qdrant_service_with_mock_http()
-        service._hybrid_cache["col"] = True
         mock_send.return_value = {"result": {"points": [{"id": "id1", "score": 0.9, "payload": {}}]}}
 
         await service.search_vectors_async(query_vector=[0.1, 0.2], collection_name="col")
@@ -1155,34 +1064,13 @@ class TestQueryPointsAsync:
         assert call_payload["using"] == "dense"
 
     @pytest.mark.asyncio
-    async def test_search_vectors_omits_using_for_old_collection(self):
+    async def test_dense_named_always_sends_using_dense(self):
         service, mock_send = _make_qdrant_service_with_mock_http()
-        service._hybrid_cache["col"] = False
-        mock_send.return_value = {"result": {"points": [{"id": "id1", "score": 0.9, "payload": {}}]}}
-
-        await service.search_vectors_async(query_vector=[0.1, 0.2], collection_name="col")
-        call_payload = mock_send.call_args.kwargs["payload"]
-        assert "using" not in call_payload
-
-    @pytest.mark.asyncio
-    async def test_dense_named_sends_using_for_hybrid_collection(self):
-        service, mock_send = _make_qdrant_service_with_mock_http()
-        service._hybrid_cache["col"] = True
         mock_send.return_value = {"result": {"points": []}}
 
         await service._search_dense_named_async(query_vector=[0.1, 0.2], collection_name="col")
         call_payload = mock_send.call_args.kwargs["payload"]
         assert call_payload["using"] == "dense"
-
-    @pytest.mark.asyncio
-    async def test_dense_named_omits_using_for_old_collection(self):
-        service, mock_send = _make_qdrant_service_with_mock_http()
-        service._hybrid_cache["col"] = False
-        mock_send.return_value = {"result": {"points": []}}
-
-        await service._search_dense_named_async(query_vector=[0.1, 0.2], collection_name="col")
-        call_payload = mock_send.call_args.kwargs["payload"]
-        assert "using" not in call_payload
 
     @pytest.mark.asyncio
     async def test_sparse_search_sends_bm25_document(self):


### PR DESCRIPTION
All Qdrant collections have been migrated to hybrid (dense + sparse vectors) via the migration. 

This PR removes the runtime is_hybrid_collection_async checks that were conditionally switching between dense-only and hybrid behavior

What changed in the Qdrant payload format
After the migration, all collections use named vectors instead of flat vectors:

Search payloads now always include "using": "dense" to target the named dense vector:

Hybrid search uses both named vectors via prefetch "using": "sparse" for BM25 keyword matching and "using": "dense" for semantic



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed runtime hybrid-collection detection and caching; searches now always use dense-mode queries.
  * Stored vectors are standardized to include both dense and sparse fields during ingestion.
  * Migration now reads collection metadata to decide hybrid configuration instead of a separate detection routine.
* **Tests**
  * Removed tests validating hybrid-detection and its caching behavior; relevant tests updated to reflect unconditional behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->