### PR TITLE
feat(traces): Fix trace search with special characters dra-1242

### DIFF
--- a/ada_backend/services/metrics/utils.py
+++ b/ada_backend/services/metrics/utils.py
@@ -92,6 +92,10 @@ def query_trace_duration(
     return df
 
 
+def _escape_ilike(value: str) -> str:
+    return value.replace("!", "!!").replace("%", "!%").replace("_", "!_")
+
+
 def query_root_trace_duration(
     project_id: UUID,
     duration_days: Optional[int] = None,
@@ -138,13 +142,26 @@ def query_root_trace_duration(
         filters += f"\n        AND graph_runner_id = '{graph_runner_id}'"
 
     if search is not None:
-        filters += """
+        escaped = _escape_ilike(search)
+        json_escaped = json.dumps(search, ensure_ascii=True)[1:-1]
+        if json_escaped != search:
+            json_escaped_like = _escape_ilike(json_escaped)
+            filters += """
         AND EXISTS (
             SELECT 1 FROM traces.span_messages m_s
             WHERE m_s.span_id = traces.spans.span_id
-            AND m_s.input_content ILIKE :search
+            AND (m_s.input_content ILIKE :search ESCAPE '!'
+                 OR m_s.input_content ILIKE :search_escaped ESCAPE '!')
         )"""
-        params["search"] = f"%{search}%"
+            params["search_escaped"] = f"%{json_escaped_like}%"
+        else:
+            filters += """
+        AND EXISTS (
+            SELECT 1 FROM traces.span_messages m_s
+            WHERE m_s.span_id = traces.spans.span_id
+            AND m_s.input_content ILIKE :search ESCAPE '!'
+        )"""
+        params["search"] = f"%{escaped}%"
 
     query = f"""
     WITH total AS (

--- a/engine/trace/sql_exporter.py
+++ b/engine/trace/sql_exporter.py
@@ -297,7 +297,11 @@ class SQLSpanExporter(SpanExporter):
         session.add(
             SpanMessage(
                 span_id=span_row.span_id,
-                input_content=sanitize_json_string(json.dumps(input)) if input is not None else None,
-                output_content=sanitize_json_string(json.dumps(output)) if output is not None else None,
+                input_content=sanitize_json_string(json.dumps(input, ensure_ascii=False))
+                if input is not None
+                else None,
+                output_content=sanitize_json_string(json.dumps(output, ensure_ascii=False))
+                if output is not None
+                else None,
             )
         )

--- a/tests/ada_backend/services/metrics/test_trace_search.py
+++ b/tests/ada_backend/services/metrics/test_trace_search.py
@@ -113,6 +113,64 @@ def test_search_traces_by_keyword():
             session.commit()
 
 
+def test_search_traces_with_special_characters():
+    now = datetime.now()
+    project_id = uuid4()
+
+    trace_utf8_id, span_utf8_id = uuid4(), uuid4()
+    trace_escaped_id, span_escaped_id = uuid4(), uuid4()
+    trace_plain_id, span_plain_id = uuid4(), uuid4()
+
+    with get_db_session() as session:
+        span_utf8 = _create_root_span(project_id, trace_utf8_id, span_utf8_id, now - timedelta(hours=1))
+        span_escaped = _create_root_span(project_id, trace_escaped_id, span_escaped_id, now - timedelta(hours=2))
+        span_plain = _create_root_span(project_id, trace_plain_id, span_plain_id, now - timedelta(hours=3))
+        session.add_all([span_utf8, span_escaped, span_plain])
+        session.commit()
+
+        msg_utf8 = _create_span_message(
+            span_utf8_id,
+            json.dumps([{"messages": [{"role": "user", "content": "Bonjour résumé"}]}], ensure_ascii=False),
+        )
+        msg_escaped = _create_span_message(
+            span_escaped_id,
+            json.dumps([{"messages": [{"role": "user", "content": "Bonjour résumé"}]}], ensure_ascii=True),
+        )
+        msg_plain = _create_span_message(
+            span_plain_id,
+            json.dumps([{"messages": [{"role": "user", "content": "Hello world 100% done"}]}]),
+        )
+        session.add_all([msg_utf8, msg_escaped, msg_plain])
+        session.commit()
+
+        all_span_ids = [str(span_utf8_id), str(span_escaped_id), str(span_plain_id)]
+        all_trace_ids = [str(trace_utf8_id), str(trace_escaped_id), str(trace_plain_id)]
+
+        try:
+            rows_accent, _ = query_root_trace_duration(project_id, duration_days=1, search="résumé")
+            assert len(rows_accent) == 2
+            trace_ids = {row["trace_rowid"] for row in rows_accent}
+            assert str(trace_utf8_id) in trace_ids
+            assert str(trace_escaped_id) in trace_ids
+
+            rows_percent, _ = query_root_trace_duration(project_id, duration_days=1, search="100%")
+            assert len(rows_percent) == 1
+            assert rows_percent[0]["trace_rowid"] == str(trace_plain_id)
+
+            rows_bare_percent, _ = query_root_trace_duration(project_id, duration_days=1, search="%")
+            assert len(rows_bare_percent) == 1
+            assert rows_bare_percent[0]["trace_rowid"] == str(trace_plain_id)
+
+        finally:
+            session.query(SpanMessage).filter(
+                SpanMessage.span_id.in_(all_span_ids)
+            ).delete(synchronize_session=False)
+            session.query(Span).filter(
+                Span.trace_rowid.in_(all_trace_ids)
+            ).delete(synchronize_session=False)
+            session.commit()
+
+
 def test_filter_traces_by_date_range():
     now = datetime.now()
     project_id = uuid4()


### PR DESCRIPTION
# Fix trace search with special/accented characters (e.g. é)

## Summary
- Fix empty search results when querying traces with non-ASCII characters (é, ñ, ü, etc.) by storing span message content as native UTF-8 instead of JSON unicode escapes (`\u00e9`)
- Add backward-compatible search that matches both legacy escaped data and new UTF-8 data, plus proper escaping of LIKE metacharacters (`%`, `_`)

## Problem
`json.dumps()` defaults to `ensure_ascii=True`, which stored `"résumé"` as `"r\u00e9sum\u00e9"` in the `span_messages.input_content` column. The `ILIKE '%résumé%'` search looked for the literal UTF-8 character, which never matched the 6-char ASCII escape sequence.