### PR TITLE
feat(Ingestion): fix chunk_size when we combine chunks together DRA-1251

### DIFF
--- a/data_ingestion/markdown/tree_chunker.py
+++ b/data_ingestion/markdown/tree_chunker.py
@@ -104,8 +104,11 @@ class TreeChunker:
             elif self._count_tokens(current_chunk.content) + self._count_tokens(last_chunk.content) > self._chunk_size:
                 first_chunks.append(last_chunk)
             else:
-                current_chunk += last_chunk
-                first_chunks[-1] = current_chunk
+                combined = current_chunk + last_chunk
+                if self._count_tokens(combined.content) > self._chunk_size:
+                    first_chunks += self._split_text(combined)
+                else:
+                    first_chunks[-1] = combined
             return first_chunks
 
     def _fetch_ancestors_to_level(self, ancestors: list[TreeChunk], level: MarkdownLevel) -> list[TreeChunk]:

--- a/data_ingestion/markdown/tree_chunker.py
+++ b/data_ingestion/markdown/tree_chunker.py
@@ -101,12 +101,10 @@ class TreeChunker:
             last_chunk = chunks[-1]
             if self._count_tokens(last_chunk.content) > self._chunk_size:
                 first_chunks += self._split_text(last_chunk)
-            elif self._count_tokens(current_chunk.content) + self._count_tokens(last_chunk.content) > self._chunk_size:
-                first_chunks.append(last_chunk)
             else:
                 combined = current_chunk + last_chunk
                 if self._count_tokens(combined.content) > self._chunk_size:
-                    first_chunks += self._split_text(combined)
+                    first_chunks.append(last_chunk)
                 else:
                     first_chunks[-1] = combined
             return first_chunks

--- a/data_ingestion/markdown/tree_chunker.py
+++ b/data_ingestion/markdown/tree_chunker.py
@@ -102,11 +102,11 @@ class TreeChunker:
             if self._count_tokens(last_chunk.content) > self._chunk_size:
                 first_chunks += self._split_text(last_chunk)
             else:
-                combined = current_chunk + last_chunk
-                if self._count_tokens(combined.content) > self._chunk_size:
+                combined_chunk = current_chunk + last_chunk
+                if self._count_tokens(combined_chunk.content) > self._chunk_size:
                     first_chunks.append(last_chunk)
                 else:
-                    first_chunks[-1] = combined
+                    first_chunks[-1] = combined_chunk
             return first_chunks
 
     def _fetch_ancestors_to_level(self, ancestors: list[TreeChunk], level: MarkdownLevel) -> list[TreeChunk]:

--- a/data_ingestion/markdown/tree_chunker.py
+++ b/data_ingestion/markdown/tree_chunker.py
@@ -67,7 +67,7 @@ class TreeChunker:
     """Class to generate chunks of markdown content.
     Markdown node are combined into chunks of a maximum token size."""
 
-    def __init__(self, model_name: str = "gpt-4o-mini", chunk_size: int = 2048, chunk_overlap: int = 0):
+    def __init__(self, model_name: str = "text-embedding-3-large", chunk_size: int = 2048, chunk_overlap: int = 0):
         self._chunk_size = chunk_size
         self._chunk_overlap = chunk_overlap
         self._encoding = tiktoken.encoding_for_model(model_name)

--- a/tests/data_ingestion/markdown/test_tree_chunker.py
+++ b/tests/data_ingestion/markdown/test_tree_chunker.py
@@ -15,7 +15,7 @@ def mock_encoding():
 
 @pytest.fixture
 def chunker(mock_encoding):
-    chunker = TreeChunker(model_name="gpt-4o-mini", chunk_size=80)
+    chunker = TreeChunker(chunk_size=80)
     chunker._encoding = mock_encoding
     return chunker
 


### PR DESCRIPTION
## SUMMARY
chunk size overflow when tree chunker merges chunks with different ancestors

Problem

When _combine_chunks merges two chunks via __add__, ancestor headers get baked into the resulting .content. The token count check only validates the two chunks' content before merging, but __add__ appends ancestor paths into the combined content — producing chunks that exceed the configured chunk_size. This causes downstream embedding failures

Fix
Re-check the combined chunk's token count after __add__, and re-split it with SentenceSplitter if it exceeds the limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined chunk combination logic to make document chunking more consistent.
* **Behavior**
  * Changed the default embedding model used for token counting, which may alter chunk sizing and tokenization.
* **Tests**
  * Updated test setup to align with the new default embedding model and chunking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->