### PR TITLE
feat(ci): keep required checks green for front PR dra-1248

### DIFF
--- a/.github/workflows/.github-ci.yml
+++ b/.github/workflows/.github-ci.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "frontend/**"
 
 permissions:
   contents: read
@@ -21,6 +19,7 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
+      has-backend-changes: ${{ steps.filter.outputs.backend }}
       migration-or-seed-changed: ${{ steps.filter.outputs.migration-or-seed }}
       mixpanel-changed: ${{ steps.filter.outputs.mixpanel }}
       traces-schema-touched: ${{ steps.traces-schema-check.outputs.traces-schema-touched }}
@@ -37,6 +36,9 @@ jobs:
         id: filter
         with:
           filters: |
+            backend:
+              - '**'
+              - '!frontend/**'
             migration-or-seed:
               - 'ada_backend/database/**'
             mixpanel:
@@ -169,6 +171,7 @@ jobs:
 
   ci-pipeline:
     needs: detect-changes
+    if: needs.detect-changes.outputs.has-backend-changes == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
# Skip CI pipeline for frontend-only PRs while keeping required checks green

## ummary
- Remove paths-ignore from the workflow trigger so the CI workflow always runs on PRs to main, even for frontend-only changes.
- Add a backend change detection filter (`!(frontend/**`)), and gate the heavy ci-pipeline job behind it. When only frontend files changed, the job is skipped — GitHub reports skipped jobs as successful, so required status checks still pass.

## Why
Previously, `paths-ignore: ["frontend/**"] `caused the entire workflow to not trigger for frontend-only PRs. Since ci-pipeline is a required check, those PRs could never be merged because the check simply never reported a status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow to conditionally run backend checks based on code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->