### PR TITLE
feat(github-actions): Skip CI/CD for frontend-only changes dra-1240

### DIFF
--- a/.github/workflows/.github-ci.yml
+++ b/.github/workflows/.github-ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "frontend/**"
 
 permissions:
   contents: read

--- a/.github/workflows/build-and-deploy-k8s.yml
+++ b/.github/workflows/build-and-deploy-k8s.yml
@@ -3,6 +3,8 @@ name: Build and Deploy to K8s
 on:
   push:
     branches: [staging, main]
+    paths-ignore:
+      - "frontend/**"
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
# Skip CI/CD pipelines for frontend-only changes

## Summary
- Add paths-ignore: `frontend/**` to the K8s build & deploy workflow (`build-and-deploy-k8s.yml`) so pushes to staging/main that only touch frontend files don't trigger unnecessary backend builds and deploys.
- Add the same paths-ignore to the CI pipeline (`.github-ci.yml`) so PRs with frontend-only changes skip the backend test suite.
- Manual workflow_dispatch triggers remain unaffected in both workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD to skip unnecessary workflow runs when changes are limited to frontend-only files.
  * Applied the skip rule to both pull-request and push workflow triggers while preserving existing branch filters and deployment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->