### PR TITLE
feat(Ingestion): add excel option for mistral ingestion

### DIFF
--- a/data_ingestion/document/document_chunking.py
+++ b/data_ingestion/document/document_chunking.py
@@ -96,6 +96,7 @@ def document_chunking_mapping(
         )
         pdf_processor = mistral_ocr_processor
         docx_processor = mistral_ocr_processor
+        excel_processor = mistral_ocr_processor
         LOGGER.info("Using Mistral OCR for PDF and DOCX processing")
 
     else:

--- a/frontend/src/components/knowledge/DataSourceDialogUpload.vue
+++ b/frontend/src/components/knowledge/DataSourceDialogUpload.vue
@@ -35,7 +35,7 @@ const documentReadingModeOptions = [
     value: 'mistral_ocr',
     title: 'Mistral OCR',
     description:
-      'Mistral-powered OCR — delivers high-accuracy text extraction from scanned documents and images within PDF and DOCX files',
+      'Mistral-powered OCR — delivers high-accuracy text extraction from scanned documents and images within PDF, DOCX, and Excel files',
   },
 ]
 
@@ -53,7 +53,7 @@ const toDocumentReadingMode = (value: unknown): DocumentReadingMode => {
 }
 
 const getFileExtensionsByMode = (mode: DocumentReadingMode) => {
-  if (mode === 'llamaparse') return ['.pdf', '.docx', '.xls', '.xlsx', '.xlsm']
+  if (mode === 'llamaparse' || mode === 'mistral_ocr') return ['.pdf', '.docx', '.xls', '.xlsx', '.xlsm']
   return ['.pdf', '.docx']
 }
 
@@ -88,7 +88,7 @@ const close = () => {
 
 const onReadingModeChange = (newMode: DocumentReadingMode) => {
   documentReadingMode.value = newMode
-  if (newMode !== 'llamaparse' && files.value.length > 0) {
+  if (newMode === 'standard' && files.value.length > 0) {
     const allowed = getFileExtensionsByMode(newMode)
 
     const valid = files.value.filter(f => {
@@ -149,7 +149,9 @@ const getFileIcon = (fileName: string) => {
     case 'doc':
     case 'docx':
       return 'tabler-file-type-doc'
+    case 'xls':
     case 'xlsx':
+    case 'xlsm':
       return 'tabler-file-type-xls'
     case 'ppt':
     case 'pptx':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mistral OCR reading mode now supports Excel files (.xls, .xlsx, .xlsm) in addition to PDF and DOCX files, expanding document upload compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->