### PR TITLE
fix(tracing): propagate run_id to sentry tags

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -57,14 +57,16 @@ Mixpanel Python SDK (`mixpanel_analytics.py`). `non_breaking_track` decorator wr
 ### Tracing Context and Sentry
 
 `engine/trace/span_context.py` is the canonical tracing context lifecycle hook. `set_tracing_span(**kwargs)` merges
-partial updates into the existing `TracingSpanParams` context and synchronizes `SENTRY_TAG_FIELDS` to Sentry tags on
-each update. Non-`None` values are stringified via `sentry_sdk.get_isolation_scope().set_tag(...)`; `None` values
-clear the tag from the current isolation scope (`remove_tag`) to prevent stale tags. Do not mutate `TracingSpanParams`
-directly in normal code paths; if you need to add/update `trace_id`, `run_id`, or other searchable fields, call
-`set_tracing_span(...)` so Sentry stays synchronized. `GraphRunner.run()` is the exception: it preserves `trace_id`
-across root span isolation before calling `set_tracing_span(trace_id=...)`. `run_id` is injected at run boundaries in
+partial updates into the existing `TracingSpanParams` context and synchronizes `SENTRY_TAG_FIELDS` to Sentry on each
+update. Sentry 2.x uses two separate streams: tags (events/issues) and attributes (logs/metrics). Non-`None` values are
+stringified and propagated to both via `sentry_sdk.get_isolation_scope().set_tag(...)` **and** `set_attribute(...)`;
+`None` values clear both (`remove_tag` + `remove_attribute`) on the isolation scope to prevent stale leakage between
+runs on the same thread. Do not mutate `TracingSpanParams` directly in normal code paths; if you need to add/update
+`trace_id`, `run_id`, or other searchable fields, call `set_tracing_span(...)` so both Sentry streams stay in sync.
+`GraphRunner.run()` is the exception: it preserves `trace_id` across root span isolation before calling
+`set_tracing_span(trace_id=...)`. `run_id` is injected at run boundaries in
 `ada_backend/services/run_service.py::run_with_tracking()` and `ada_backend/workers/run_queue_worker.py::process_payload()`.
-Do not set tracing tags in routers/services directly; add new searchable fields in `TracingSpanParams` +
+Do not set tracing tags/attributes in routers/services directly; add new searchable fields in `TracingSpanParams` +
 `SENTRY_TAG_FIELDS` instead.
 
 ### MCP Server

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -68,6 +68,11 @@ sync. `GraphRunner.run()` is the only exception: it preserves `trace_id` across 
 Inject `run_id` at run boundaries (`run_with_tracking()`, `RunQueueWorker.process_payload()`, and async enqueue paths
 before `push_run_task(...)`) so logs and Sentry events keep the run context.
 
+Call `reset_tracing_span()` only at top-level execution boundaries where a thread/task is reused across independent
+runs (currently only `RunQueueWorker.process_payload()` inside its `sentry_sdk.isolation_scope()`). Never call it
+inside a single logical run: propagated fields (`cron_id`, `project_id`, ...) must keep flowing via
+`set_tracing_span`'s merge semantics.
+
 ### MCP Server
 
 `mcp_server/`: standalone pod calling the backend over HTTP + Supabase directly. See `mcp_server/README.md`.

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -56,23 +56,17 @@ Mixpanel Python SDK (`mixpanel_analytics.py`). `non_breaking_track` decorator wr
 
 ### Tracing Context and Sentry
 
-`engine/trace/span_context.py` is the canonical tracing context lifecycle hook. `set_tracing_span(**kwargs)` merges
-partial updates into the existing `TracingSpanParams` context and synchronizes `SENTRY_TAG_FIELDS` to Sentry on each
-update. `SENTRY_TAG_FIELDS` is a `dict[str, str]` mapping each `TracingSpanParams` attribute to the key used on the
-Sentry isolation scope; `environment` is remapped to `env` to avoid shadowing Sentry's native `environment` tag
-(which identifies staging vs. prod deployments). Sentry 2.x uses two separate streams: tags (events/issues) and
-attributes (logs/metrics). Non-`None` values are stringified and propagated to both via
-`sentry_sdk.get_isolation_scope().set_tag(...)` **and** `set_attribute(...)`; `None` values clear both (`remove_tag` +
-`remove_attribute`) on the isolation scope to prevent stale leakage between runs on the same thread. Do not mutate
-`TracingSpanParams` directly in normal code paths; if you need to add/update `trace_id`, `run_id`, or other searchable
-fields, call `set_tracing_span(...)` so both Sentry streams stay in sync. `GraphRunner.run()` is the exception: it
-preserves `trace_id` across root span isolation before calling `set_tracing_span(trace_id=...)`. `run_id` is injected
-at run boundaries in `ada_backend/services/run_service.py::run_with_tracking()` and
-`ada_backend/workers/run_queue_worker.py::process_payload()`. For async enqueue paths (`chat_async` router and
-`retry_run` service), `setup_tracing_context(session, project_id)` + `set_tracing_span(run_id=str(run.id))` must be
-called **before** `push_run_task(...)` so the router/service log stream (including `Pushed run ... to Redis queue`)
-carries `run_id`, `project_id`, and `organization_id`. Do not set tracing tags/attributes in routers/services
-directly; add new searchable fields in `TracingSpanParams` + `SENTRY_TAG_FIELDS` instead.
+`engine/trace/span_context.py` is the canonical tracing context hook. `set_tracing_span(**kwargs)` merges partial
+updates into `TracingSpanParams` and synchronizes searchable fields from `SENTRY_TAG_FIELDS` to Sentry's isolation
+scope. Keep `environment` mapped to `env`, and add new searchable fields via `TracingSpanParams` +
+`SENTRY_TAG_FIELDS` instead of ad-hoc Sentry tagging in routers/services.
+
+Do not mutate `TracingSpanParams` directly in normal code paths; call `set_tracing_span(...)` so Sentry stays in
+sync. `GraphRunner.run()` is the only exception: it preserves `trace_id` across root span isolation before calling
+`set_tracing_span(trace_id=...)`.
+
+Inject `run_id` at run boundaries (`run_with_tracking()`, `RunQueueWorker.process_payload()`, and async enqueue paths
+before `push_run_task(...)`) so logs and Sentry events keep the run context.
 
 ### MCP Server
 

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -58,9 +58,14 @@ Mixpanel Python SDK (`mixpanel_analytics.py`). `non_breaking_track` decorator wr
 
 `engine/trace/span_context.py` is the canonical tracing context lifecycle hook. `set_tracing_span(**kwargs)` merges
 partial updates into the existing `TracingSpanParams` context and synchronizes `SENTRY_TAG_FIELDS` to Sentry tags on
-each update. Non-`None` values are stringified via `sentry_sdk.set_tag`; `None` values clear the tag from the current
-isolation scope (`remove_tag`) to prevent stale tags. Do not set tracing tags in routers/services directly; add new
-searchable fields in `TracingSpanParams` + `SENTRY_TAG_FIELDS` instead.
+each update. Non-`None` values are stringified via `sentry_sdk.get_isolation_scope().set_tag(...)`; `None` values
+clear the tag from the current isolation scope (`remove_tag`) to prevent stale tags. Do not mutate `TracingSpanParams`
+directly in normal code paths; if you need to add/update `trace_id`, `run_id`, or other searchable fields, call
+`set_tracing_span(...)` so Sentry stays synchronized. `GraphRunner.run()` is the exception: it preserves `trace_id`
+across root span isolation before calling `set_tracing_span(trace_id=...)`. `run_id` is injected at run boundaries in
+`ada_backend/services/run_service.py::run_with_tracking()` and `ada_backend/workers/run_queue_worker.py::process_payload()`.
+Do not set tracing tags in routers/services directly; add new searchable fields in `TracingSpanParams` +
+`SENTRY_TAG_FIELDS` instead.
 
 ### MCP Server
 

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -58,16 +58,21 @@ Mixpanel Python SDK (`mixpanel_analytics.py`). `non_breaking_track` decorator wr
 
 `engine/trace/span_context.py` is the canonical tracing context lifecycle hook. `set_tracing_span(**kwargs)` merges
 partial updates into the existing `TracingSpanParams` context and synchronizes `SENTRY_TAG_FIELDS` to Sentry on each
-update. Sentry 2.x uses two separate streams: tags (events/issues) and attributes (logs/metrics). Non-`None` values are
-stringified and propagated to both via `sentry_sdk.get_isolation_scope().set_tag(...)` **and** `set_attribute(...)`;
-`None` values clear both (`remove_tag` + `remove_attribute`) on the isolation scope to prevent stale leakage between
-runs on the same thread. Do not mutate `TracingSpanParams` directly in normal code paths; if you need to add/update
-`trace_id`, `run_id`, or other searchable fields, call `set_tracing_span(...)` so both Sentry streams stay in sync.
-`GraphRunner.run()` is the exception: it preserves `trace_id` across root span isolation before calling
-`set_tracing_span(trace_id=...)`. `run_id` is injected at run boundaries in
-`ada_backend/services/run_service.py::run_with_tracking()` and `ada_backend/workers/run_queue_worker.py::process_payload()`.
-Do not set tracing tags/attributes in routers/services directly; add new searchable fields in `TracingSpanParams` +
-`SENTRY_TAG_FIELDS` instead.
+update. `SENTRY_TAG_FIELDS` is a `dict[str, str]` mapping each `TracingSpanParams` attribute to the key used on the
+Sentry isolation scope; `environment` is remapped to `env` to avoid shadowing Sentry's native `environment` tag
+(which identifies staging vs. prod deployments). Sentry 2.x uses two separate streams: tags (events/issues) and
+attributes (logs/metrics). Non-`None` values are stringified and propagated to both via
+`sentry_sdk.get_isolation_scope().set_tag(...)` **and** `set_attribute(...)`; `None` values clear both (`remove_tag` +
+`remove_attribute`) on the isolation scope to prevent stale leakage between runs on the same thread. Do not mutate
+`TracingSpanParams` directly in normal code paths; if you need to add/update `trace_id`, `run_id`, or other searchable
+fields, call `set_tracing_span(...)` so both Sentry streams stay in sync. `GraphRunner.run()` is the exception: it
+preserves `trace_id` across root span isolation before calling `set_tracing_span(trace_id=...)`. `run_id` is injected
+at run boundaries in `ada_backend/services/run_service.py::run_with_tracking()` and
+`ada_backend/workers/run_queue_worker.py::process_payload()`. For async enqueue paths (`chat_async` router and
+`retry_run` service), `setup_tracing_context(session, project_id)` + `set_tracing_span(run_id=str(run.id))` must be
+called **before** `push_run_task(...)` so the router/service log stream (including `Pushed run ... to Redis queue`)
+carries `run_id`, `project_id`, and `organization_id`. Do not set tracing tags/attributes in routers/services
+directly; add new searchable fields in `TracingSpanParams` + `SENTRY_TAG_FIELDS` instead.
 
 ### MCP Server
 

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -56,22 +56,11 @@ Mixpanel Python SDK (`mixpanel_analytics.py`). `non_breaking_track` decorator wr
 
 ### Tracing Context and Sentry
 
-`engine/trace/span_context.py` is the canonical tracing context hook. `set_tracing_span(**kwargs)` merges partial
-updates into `TracingSpanParams` and synchronizes searchable fields from `SENTRY_TAG_FIELDS` to Sentry's isolation
-scope. Keep `environment` mapped to `env`, and add new searchable fields via `TracingSpanParams` +
-`SENTRY_TAG_FIELDS` instead of ad-hoc Sentry tagging in routers/services.
+`engine/trace/span_context.py` is the canonical tracing context hook. Use `set_tracing_span(**kwargs)` to merge updates and sync searchable fields to Sentry. Use `reset_tracing_span()` only at top-level execution boundaries (e.g., `RunQueueWorker`) to clear context between independent runs.
 
-Do not mutate `TracingSpanParams` directly in normal code paths; call `set_tracing_span(...)` so Sentry stays in
-sync. `GraphRunner.run()` is the only exception: it preserves `trace_id` across root span isolation before calling
-`set_tracing_span(trace_id=...)`.
-
-Inject `run_id` at run boundaries (`run_with_tracking()`, `RunQueueWorker.process_payload()`, and async enqueue paths
-before `push_run_task(...)`) so logs and Sentry events keep the run context.
-
-Call `reset_tracing_span()` only at top-level execution boundaries where a thread/task is reused across independent
-runs (currently only `RunQueueWorker.process_payload()` inside its `sentry_sdk.isolation_scope()`). Never call it
-inside a single logical run: propagated fields (`cron_id`, `project_id`, ...) must keep flowing via
-`set_tracing_span`'s merge semantics.
+- Never mutate `TracingSpanParams` directly.
+- Add new searchable fields via `TracingSpanParams` + `SENTRY_TAG_FIELDS` (map `environment` to `env`).
+- Inject `run_id` at run boundaries to keep logs and Sentry events correlated.
 
 ### MCP Server
 

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -140,8 +140,11 @@ In ingestion workers, `ingestion_script.ingest_db_source.upload_db_source()` sho
 `set_tracing_span(**kwargs)` is the canonical place to mutate tracing context. It merges partial updates into the
 existing `ContextVar` entry and then synchronizes selected fields to Sentry through `_sync_to_sentry`.
 
-- `SENTRY_TAG_FIELDS` defines the allowlist propagated to Sentry (`run_id`, `cron_id`, `trace_id`, `project_id`,
-  `organization_id`, `environment`, `call_type`, `graph_runner_id`, `tag_name`)
+- `SENTRY_TAG_FIELDS` is a `dict[str, str]` mapping each `TracingSpanParams` attribute to the key used on the Sentry
+  isolation scope. Currently: `run_id`, `cron_id`, `trace_id`, `project_id`, `organization_id`,
+  `environment` → `env`, `call_type`, `graph_runner_id`, `tag_name`. The `environment` attribute is deliberately
+  remapped to the Sentry key `env` so it does not shadow Sentry's native `environment` tag (which identifies
+  staging vs. prod deployments).
 - non-`None` values are stringified and propagated to **both** streams on the isolation scope:
   - `set_tag(...)` for the events/issues stream (searchable on Sentry Issues)
   - `set_attribute(...)` for the logs/metrics stream (searchable on Sentry Logs)
@@ -149,11 +152,23 @@ existing `ContextVar` entry and then synchronizes selected fields to Sentry thro
 - calling `set_tracing_span` is safe when Sentry is disabled; tag/attribute operations are no-ops until `sentry_sdk.init` runs
 
 When introducing a new tracing field, add it to `TracingSpanParams` first. If it should be searchable in Sentry,
-also add it to `SENTRY_TAG_FIELDS` so the propagation remains centralized and endpoint-agnostic.
+also add it to `SENTRY_TAG_FIELDS` so the propagation remains centralized and endpoint-agnostic. At import time,
+`span_context` asserts that every key in `SENTRY_TAG_FIELDS` is a real `TracingSpanParams` attribute.
 Avoid mutating `TracingSpanParams` fields directly after reading the context; use `set_tracing_span(...)` so Sentry
 stays in sync. `GraphRunner.run()` is the only exception: it updates the existing `trace_id` before calling
 `set_tracing_span(trace_id=...)` so the value survives root span isolation and remains available to callers after
-failures. `run_id` is injected at run boundaries in `run_with_tracking()` and `RunQueueWorker.process_payload()`.
+failures.
+
+`run_id`, `project_id`, and `organization_id` are injected at the earliest point of each run flow so that even
+router-level logs emitted *before* the run reaches the worker (e.g. `push_run_task` enqueue logs) already carry
+the tags:
+- Sync path: `run_with_tracking()` calls `set_tracing_span(run_id=...)` right after (re)creating the run; project
+  and organization come from the upstream `setup_tracing_context(...)` call in `run_agent(...)`.
+- Async enqueue path (`POST /projects/{id}/graphs/{gr_id}/chat/async` and `retry_run()`): both call
+  `setup_tracing_context(session, project_id)` + `set_tracing_span(run_id=str(run.id))` immediately after
+  `create_run(...)`, before `push_run_task(...)`.
+- Worker path: `RunQueueWorker.process_payload(...)` opens a fresh `sentry_sdk.isolation_scope()` and re-sets
+  `run_id` so tags are isolated per payload (no leakage across consecutive runs on the same worker thread).
 
 ## Key Files
 

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -138,13 +138,15 @@ In ingestion workers, `ingestion_script.ingest_db_source.upload_db_source()` sho
 **File**: `engine/trace/span_context.py`
 
 `set_tracing_span(**kwargs)` is the canonical place to mutate tracing context. It merges partial updates into the
-existing `ContextVar` entry and then synchronizes selected fields to Sentry tags through `_sync_to_sentry`.
+existing `ContextVar` entry and then synchronizes selected fields to Sentry through `_sync_to_sentry`.
 
 - `SENTRY_TAG_FIELDS` defines the allowlist propagated to Sentry (`run_id`, `cron_id`, `trace_id`, `project_id`,
   `organization_id`, `environment`, `call_type`, `graph_runner_id`, `tag_name`)
-- non-`None` values are converted to strings and sent via `sentry_sdk.get_isolation_scope().set_tag(...)`
-- `None` values remove the tag from the current Sentry isolation scope (`remove_tag`) to avoid stale tag leakage
-- calling `set_tracing_span` is safe when Sentry is disabled; tag operations are no-ops until `sentry_sdk.init` runs
+- non-`None` values are stringified and propagated to **both** streams on the isolation scope:
+  - `set_tag(...)` for the events/issues stream (searchable on Sentry Issues)
+  - `set_attribute(...)` for the logs/metrics stream (searchable on Sentry Logs)
+- `None` values clear both `remove_tag(...)` and `remove_attribute(...)` to avoid stale leakage across runs
+- calling `set_tracing_span` is safe when Sentry is disabled; tag/attribute operations are no-ops until `sentry_sdk.init` runs
 
 When introducing a new tracing field, add it to `TracingSpanParams` first. If it should be searchable in Sentry,
 also add it to `SENTRY_TAG_FIELDS` so the propagation remains centralized and endpoint-agnostic.

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -137,29 +137,12 @@ In ingestion workers, `ingestion_script.ingest_db_source.upload_db_source()` sho
 
 **File**: `engine/trace/span_context.py`
 
-`set_tracing_span(**kwargs)` is the canonical place to mutate tracing context. It merges partial updates into the
-existing `ContextVar` entry and then synchronizes selected fields to Sentry through `_sync_to_sentry`.
+`set_tracing_span(**kwargs)` merges partial updates into the `ContextVar` and synchronizes selected fields to Sentry's isolation scope (both tags and attributes). `reset_tracing_span()` wipes the context and Sentry tags for top-level boundaries (e.g., `RunQueueWorker`) to prevent leakage between independent runs.
 
-- `SENTRY_TAG_FIELDS` maps `TracingSpanParams` attributes to Sentry keys. Searchable fields currently include
-  `run_id`, `cron_id`, `trace_id`, `project_id`, `organization_id`, `call_type`, `graph_runner_id`, `tag_name`, and
-  `environment` mapped to `env` so it does not shadow Sentry's native deployment `environment`.
-- Sync happens on the isolation scope for both tags and attributes; `None` clears both sides to avoid stale values
-  across runs on the same thread.
-- When adding a new searchable field, add it to `TracingSpanParams` and `SENTRY_TAG_FIELDS`. `span_context` validates
-  that the mapping only references real tracing fields.
-
-Avoid mutating `TracingSpanParams` directly in normal code paths; use `set_tracing_span(...)` so Sentry stays in sync.
-`GraphRunner.run()` is the only exception: it preserves `trace_id` across root span isolation before calling
-`set_tracing_span(trace_id=...)`.
-
-`run_id` is injected at run boundaries: sync runs in `run_with_tracking()`, async enqueue paths before
-`push_run_task(...)`, and worker execution in `RunQueueWorker.process_payload()`.
-
-`reset_tracing_span()` wipes the `ContextVar` and removes the `SENTRY_TAG_FIELDS` tags/attributes from the current
-isolation scope. It is intended for top-level boundaries where a single thread or task is reused across independent
-runs, and is currently called only at the start of `RunQueueWorker.process_payload()` (inside its
-`sentry_sdk.isolation_scope()`). Do not use it inside a single logical run — normal propagation (e.g. `cron_id` set
-upstream) must keep flowing via `set_tracing_span`'s merge semantics.
+- `SENTRY_TAG_FIELDS` maps `TracingSpanParams` attributes to Sentry keys (e.g., `environment` -> `env`).
+- Sync handles `None` by clearing tags/attributes to avoid stale values.
+- `run_id` is injected at run boundaries (`run_with_tracking`, async enqueue, worker processing).
+- Avoid mutating `TracingSpanParams` directly; always use the helper functions.
 
 ## Key Files
 

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -155,6 +155,12 @@ Avoid mutating `TracingSpanParams` directly in normal code paths; use `set_traci
 `run_id` is injected at run boundaries: sync runs in `run_with_tracking()`, async enqueue paths before
 `push_run_task(...)`, and worker execution in `RunQueueWorker.process_payload()`.
 
+`reset_tracing_span()` wipes the `ContextVar` and removes the `SENTRY_TAG_FIELDS` tags/attributes from the current
+isolation scope. It is intended for top-level boundaries where a single thread or task is reused across independent
+runs, and is currently called only at the start of `RunQueueWorker.process_payload()` (inside its
+`sentry_sdk.isolation_scope()`). Do not use it inside a single logical run — normal propagation (e.g. `cron_id` set
+upstream) must keep flowing via `set_tracing_span`'s merge semantics.
+
 ## Key Files
 
 | Concept | File |

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -140,14 +140,18 @@ In ingestion workers, `ingestion_script.ingest_db_source.upload_db_source()` sho
 `set_tracing_span(**kwargs)` is the canonical place to mutate tracing context. It merges partial updates into the
 existing `ContextVar` entry and then synchronizes selected fields to Sentry tags through `_sync_to_sentry`.
 
-- `SENTRY_TAG_FIELDS` defines the allowlist propagated to Sentry (`cron_id`, `trace_id`, `project_id`,
+- `SENTRY_TAG_FIELDS` defines the allowlist propagated to Sentry (`run_id`, `cron_id`, `trace_id`, `project_id`,
   `organization_id`, `environment`, `call_type`, `graph_runner_id`, `tag_name`)
-- non-`None` values are converted to strings and sent via `sentry_sdk.set_tag`
+- non-`None` values are converted to strings and sent via `sentry_sdk.get_isolation_scope().set_tag(...)`
 - `None` values remove the tag from the current Sentry isolation scope (`remove_tag`) to avoid stale tag leakage
 - calling `set_tracing_span` is safe when Sentry is disabled; tag operations are no-ops until `sentry_sdk.init` runs
 
 When introducing a new tracing field, add it to `TracingSpanParams` first. If it should be searchable in Sentry,
 also add it to `SENTRY_TAG_FIELDS` so the propagation remains centralized and endpoint-agnostic.
+Avoid mutating `TracingSpanParams` fields directly after reading the context; use `set_tracing_span(...)` so Sentry
+stays in sync. `GraphRunner.run()` is the only exception: it updates the existing `trace_id` before calling
+`set_tracing_span(trace_id=...)` so the value survives root span isolation and remains available to callers after
+failures. `run_id` is injected at run boundaries in `run_with_tracking()` and `RunQueueWorker.process_payload()`.
 
 ## Key Files
 

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -140,35 +140,20 @@ In ingestion workers, `ingestion_script.ingest_db_source.upload_db_source()` sho
 `set_tracing_span(**kwargs)` is the canonical place to mutate tracing context. It merges partial updates into the
 existing `ContextVar` entry and then synchronizes selected fields to Sentry through `_sync_to_sentry`.
 
-- `SENTRY_TAG_FIELDS` is a `dict[str, str]` mapping each `TracingSpanParams` attribute to the key used on the Sentry
-  isolation scope. Currently: `run_id`, `cron_id`, `trace_id`, `project_id`, `organization_id`,
-  `environment` → `env`, `call_type`, `graph_runner_id`, `tag_name`. The `environment` attribute is deliberately
-  remapped to the Sentry key `env` so it does not shadow Sentry's native `environment` tag (which identifies
-  staging vs. prod deployments).
-- non-`None` values are stringified and propagated to **both** streams on the isolation scope:
-  - `set_tag(...)` for the events/issues stream (searchable on Sentry Issues)
-  - `set_attribute(...)` for the logs/metrics stream (searchable on Sentry Logs)
-- `None` values clear both `remove_tag(...)` and `remove_attribute(...)` to avoid stale leakage across runs
-- calling `set_tracing_span` is safe when Sentry is disabled; tag/attribute operations are no-ops until `sentry_sdk.init` runs
+- `SENTRY_TAG_FIELDS` maps `TracingSpanParams` attributes to Sentry keys. Searchable fields currently include
+  `run_id`, `cron_id`, `trace_id`, `project_id`, `organization_id`, `call_type`, `graph_runner_id`, `tag_name`, and
+  `environment` mapped to `env` so it does not shadow Sentry's native deployment `environment`.
+- Sync happens on the isolation scope for both tags and attributes; `None` clears both sides to avoid stale values
+  across runs on the same thread.
+- When adding a new searchable field, add it to `TracingSpanParams` and `SENTRY_TAG_FIELDS`. `span_context` validates
+  that the mapping only references real tracing fields.
 
-When introducing a new tracing field, add it to `TracingSpanParams` first. If it should be searchable in Sentry,
-also add it to `SENTRY_TAG_FIELDS` so the propagation remains centralized and endpoint-agnostic. At import time,
-`span_context` asserts that every key in `SENTRY_TAG_FIELDS` is a real `TracingSpanParams` attribute.
-Avoid mutating `TracingSpanParams` fields directly after reading the context; use `set_tracing_span(...)` so Sentry
-stays in sync. `GraphRunner.run()` is the only exception: it updates the existing `trace_id` before calling
-`set_tracing_span(trace_id=...)` so the value survives root span isolation and remains available to callers after
-failures.
+Avoid mutating `TracingSpanParams` directly in normal code paths; use `set_tracing_span(...)` so Sentry stays in sync.
+`GraphRunner.run()` is the only exception: it preserves `trace_id` across root span isolation before calling
+`set_tracing_span(trace_id=...)`.
 
-`run_id`, `project_id`, and `organization_id` are injected at the earliest point of each run flow so that even
-router-level logs emitted *before* the run reaches the worker (e.g. `push_run_task` enqueue logs) already carry
-the tags:
-- Sync path: `run_with_tracking()` calls `set_tracing_span(run_id=...)` right after (re)creating the run; project
-  and organization come from the upstream `setup_tracing_context(...)` call in `run_agent(...)`.
-- Async enqueue path (`POST /projects/{id}/graphs/{gr_id}/chat/async` and `retry_run()`): both call
-  `setup_tracing_context(session, project_id)` + `set_tracing_span(run_id=str(run.id))` immediately after
-  `create_run(...)`, before `push_run_task(...)`.
-- Worker path: `RunQueueWorker.process_payload(...)` opens a fresh `sentry_sdk.isolation_scope()` and re-sets
-  `run_id` so tags are isolated per payload (no leakage across consecutive runs on the same worker thread).
+`run_id` is injected at run boundaries: sync runs in `run_with_tracking()`, async enqueue paths before
+`push_run_task(...)`, and worker execution in `RunQueueWorker.process_payload()`.
 
 ## Key Files
 

--- a/ada_backend/routers/project_router.py
+++ b/ada_backend/routers/project_router.py
@@ -52,7 +52,6 @@ from ada_backend.services.project_service import (
 from ada_backend.services.run_service import create_run, run_with_tracking, update_run_status
 from ada_backend.services.tag_service import compose_tag_name
 from ada_backend.utils.redis_client import push_run_task
-from engine.trace.span_context import set_tracing_span
 from engine.components.errors import (
     CategorizationError,
     KeyTypePromptTemplateError,
@@ -60,6 +59,7 @@ from engine.components.errors import (
     MissingKeyPromptTemplateError,
     NoMatchingRouteError,
 )
+from engine.trace.span_context import set_tracing_span
 
 LOGGER = logging.getLogger(__name__)
 

--- a/ada_backend/routers/project_router.py
+++ b/ada_backend/routers/project_router.py
@@ -28,7 +28,7 @@ from ada_backend.schemas.project_schema import (
     ProjectWithGraphRunnersSchema,
 )
 from ada_backend.schemas.run_schema import AsyncRunAcceptedSchema
-from ada_backend.services.agent_runner_service import run_agent, run_env_agent
+from ada_backend.services.agent_runner_service import run_agent, run_env_agent, setup_tracing_context
 from ada_backend.services.api_key_service import verify_project_access
 from ada_backend.services.charts_service import get_charts_by_projects
 from ada_backend.services.errors import (
@@ -52,6 +52,7 @@ from ada_backend.services.project_service import (
 from ada_backend.services.run_service import create_run, run_with_tracking, update_run_status
 from ada_backend.services.tag_service import compose_tag_name
 from ada_backend.utils.redis_client import push_run_task
+from engine.trace.span_context import set_tracing_span
 from engine.components.errors import (
     CategorizationError,
     KeyTypePromptTemplateError,
@@ -502,6 +503,8 @@ async def chat_async(
             project_id=project_id,
             trigger=CallType.SANDBOX,
         )
+        setup_tracing_context(session=session, project_id=project_id)
+        set_tracing_span(run_id=str(run.id))
         pushed = push_run_task(
             run_id=run.id,
             project_id=project_id,

--- a/ada_backend/services/run_service.py
+++ b/ada_backend/services/run_service.py
@@ -16,6 +16,7 @@ from ada_backend.repositories.run_input_repository import get_run_input
 from ada_backend.schemas.project_schema import ChatResponse
 from ada_backend.schemas.run_schema import AsyncRunAcceptedSchema, RunResponseSchema
 from ada_backend.services.alerting.alert_service import maybe_send_run_failure_alert
+from ada_backend.services.agent_runner_service import setup_tracing_context
 from ada_backend.services.errors import (
     InvalidRunStatusTransition,
     ProjectNotFound,
@@ -396,6 +397,9 @@ def retry_run(
         retry_group_id=retry_group_id,
         attempt_number=next_attempt,
     )
+
+    setup_tracing_context(session=session, project_id=project_id)
+    set_tracing_span(run_id=str(retried_run.id))
 
     pushed = push_run_task(
         run_id=retried_run.id,

--- a/ada_backend/services/run_service.py
+++ b/ada_backend/services/run_service.py
@@ -15,8 +15,8 @@ from ada_backend.repositories.project_repository import get_project
 from ada_backend.repositories.run_input_repository import get_run_input
 from ada_backend.schemas.project_schema import ChatResponse
 from ada_backend.schemas.run_schema import AsyncRunAcceptedSchema, RunResponseSchema
-from ada_backend.services.alerting.alert_service import maybe_send_run_failure_alert
 from ada_backend.services.agent_runner_service import setup_tracing_context
+from ada_backend.services.alerting.alert_service import maybe_send_run_failure_alert
 from ada_backend.services.errors import (
     InvalidRunStatusTransition,
     ProjectNotFound,

--- a/ada_backend/services/run_service.py
+++ b/ada_backend/services/run_service.py
@@ -26,6 +26,7 @@ from ada_backend.services.errors import (
 from ada_backend.services.s3_files_service import get_s3_client_and_ensure_bucket
 from ada_backend.utils.redis_client import push_run_task
 from data_ingestion.boto3_client import get_content_from_file, upload_file_to_bucket
+from engine.trace.span_context import set_tracing_span
 from settings import settings
 
 LOGGER = logging.getLogger(__name__)
@@ -97,6 +98,7 @@ async def run_with_tracking(
                 event_id=event_id,
             )
             run_id = run.id
+        set_tracing_span(run_id=str(run_id))
         now = datetime.now(timezone.utc)
         update_run_status(
             session,

--- a/ada_backend/workers/run_queue_worker.py
+++ b/ada_backend/workers/run_queue_worker.py
@@ -59,9 +59,9 @@ class RunQueueWorker(BaseQueueWorker):
             try:
                 try:
                     env = EnvType(env_str) if env_str else None
-                except ValueError as e:
+                except ValueError:
                     LOGGER.warning("Invalid env in run %s: %s", run_id, env_str)
-                    raise e
+                    raise
 
                 try:
                     call_type = CallType(trigger_str)

--- a/ada_backend/workers/run_queue_worker.py
+++ b/ada_backend/workers/run_queue_worker.py
@@ -14,7 +14,7 @@ from ada_backend.services.run_service import _upload_result_to_s3, update_run_st
 from ada_backend.services.tag_service import compose_tag_name
 from ada_backend.utils.redis_client import publish_run_event
 from ada_backend.workers.base_queue_worker import BaseQueueWorker
-from engine.trace.span_context import set_tracing_span
+from engine.trace.span_context import reset_tracing_span, set_tracing_span
 from settings import settings
 
 LOGGER = logging.getLogger(__name__)
@@ -55,6 +55,7 @@ class RunQueueWorker(BaseQueueWorker):
         trigger_str = payload.get("trigger", CallType.API.value)
 
         with sentry_sdk.isolation_scope():
+            reset_tracing_span()
             set_tracing_span(run_id=str(run_id))
             try:
                 try:

--- a/ada_backend/workers/run_queue_worker.py
+++ b/ada_backend/workers/run_queue_worker.py
@@ -3,6 +3,8 @@ import logging
 from datetime import datetime, timezone
 from uuid import UUID
 
+import sentry_sdk
+
 from ada_backend.database.models import CallType, EnvType, GraphRunner, ResponseFormat, RunStatus
 from ada_backend.database.setup_db import get_db_session
 from ada_backend.repositories import run_repository
@@ -12,6 +14,7 @@ from ada_backend.services.run_service import _upload_result_to_s3, update_run_st
 from ada_backend.services.tag_service import compose_tag_name
 from ada_backend.utils.redis_client import publish_run_event
 from ada_backend.workers.base_queue_worker import BaseQueueWorker
+from engine.trace.span_context import set_tracing_span
 from settings import settings
 
 LOGGER = logging.getLogger(__name__)
@@ -51,115 +54,117 @@ class RunQueueWorker(BaseQueueWorker):
         response_format = ResponseFormat(payload.get("response_format") or "s3_key")
         trigger_str = payload.get("trigger", CallType.API.value)
 
-        try:
+        with sentry_sdk.isolation_scope():
+            set_tracing_span(run_id=str(run_id))
             try:
-                env = EnvType(env_str) if env_str else None
-            except ValueError as e:
-                LOGGER.warning("Invalid env in run %s: %s", run_id, env_str)
-                raise e
+                try:
+                    env = EnvType(env_str) if env_str else None
+                except ValueError as e:
+                    LOGGER.warning("Invalid env in run %s: %s", run_id, env_str)
+                    raise e
 
-            try:
-                call_type = CallType(trigger_str)
-            except ValueError:
-                LOGGER.warning("Invalid trigger in run %s: %s, defaulting to API", run_id, trigger_str)
-                call_type = CallType.API
+                try:
+                    call_type = CallType(trigger_str)
+                except ValueError:
+                    LOGGER.warning("Invalid trigger in run %s: %s, defaulting to API", run_id, trigger_str)
+                    call_type = CallType.API
 
-            with get_db_session() as session:
-                run = run_repository.get_run(session, run_id)
-                if not run:
-                    LOGGER.warning("Run %s not found, skipping", run_id)
-                    return
-                current = run.status if isinstance(run.status, RunStatus) else RunStatus(str(run.status))
-                if current != RunStatus.PENDING:
-                    LOGGER.debug("Run %s already %s, skipping", run_id, current)
-                    return
+                with get_db_session() as session:
+                    run = run_repository.get_run(session, run_id)
+                    if not run:
+                        LOGGER.warning("Run %s not found, skipping", run_id)
+                        return
+                    current = run.status if isinstance(run.status, RunStatus) else RunStatus(str(run.status))
+                    if current != RunStatus.PENDING:
+                        LOGGER.debug("Run %s already %s, skipping", run_id, current)
+                        return
 
-                retry_group = run.retry_group_id or run.id
-                save_run_input(session, retry_group_id=retry_group, project_id=project_id, input_data=input_data)
+                    retry_group = run.retry_group_id or run.id
+                    save_run_input(session, retry_group_id=retry_group, project_id=project_id, input_data=input_data)
 
-                now = datetime.now(timezone.utc)
-                update_run_status(
-                    session,
-                    run_id=run_id,
-                    project_id=project_id,
-                    status=RunStatus.RUNNING,
-                    started_at=now,
-                )
-
-            async def event_callback(evt: dict):
-                publish_run_event(run_id, evt)
-
-            async def execute_agent():
-                if env:
-                    return await run_env_agent(
+                    now = datetime.now(timezone.utc)
+                    update_run_status(
+                        session,
+                        run_id=run_id,
                         project_id=project_id,
-                        env=env,
+                        status=RunStatus.RUNNING,
+                        started_at=now,
+                    )
+
+                async def event_callback(evt: dict):
+                    publish_run_event(run_id, evt)
+
+                async def execute_agent():
+                    if env:
+                        return await run_env_agent(
+                            project_id=project_id,
+                            env=env,
+                            input_data=input_data,
+                            call_type=call_type,
+                            response_format=response_format,
+                            event_callback=event_callback,
+                        )
+                    raw_gr_id = payload.get("graph_runner_id")
+                    if not raw_gr_id:
+                        raise ValueError("Payload has no env and no graph_runner_id")
+                    graph_runner_id = UUID(raw_gr_id)
+                    with get_db_session() as sess:
+                        graph_runner = sess.get(GraphRunner, graph_runner_id)
+                        if graph_runner is None:
+                            raise ValueError(f"GraphRunner {graph_runner_id} not found for project {project_id}")
+                        tag_name = compose_tag_name(graph_runner.tag_version, graph_runner.version_name)
+                    return await run_agent(
+                        project_id=project_id,
+                        graph_runner_id=graph_runner_id,
                         input_data=input_data,
+                        environment=None,
                         call_type=call_type,
+                        tag_name=tag_name,
                         response_format=response_format,
                         event_callback=event_callback,
                     )
-                raw_gr_id = payload.get("graph_runner_id")
-                if not raw_gr_id:
-                    raise ValueError("Payload has no env and no graph_runner_id")
-                graph_runner_id = UUID(raw_gr_id)
-                with get_db_session() as sess:
-                    graph_runner = sess.get(GraphRunner, graph_runner_id)
-                    if graph_runner is None:
-                        raise ValueError(f"GraphRunner {graph_runner_id} not found for project {project_id}")
-                    tag_name = compose_tag_name(graph_runner.tag_version, graph_runner.version_name)
-                return await run_agent(
-                    project_id=project_id,
-                    graph_runner_id=graph_runner_id,
-                    input_data=input_data,
-                    environment=None,
-                    call_type=call_type,
-                    tag_name=tag_name,
-                    response_format=response_format,
-                    event_callback=event_callback,
-                )
 
-            result = loop.run_until_complete(execute_agent())
-            result_id = _upload_result_to_s3(result, project_id=project_id, run_id=run_id)
-            with get_db_session() as session:
-                update_run_status(
-                    session,
-                    run_id=run_id,
-                    project_id=project_id,
-                    status=RunStatus.COMPLETED,
-                    trace_id=result.trace_id,
-                    result_id=result_id,
-                    finished_at=datetime.now(timezone.utc),
-                )
-            publish_run_event(
-                run_id,
-                {"type": "run.completed", "trace_id": result.trace_id, "result_id": result_id},
-            )
-            LOGGER.info("Run %s completed", run_id)
-        except Exception as e:
-            LOGGER.exception("Run %s failed: %s", run_id, e)
-            trace_id = getattr(e, "trace_id", None)
-            try:
+                result = loop.run_until_complete(execute_agent())
+                result_id = _upload_result_to_s3(result, project_id=project_id, run_id=run_id)
                 with get_db_session() as session:
                     update_run_status(
                         session,
                         run_id=run_id,
                         project_id=project_id,
-                        status=RunStatus.FAILED,
-                        error={"message": str(e), "type": type(e).__name__},
-                        trace_id=trace_id,
+                        status=RunStatus.COMPLETED,
+                        trace_id=result.trace_id,
+                        result_id=result_id,
                         finished_at=datetime.now(timezone.utc),
                     )
-            except Exception as status_exc:
-                LOGGER.exception("Failed to update run %s to FAILED: %s", run_id, status_exc)
-
-            try:
                 publish_run_event(
                     run_id,
-                    {"type": "run.failed", "error": {"message": str(e), "type": type(e).__name__}},
+                    {"type": "run.completed", "trace_id": result.trace_id, "result_id": result_id},
                 )
-            except Exception as event_exc:
-                LOGGER.exception("Failed to publish run.failed event for %s: %s", run_id, event_exc)
+                LOGGER.info("Run %s completed", run_id)
+            except Exception as e:
+                LOGGER.exception("Run %s failed: %s", run_id, e)
+                trace_id = getattr(e, "trace_id", None)
+                try:
+                    with get_db_session() as session:
+                        update_run_status(
+                            session,
+                            run_id=run_id,
+                            project_id=project_id,
+                            status=RunStatus.FAILED,
+                            error={"message": str(e), "type": type(e).__name__},
+                            trace_id=trace_id,
+                            finished_at=datetime.now(timezone.utc),
+                        )
+                except Exception as status_exc:
+                    LOGGER.exception("Failed to update run %s to FAILED: %s", run_id, status_exc)
+
+                try:
+                    publish_run_event(
+                        run_id,
+                        {"type": "run.failed", "error": {"message": str(e), "type": type(e).__name__}},
+                    )
+                except Exception as event_exc:
+                    LOGGER.exception("Failed to publish run.failed event for %s: %s", run_id, event_exc)
 
 
 _worker = RunQueueWorker()

--- a/engine/graph_runner/graph_runner.py
+++ b/engine/graph_runner/graph_runner.py
@@ -18,7 +18,7 @@ from engine.graph_runner.port_management import get_target_field_type
 from engine.graph_runner.runnable import Runnable
 from engine.graph_runner.types import Task, TaskState
 from engine.trace.serializer import serialize_to_json
-from engine.trace.span_context import get_tracing_span
+from engine.trace.span_context import get_tracing_span, set_tracing_span
 from engine.trace.trace_manager import TraceManager
 
 LOGGER = logging.getLogger(__name__)
@@ -109,7 +109,9 @@ class GraphRunner:
             params = get_tracing_span()
             if params:
                 span_json = json.loads(span.to_json())
-                params.trace_id = span_json["context"]["trace_id"]
+                trace_id = span_json["context"]["trace_id"]
+                params.trace_id = trace_id
+                set_tracing_span(trace_id=trace_id)
 
             trace_input = serialize_to_json(input_data, shorten_string=True)
             span.set_attributes({

--- a/engine/trace/span_context.py
+++ b/engine/trace/span_context.py
@@ -33,30 +33,43 @@ class TracingSpanParams:
 _tracing_context: ContextVar[Optional[TracingSpanParams]] = ContextVar("_tracing_context", default=None)
 
 _SPAN_FIELDS = {f.name for f in dataclasses.fields(TracingSpanParams)}
-SENTRY_TAG_FIELDS = (
-    "run_id",
-    "cron_id",
-    "trace_id",
-    "project_id",
-    "organization_id",
-    "environment",
-    "call_type",
-    "graph_runner_id",
-    "tag_name",
-)
+
+# Mapping of TracingSpanParams attribute name → Sentry tag/attribute key.
+# Keys must exist on TracingSpanParams. Values are the key used on Sentry's
+# isolation scope (tags and attributes). `environment` is remapped to `env` to
+# avoid shadowing Sentry's native `environment` tag (which identifies staging vs.
+# prod). All other fields keep the same name on both sides.
+SENTRY_TAG_FIELDS: dict[str, str] = {
+    "run_id": "run_id",
+    "cron_id": "cron_id",
+    "trace_id": "trace_id",
+    "project_id": "project_id",
+    "organization_id": "organization_id",
+    "environment": "env",
+    "call_type": "call_type",
+    "graph_runner_id": "graph_runner_id",
+    "tag_name": "tag_name",
+}
+
+_invalid_sentry_fields = set(SENTRY_TAG_FIELDS) - _SPAN_FIELDS
+if _invalid_sentry_fields:
+    raise RuntimeError(
+        f"SENTRY_TAG_FIELDS contains attributes not defined on TracingSpanParams: "
+        f"{sorted(_invalid_sentry_fields)}"
+    )
 
 
 def _sync_to_sentry(params: TracingSpanParams) -> None:
     isolation_scope = sentry_sdk.get_isolation_scope()
-    for field_name in SENTRY_TAG_FIELDS:
-        field_value = getattr(params, field_name)
+    for attr_name, sentry_key in SENTRY_TAG_FIELDS.items():
+        field_value = getattr(params, attr_name)
         if field_value is None:
-            isolation_scope.remove_tag(field_name)
-            isolation_scope.remove_attribute(field_name)
+            isolation_scope.remove_tag(sentry_key)
+            isolation_scope.remove_attribute(sentry_key)
             continue
         str_value = str(field_value)
-        isolation_scope.set_tag(field_name, str_value)
-        isolation_scope.set_attribute(field_name, str_value)
+        isolation_scope.set_tag(sentry_key, str_value)
+        isolation_scope.set_attribute(sentry_key, str_value)
 
 
 def set_tracing_span(**kwargs) -> None:

--- a/engine/trace/span_context.py
+++ b/engine/trace/span_context.py
@@ -34,11 +34,8 @@ _tracing_context: ContextVar[Optional[TracingSpanParams]] = ContextVar("_tracing
 
 _SPAN_FIELDS = {f.name for f in dataclasses.fields(TracingSpanParams)}
 
-# Mapping of TracingSpanParams attribute name → Sentry tag/attribute key.
-# Keys must exist on TracingSpanParams. Values are the key used on Sentry's
-# isolation scope (tags and attributes). `environment` is remapped to `env` to
-# avoid shadowing Sentry's native `environment` tag (which identifies staging vs.
-# prod). All other fields keep the same name on both sides.
+# Maps TracingSpanParams fields to Sentry tag keys; 'environment' becomes 'env' to avoid conflicts.
+# All other fields use their original names.
 SENTRY_TAG_FIELDS: dict[str, str] = {
     "run_id": "run_id",
     "cron_id": "cron_id",
@@ -54,8 +51,7 @@ SENTRY_TAG_FIELDS: dict[str, str] = {
 _invalid_sentry_fields = set(SENTRY_TAG_FIELDS) - _SPAN_FIELDS
 if _invalid_sentry_fields:
     raise RuntimeError(
-        f"SENTRY_TAG_FIELDS contains attributes not defined on TracingSpanParams: "
-        f"{sorted(_invalid_sentry_fields)}"
+        f"SENTRY_TAG_FIELDS contains attributes not defined on TracingSpanParams: " f"{sorted(_invalid_sentry_fields)}"
     )
 
 

--- a/engine/trace/span_context.py
+++ b/engine/trace/span_context.py
@@ -26,6 +26,7 @@ class TracingSpanParams:
     graph_runner_id: Optional[UUID] = None
     tag_name: Optional[str] = None
     cron_id: Optional[str] = None
+    run_id: Optional[str] = None
     shared_sandbox: Optional["AsyncSandbox"] = None
 
 
@@ -33,6 +34,7 @@ _tracing_context: ContextVar[Optional[TracingSpanParams]] = ContextVar("_tracing
 
 _SPAN_FIELDS = {f.name for f in dataclasses.fields(TracingSpanParams)}
 SENTRY_TAG_FIELDS = (
+    "run_id",
     "cron_id",
     "trace_id",
     "project_id",
@@ -51,7 +53,7 @@ def _sync_to_sentry(params: TracingSpanParams) -> None:
         if field_value is None:
             isolation_scope.remove_tag(field_name)
             continue
-        sentry_sdk.set_tag(field_name, str(field_value))
+        isolation_scope.set_tag(field_name, str(field_value))
 
 
 def set_tracing_span(**kwargs) -> None:

--- a/engine/trace/span_context.py
+++ b/engine/trace/span_context.py
@@ -52,8 +52,11 @@ def _sync_to_sentry(params: TracingSpanParams) -> None:
         field_value = getattr(params, field_name)
         if field_value is None:
             isolation_scope.remove_tag(field_name)
+            isolation_scope.remove_attribute(field_name)
             continue
-        isolation_scope.set_tag(field_name, str(field_value))
+        str_value = str(field_value)
+        isolation_scope.set_tag(field_name, str_value)
+        isolation_scope.set_attribute(field_name, str_value)
 
 
 def set_tracing_span(**kwargs) -> None:

--- a/engine/trace/span_context.py
+++ b/engine/trace/span_context.py
@@ -87,6 +87,21 @@ def set_tracing_span(**kwargs) -> None:
     _sync_to_sentry(params)
 
 
+def reset_tracing_span() -> None:
+    """Clear the tracing context and matching Sentry tags/attributes on the current isolation scope.
+
+    Intended for top-level execution boundaries where a thread or task is reused across
+    independent runs (e.g. `RunQueueWorker.process_payload`). Do not call this inside a
+    single logical run: normal code should rely on `set_tracing_span`'s merge semantics
+    so that upstream fields (cron_id, project_id, ...) keep propagating.
+    """
+    _tracing_context.set(None)
+    isolation_scope = sentry_sdk.get_isolation_scope()
+    for sentry_key in SENTRY_TAG_FIELDS.values():
+        isolation_scope.remove_tag(sentry_key)
+        isolation_scope.remove_attribute(sentry_key)
+
+
 def get_tracing_span() -> Optional[TracingSpanParams]:
     """Retrieve the current tracing context, if any."""
     return _tracing_context.get()

--- a/tests/ada_backend/routers/test_project_router_errors.py
+++ b/tests/ada_backend/routers/test_project_router_errors.py
@@ -39,33 +39,45 @@ def _make_run(run_id=None):
 
 class TestChatAsyncNoneEnvironment:
     @pytest.mark.asyncio
+    @patch("ada_backend.routers.project_router.set_tracing_span")
+    @patch("ada_backend.routers.project_router.setup_tracing_context")
     @patch("ada_backend.routers.project_router.push_run_task", return_value=True)
     @patch("ada_backend.routers.project_router.create_run")
     @patch("ada_backend.routers.project_router.get_project_env_binding")
-    async def test_does_not_crash_when_environment_is_none(self, mock_get_binding, mock_create_run, mock_push):
+    async def test_does_not_crash_when_environment_is_none(
+        self, mock_get_binding, mock_create_run, mock_push, mock_setup_ctx, mock_set_span
+    ):
         run = _make_run()
         gr_id = uuid4()
+        project_id = uuid4()
         mock_get_binding.return_value = _make_binding(environment=None)
         mock_create_run.return_value = run
+        session = MagicMock()
 
         result = await chat_async(
-            project_id=uuid4(),
+            project_id=project_id,
             graph_runner_id=gr_id,
             user=_make_fake_user(),
             input_data={"messages": [{"role": "user", "content": "hi"}]},
-            session=MagicMock(),
+            session=session,
         )
 
         assert result.run_id == run.id
         mock_push.assert_called_once()
         assert mock_push.call_args.kwargs["env"] is None
         assert mock_push.call_args.kwargs["graph_runner_id"] == gr_id
+        mock_setup_ctx.assert_called_once_with(session=session, project_id=project_id)
+        mock_set_span.assert_called_once_with(run_id=str(run.id))
 
     @pytest.mark.asyncio
+    @patch("ada_backend.routers.project_router.set_tracing_span")
+    @patch("ada_backend.routers.project_router.setup_tracing_context")
     @patch("ada_backend.routers.project_router.push_run_task", return_value=True)
     @patch("ada_backend.routers.project_router.create_run")
     @patch("ada_backend.routers.project_router.get_project_env_binding")
-    async def test_passes_env_value_when_environment_is_present(self, mock_get_binding, mock_create_run, mock_push):
+    async def test_passes_env_value_when_environment_is_present(
+        self, mock_get_binding, mock_create_run, mock_push, mock_setup_ctx, mock_set_span
+    ):
         mock_env = EnvType.DRAFT
         run = _make_run()
         gr_id = uuid4()
@@ -86,12 +98,14 @@ class TestChatAsyncNoneEnvironment:
         assert mock_push.call_args.kwargs["graph_runner_id"] == gr_id
 
     @pytest.mark.asyncio
+    @patch("ada_backend.routers.project_router.set_tracing_span")
+    @patch("ada_backend.routers.project_router.setup_tracing_context")
     @patch("ada_backend.routers.project_router.push_run_task", return_value=False)
     @patch("ada_backend.routers.project_router.update_run_status")
     @patch("ada_backend.routers.project_router.create_run")
     @patch("ada_backend.routers.project_router.get_project_env_binding")
     async def test_returns_503_when_push_fails_with_none_env(
-        self, mock_get_binding, mock_create_run, mock_update, mock_push
+        self, mock_get_binding, mock_create_run, mock_update, mock_push, mock_setup_ctx, mock_set_span
     ):
         mock_get_binding.return_value = _make_binding(environment=None)
         mock_create_run.return_value = _make_run()

--- a/tests/ada_backend/routers/test_project_router_errors.py
+++ b/tests/ada_backend/routers/test_project_router_errors.py
@@ -39,13 +39,12 @@ def _make_run(run_id=None):
 
 class TestChatAsyncNoneEnvironment:
     @pytest.mark.asyncio
-    @patch("ada_backend.routers.project_router.set_tracing_span")
     @patch("ada_backend.routers.project_router.setup_tracing_context")
     @patch("ada_backend.routers.project_router.push_run_task", return_value=True)
     @patch("ada_backend.routers.project_router.create_run")
     @patch("ada_backend.routers.project_router.get_project_env_binding")
     async def test_does_not_crash_when_environment_is_none(
-        self, mock_get_binding, mock_create_run, mock_push, mock_setup_ctx, mock_set_span
+        self, mock_get_binding, mock_create_run, mock_push, mock_setup_ctx
     ):
         run = _make_run()
         gr_id = uuid4()
@@ -67,16 +66,14 @@ class TestChatAsyncNoneEnvironment:
         assert mock_push.call_args.kwargs["env"] is None
         assert mock_push.call_args.kwargs["graph_runner_id"] == gr_id
         mock_setup_ctx.assert_called_once_with(session=session, project_id=project_id)
-        mock_set_span.assert_called_once_with(run_id=str(run.id))
 
     @pytest.mark.asyncio
-    @patch("ada_backend.routers.project_router.set_tracing_span")
     @patch("ada_backend.routers.project_router.setup_tracing_context")
     @patch("ada_backend.routers.project_router.push_run_task", return_value=True)
     @patch("ada_backend.routers.project_router.create_run")
     @patch("ada_backend.routers.project_router.get_project_env_binding")
     async def test_passes_env_value_when_environment_is_present(
-        self, mock_get_binding, mock_create_run, mock_push, mock_setup_ctx, mock_set_span
+        self, mock_get_binding, mock_create_run, mock_push, mock_setup_ctx
     ):
         mock_env = EnvType.DRAFT
         run = _make_run()
@@ -98,14 +95,13 @@ class TestChatAsyncNoneEnvironment:
         assert mock_push.call_args.kwargs["graph_runner_id"] == gr_id
 
     @pytest.mark.asyncio
-    @patch("ada_backend.routers.project_router.set_tracing_span")
     @patch("ada_backend.routers.project_router.setup_tracing_context")
     @patch("ada_backend.routers.project_router.push_run_task", return_value=False)
     @patch("ada_backend.routers.project_router.update_run_status")
     @patch("ada_backend.routers.project_router.create_run")
     @patch("ada_backend.routers.project_router.get_project_env_binding")
     async def test_returns_503_when_push_fails_with_none_env(
-        self, mock_get_binding, mock_create_run, mock_update, mock_push, mock_setup_ctx, mock_set_span
+        self, mock_get_binding, mock_create_run, mock_update, mock_push, mock_setup_ctx
     ):
         mock_get_binding.return_value = _make_binding(environment=None)
         mock_create_run.return_value = _make_run()

--- a/tests/ada_backend/services/test_run_service.py
+++ b/tests/ada_backend/services/test_run_service.py
@@ -158,6 +158,8 @@ class TestRetryRun:
             patch(f"{MODULE}.get_run_input", return_value={"messages": [{"role": "user", "content": "retry"}]}),
             patch(f"{MODULE}.create_run", return_value=created_run) as create_run_mock,
             patch(f"{MODULE}.push_run_task", return_value=True) as push_mock,
+            patch(f"{MODULE}.setup_tracing_context") as setup_ctx_mock,
+            patch(f"{MODULE}.set_tracing_span") as set_span_mock,
         ):
             repo.get_run.return_value = existing_run
             repo.get_latest_run_by_retry_group.return_value = latest_attempt
@@ -175,6 +177,8 @@ class TestRetryRun:
         assert create_run_mock.call_args.kwargs["retry_group_id"] == retry_group_id
         push_mock.assert_called_once()
         assert push_mock.call_args.kwargs["input_data"] == {"messages": [{"role": "user", "content": "retry"}]}
+        setup_ctx_mock.assert_called_once_with(session=session, project_id=project_id)
+        set_span_mock.assert_called_once_with(run_id=str(new_run_id))
 
     def test_raises_when_no_persisted_input_exists(self):
         session = self._make_session()

--- a/tests/ada_backend/services/test_run_service.py
+++ b/tests/ada_backend/services/test_run_service.py
@@ -159,7 +159,6 @@ class TestRetryRun:
             patch(f"{MODULE}.create_run", return_value=created_run) as create_run_mock,
             patch(f"{MODULE}.push_run_task", return_value=True) as push_mock,
             patch(f"{MODULE}.setup_tracing_context") as setup_ctx_mock,
-            patch(f"{MODULE}.set_tracing_span") as set_span_mock,
         ):
             repo.get_run.return_value = existing_run
             repo.get_latest_run_by_retry_group.return_value = latest_attempt
@@ -178,7 +177,6 @@ class TestRetryRun:
         push_mock.assert_called_once()
         assert push_mock.call_args.kwargs["input_data"] == {"messages": [{"role": "user", "content": "retry"}]}
         setup_ctx_mock.assert_called_once_with(session=session, project_id=project_id)
-        set_span_mock.assert_called_once_with(run_id=str(new_run_id))
 
     def test_raises_when_no_persisted_input_exists(self):
         session = self._make_session()

--- a/tests/ada_backend/workers/test_run_queue_worker.py
+++ b/tests/ada_backend/workers/test_run_queue_worker.py
@@ -7,6 +7,7 @@ import pytest
 
 from ada_backend.database.models import RunStatus
 from ada_backend.workers.run_queue_worker import RunQueueWorker
+from engine.trace.span_context import get_tracing_span
 
 
 @pytest.fixture
@@ -22,6 +23,15 @@ def loop():
     lp = asyncio.new_event_loop()
     yield lp
     lp.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_tracing_context():
+    from engine.trace.span_context import _tracing_context
+
+    token = _tracing_context.set(None)
+    yield
+    _tracing_context.reset(token)
 
 
 class TestProcessPayloadGraphRunnerNotFound:
@@ -149,3 +159,55 @@ class TestProcessPayloadPersistsInput:
 
             _, kwargs = mock_save.call_args
             assert kwargs["retry_group_id"] == run_id
+
+
+class TestProcessPayloadTracing:
+    def test_sets_run_id_inside_fresh_isolation_scope(self, worker, loop):
+        run_id = uuid4()
+        project_id = uuid4()
+
+        payload = {
+            "run_id": str(run_id),
+            "project_id": str(project_id),
+            "env": "production",
+            "input_data": {"text": "hello"},
+            "trigger": "api",
+        }
+
+        mock_run = MagicMock()
+        mock_run.status = "pending"
+        mock_run.retry_group_id = None
+        mock_run.id = run_id
+
+        observed = {"entered_scope": False, "run_id": None}
+
+        @contextmanager
+        def fake_db_session():
+            yield MagicMock()
+
+        @contextmanager
+        def fake_isolation_scope():
+            observed["entered_scope"] = True
+            yield
+
+        async def fake_run_env_agent(**kwargs):
+            params = get_tracing_span()
+            observed["run_id"] = params.run_id if params else None
+            raise Exception("boom")
+
+        with (
+            patch.object(worker, "_ensure_trace_manager"),
+            patch("ada_backend.workers.run_queue_worker.get_db_session", side_effect=fake_db_session),
+            patch("ada_backend.workers.run_queue_worker.run_repository") as mock_run_repo,
+            patch("ada_backend.workers.run_queue_worker.update_run_status"),
+            patch("ada_backend.workers.run_queue_worker.publish_run_event"),
+            patch("ada_backend.workers.run_queue_worker.save_run_input"),
+            patch("ada_backend.workers.run_queue_worker.sentry_sdk.isolation_scope", side_effect=fake_isolation_scope),
+            patch("ada_backend.workers.run_queue_worker.run_env_agent", side_effect=fake_run_env_agent),
+        ):
+            mock_run_repo.get_run.return_value = mock_run
+
+            worker.process_payload(payload, loop)
+
+        assert observed["entered_scope"] is True
+        assert observed["run_id"] == str(run_id)

--- a/tests/ada_backend/workers/test_run_queue_worker.py
+++ b/tests/ada_backend/workers/test_run_queue_worker.py
@@ -7,7 +7,7 @@ import pytest
 
 from ada_backend.database.models import RunStatus
 from ada_backend.workers.run_queue_worker import RunQueueWorker
-from engine.trace.span_context import get_tracing_span
+from engine.trace.span_context import get_tracing_span, set_tracing_span
 
 
 @pytest.fixture
@@ -211,3 +211,53 @@ class TestProcessPayloadTracing:
 
         assert observed["entered_scope"] is True
         assert observed["run_id"] == str(run_id)
+
+    def test_resets_stale_context_from_previous_run(self, worker, loop):
+        set_tracing_span(cron_id="cron-stale", project_id="proj-stale", organization_id="org-stale")
+
+        run_id = uuid4()
+        project_id = uuid4()
+
+        payload = {
+            "run_id": str(run_id),
+            "project_id": str(project_id),
+            "env": "production",
+            "input_data": {"text": "hello"},
+            "trigger": "api",
+        }
+
+        mock_run = MagicMock()
+        mock_run.status = "pending"
+        mock_run.retry_group_id = None
+        mock_run.id = run_id
+
+        observed = {"cron_id": "not-set", "project_id": "not-set", "organization_id": "not-set"}
+
+        @contextmanager
+        def fake_db_session():
+            yield MagicMock()
+
+        async def fake_run_env_agent(**kwargs):
+            params = get_tracing_span()
+            assert params is not None
+            observed["cron_id"] = params.cron_id
+            observed["project_id"] = params.project_id
+            observed["organization_id"] = params.organization_id
+            raise Exception("boom")
+
+        with (
+            patch.object(worker, "_ensure_trace_manager"),
+            patch("ada_backend.workers.run_queue_worker.get_db_session", side_effect=fake_db_session),
+            patch("ada_backend.workers.run_queue_worker.run_repository") as mock_run_repo,
+            patch("ada_backend.workers.run_queue_worker.update_run_status"),
+            patch("ada_backend.workers.run_queue_worker.publish_run_event"),
+            patch("ada_backend.workers.run_queue_worker.save_run_input"),
+            patch("ada_backend.workers.run_queue_worker.run_env_agent", side_effect=fake_run_env_agent),
+        ):
+            mock_run_repo.get_run.return_value = mock_run
+
+            worker.process_payload(payload, loop)
+
+        assert observed["cron_id"] is None
+        assert observed["project_id"] == ""
+        assert observed["organization_id"] == ""

--- a/tests/ada_backend/workers/test_run_queue_worker.py
+++ b/tests/ada_backend/workers/test_run_queue_worker.py
@@ -245,6 +245,10 @@ class TestProcessPayloadTracing:
             observed["organization_id"] = params.organization_id
             raise Exception("boom")
 
+        @contextmanager
+        def fake_isolation_scope():
+            yield
+
         with (
             patch.object(worker, "_ensure_trace_manager"),
             patch("ada_backend.workers.run_queue_worker.get_db_session", side_effect=fake_db_session),
@@ -252,6 +256,7 @@ class TestProcessPayloadTracing:
             patch("ada_backend.workers.run_queue_worker.update_run_status"),
             patch("ada_backend.workers.run_queue_worker.publish_run_event"),
             patch("ada_backend.workers.run_queue_worker.save_run_input"),
+            patch("ada_backend.workers.run_queue_worker.sentry_sdk.isolation_scope", side_effect=fake_isolation_scope),
             patch("ada_backend.workers.run_queue_worker.run_env_agent", side_effect=fake_run_env_agent),
         ):
             mock_run_repo.get_run.return_value = mock_run

--- a/tests/engine/test_graph_runner_trace_on_failure.py
+++ b/tests/engine/test_graph_runner_trace_on_failure.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import uuid
+from unittest.mock import patch
 
 import networkx as nx
 import pytest
@@ -74,9 +75,11 @@ class TestTraceIdSetOnFailure:
             trace_manager=tm,
         )
 
-        with pytest.raises(RuntimeError, match="simulated component failure"):
-            asyncio.run(gr.run({"input": "hello"}, is_root_execution=True))
+        with patch("engine.graph_runner.graph_runner.set_tracing_span", wraps=set_tracing_span) as mock_set_tracing_span:
+            with pytest.raises(RuntimeError, match="simulated component failure"):
+                asyncio.run(gr.run({"input": "hello"}, is_root_execution=True))
 
         params = get_tracing_span()
         assert params is not None
         assert params.trace_id is not None, "trace_id should be set even when execution fails"
+        assert any(call.kwargs.get("trace_id") == params.trace_id for call in mock_set_tracing_span.call_args_list)

--- a/tests/engine/test_graph_runner_trace_on_failure.py
+++ b/tests/engine/test_graph_runner_trace_on_failure.py
@@ -75,7 +75,10 @@ class TestTraceIdSetOnFailure:
             trace_manager=tm,
         )
 
-        with patch("engine.graph_runner.graph_runner.set_tracing_span", wraps=set_tracing_span) as mock_set_tracing_span:
+        with patch(
+            "engine.graph_runner.graph_runner.set_tracing_span",
+            wraps=set_tracing_span,
+        ) as mock_set_tracing_span:
             with pytest.raises(RuntimeError, match="simulated component failure"):
                 asyncio.run(gr.run({"input": "hello"}, is_root_execution=True))
 

--- a/tests/engine/trace/test_span_context.py
+++ b/tests/engine/trace/test_span_context.py
@@ -3,7 +3,13 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 from engine.trace import span_context
-from engine.trace.span_context import TracingSpanParams, get_tracing_span, set_tracing_span
+from engine.trace.span_context import (
+    SENTRY_TAG_FIELDS,
+    TracingSpanParams,
+    get_tracing_span,
+    reset_tracing_span,
+    set_tracing_span,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -167,3 +173,39 @@ class TestSetTracingSpan:
 
         mock_scope.remove_tag.assert_any_call("env")
         mock_scope.remove_attribute.assert_any_call("env")
+
+
+class TestResetTracingSpan:
+    def test_reset_clears_context(self):
+        set_tracing_span(cron_id="cron-123", project_id="proj")
+        assert get_tracing_span() is not None
+
+        reset_tracing_span()
+
+        assert get_tracing_span() is None
+
+    def test_reset_does_not_leak_cron_id_into_next_run(self):
+        set_tracing_span(cron_id="cron-123", project_id="proj-old")
+        reset_tracing_span()
+        set_tracing_span(run_id="run-new")
+
+        params = get_tracing_span()
+        assert params is not None
+        assert params.run_id == "run-new"
+        assert params.cron_id is None
+        assert params.project_id == ""
+
+    def test_reset_removes_all_sentry_tags_and_attributes(self):
+        mock_scope = Mock()
+        with patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope):
+            reset_tracing_span()
+
+        expected_keys = set(SENTRY_TAG_FIELDS.values())
+        removed_tags = {call_args.args[0] for call_args in mock_scope.remove_tag.call_args_list}
+        removed_attrs = {call_args.args[0] for call_args in mock_scope.remove_attribute.call_args_list}
+        assert expected_keys.issubset(removed_tags)
+        assert expected_keys.issubset(removed_attrs)
+
+    def test_reset_is_safe_when_context_is_already_empty(self):
+        reset_tracing_span()
+        assert get_tracing_span() is None

--- a/tests/engine/trace/test_span_context.py
+++ b/tests/engine/trace/test_span_context.py
@@ -74,16 +74,15 @@ class TestSetTracingSpan:
                 trace_id="trace-123",
             )
 
-        mock_scope.set_tag.assert_has_calls(
-            [
-                call("run_id", "run-123"),
-                call("cron_id", "cron-123"),
-                call("trace_id", "trace-123"),
-                call("project_id", "proj"),
-                call("organization_id", "org"),
-            ],
-            any_order=True,
-        )
+        expected = [
+            call("run_id", "run-123"),
+            call("cron_id", "cron-123"),
+            call("trace_id", "trace-123"),
+            call("project_id", "proj"),
+            call("organization_id", "org"),
+        ]
+        mock_scope.set_tag.assert_has_calls(expected, any_order=True)
+        mock_scope.set_attribute.assert_has_calls(expected, any_order=True)
 
     def test_none_fields_not_sent_to_isolation_scope(self):
         mock_scope = Mock()
@@ -91,7 +90,9 @@ class TestSetTracingSpan:
             set_tracing_span(project_id="proj", organization_id="org", organization_llm_providers=[], cron_id=None)
 
         assert all(args.args[0] != "cron_id" for args in mock_scope.set_tag.call_args_list)
+        assert all(args.args[0] != "cron_id" for args in mock_scope.set_attribute.call_args_list)
         mock_scope.remove_tag.assert_any_call("cron_id")
+        mock_scope.remove_attribute.assert_any_call("cron_id")
 
     def test_run_id_removal_clears_tag_from_isolation_scope(self):
         mock_scope = Mock()
@@ -100,7 +101,9 @@ class TestSetTracingSpan:
             set_tracing_span(run_id=None)
 
         assert ("run_id", "run-123") in [args.args for args in mock_scope.set_tag.call_args_list]
+        assert ("run_id", "run-123") in [args.args for args in mock_scope.set_attribute.call_args_list]
         mock_scope.remove_tag.assert_any_call("run_id")
+        mock_scope.remove_attribute.assert_any_call("run_id")
 
     def test_non_whitelisted_fields_not_sent(self):
         mock_scope = Mock()
@@ -117,6 +120,10 @@ class TestSetTracingSpan:
         assert "organization_llm_providers" not in sent_fields
         assert "shared_sandbox" not in sent_fields
         assert "uuid_for_temp_folder" not in sent_fields
+        sent_attribute_fields = {args.args[0] for args in mock_scope.set_attribute.call_args_list}
+        assert "organization_llm_providers" not in sent_attribute_fields
+        assert "shared_sandbox" not in sent_attribute_fields
+        assert "uuid_for_temp_folder" not in sent_attribute_fields
 
     def test_sentry_tag_fields_extensibility(self, monkeypatch):
         monkeypatch.setattr(
@@ -134,3 +141,4 @@ class TestSetTracingSpan:
             )
 
         assert ("conversation_id", "conv-1") in [args.args for args in mock_scope.set_tag.call_args_list]
+        assert ("conversation_id", "conv-1") in [args.args for args in mock_scope.set_attribute.call_args_list]

--- a/tests/engine/trace/test_span_context.py
+++ b/tests/engine/trace/test_span_context.py
@@ -62,37 +62,49 @@ class TestSetTracingSpan:
         assert params is not None
         assert isinstance(params, TracingSpanParams)
 
-    def test_set_tracing_span_syncs_tags_to_sentry(self):
-        with patch("engine.trace.span_context.sentry_sdk.set_tag") as mock_set_tag:
+    def test_set_tracing_span_syncs_tags_to_isolation_scope(self):
+        mock_scope = Mock()
+        with patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope):
             set_tracing_span(
                 project_id="proj",
                 organization_id="org",
                 organization_llm_providers=["openai"],
                 cron_id="cron-123",
+                run_id="run-123",
+                trace_id="trace-123",
             )
 
-        mock_set_tag.assert_has_calls(
+        mock_scope.set_tag.assert_has_calls(
             [
+                call("run_id", "run-123"),
                 call("cron_id", "cron-123"),
+                call("trace_id", "trace-123"),
                 call("project_id", "proj"),
                 call("organization_id", "org"),
             ],
             any_order=True,
         )
 
-    def test_none_fields_not_sent_to_sentry(self):
+    def test_none_fields_not_sent_to_isolation_scope(self):
         mock_scope = Mock()
-        with (
-            patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope),
-            patch("engine.trace.span_context.sentry_sdk.set_tag") as mock_set_tag,
-        ):
+        with patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope):
             set_tracing_span(project_id="proj", organization_id="org", organization_llm_providers=[], cron_id=None)
 
-        assert all(args.args[0] != "cron_id" for args in mock_set_tag.call_args_list)
+        assert all(args.args[0] != "cron_id" for args in mock_scope.set_tag.call_args_list)
         mock_scope.remove_tag.assert_any_call("cron_id")
 
+    def test_run_id_removal_clears_tag_from_isolation_scope(self):
+        mock_scope = Mock()
+        with patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope):
+            set_tracing_span(run_id="run-123")
+            set_tracing_span(run_id=None)
+
+        assert ("run_id", "run-123") in [args.args for args in mock_scope.set_tag.call_args_list]
+        mock_scope.remove_tag.assert_any_call("run_id")
+
     def test_non_whitelisted_fields_not_sent(self):
-        with patch("engine.trace.span_context.sentry_sdk.set_tag") as mock_set_tag:
+        mock_scope = Mock()
+        with patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope):
             set_tracing_span(
                 project_id="proj",
                 organization_id="org",
@@ -101,7 +113,7 @@ class TestSetTracingSpan:
                 conversation_id="conv-1",
             )
 
-        sent_fields = {args.args[0] for args in mock_set_tag.call_args_list}
+        sent_fields = {args.args[0] for args in mock_scope.set_tag.call_args_list}
         assert "organization_llm_providers" not in sent_fields
         assert "shared_sandbox" not in sent_fields
         assert "uuid_for_temp_folder" not in sent_fields
@@ -112,7 +124,8 @@ class TestSetTracingSpan:
             "SENTRY_TAG_FIELDS",
             (*span_context.SENTRY_TAG_FIELDS, "conversation_id"),
         )
-        with patch("engine.trace.span_context.sentry_sdk.set_tag") as mock_set_tag:
+        mock_scope = Mock()
+        with patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope):
             set_tracing_span(
                 project_id="proj",
                 organization_id="org",
@@ -120,4 +133,4 @@ class TestSetTracingSpan:
                 conversation_id="conv-1",
             )
 
-        assert ("conversation_id", "conv-1") in [args.args for args in mock_set_tag.call_args_list]
+        assert ("conversation_id", "conv-1") in [args.args for args in mock_scope.set_tag.call_args_list]

--- a/tests/engine/trace/test_span_context.py
+++ b/tests/engine/trace/test_span_context.py
@@ -129,7 +129,7 @@ class TestSetTracingSpan:
         monkeypatch.setattr(
             span_context,
             "SENTRY_TAG_FIELDS",
-            (*span_context.SENTRY_TAG_FIELDS, "conversation_id"),
+            {**span_context.SENTRY_TAG_FIELDS, "conversation_id": "conversation_id"},
         )
         mock_scope = Mock()
         with patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope):
@@ -142,3 +142,28 @@ class TestSetTracingSpan:
 
         assert ("conversation_id", "conv-1") in [args.args for args in mock_scope.set_tag.call_args_list]
         assert ("conversation_id", "conv-1") in [args.args for args in mock_scope.set_attribute.call_args_list]
+
+    def test_environment_is_remapped_to_env_sentry_key(self):
+        from ada_backend.database.models import EnvType
+
+        mock_scope = Mock()
+        with patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope):
+            set_tracing_span(environment=EnvType.DRAFT)
+
+        tag_keys = {args.args[0] for args in mock_scope.set_tag.call_args_list}
+        attr_keys = {args.args[0] for args in mock_scope.set_attribute.call_args_list}
+        assert "env" in tag_keys
+        assert "env" in attr_keys
+        assert "environment" not in tag_keys
+        assert "environment" not in attr_keys
+
+    def test_environment_removal_uses_env_sentry_key(self):
+        from ada_backend.database.models import EnvType
+
+        mock_scope = Mock()
+        with patch("engine.trace.span_context.sentry_sdk.get_isolation_scope", return_value=mock_scope):
+            set_tracing_span(environment=EnvType.DRAFT)
+            set_tracing_span(environment=None)
+
+        mock_scope.remove_tag.assert_any_call("env")
+        mock_scope.remove_attribute.assert_any_call("env")

--- a/tests/engine/trace/test_span_context.py
+++ b/tests/engine/trace/test_span_context.py
@@ -190,10 +190,11 @@ class TestResetTracingSpan:
         set_tracing_span(run_id="run-new")
 
         params = get_tracing_span()
+        defaults = TracingSpanParams()
         assert params is not None
         assert params.run_id == "run-new"
         assert params.cron_id is None
-        assert params.project_id == ""
+        assert params.project_id == defaults.project_id
 
     def test_reset_removes_all_sentry_tags_and_attributes(self):
         mock_scope = Mock()


### PR DESCRIPTION
## What changed
Fixes Sentry tag propagation by adding `run_id` to the tracing context, preventing `ContextVar` leakage in long-lived workers, and renaming the `environment` tag to `env`.

## Why
Sentry was missing key filters (`run_id`, `project_id`, `org_id`). The root causes were: `run_id` wasn't tracked in the span, worker threads leaked stale context between independent runs, and our `environment` tag shadowed Sentry's native deployment tag.

## Scope / constraints
- Added `reset_tracing_span()` exclusively for top-level worker boundaries.
- Centralized tracing-to-Sentry sync remains in `set_tracing_span`.
- No extra log volume or PII/user-level tagging (`user_id`).

## Validation
Targeted regression suite passed (22 tests):
- `tests/engine/trace/test_span_context.py`
- `tests/ada_backend/workers/test_run_queue_worker.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced tracing and observability infrastructure to improve debugging capabilities. Implemented stricter isolation of execution context between independent runs to prevent information leakage. Refined metric mapping to external monitoring platforms for better visibility. Added automatic context cleanup at execution boundaries to ensure clean state between operations and improve overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->