### PR TITLE
feat(sets):  Validate project ownership in get_set_ids_service dra-1111

### DIFF
--- a/ada_backend/routers/variables_router.py
+++ b/ada_backend/routers/variables_router.py
@@ -28,7 +28,13 @@ from ada_backend.schemas.variable_schemas import (
     VariableSetResponse,
     VariableSetUpsertRequest,
 )
-from ada_backend.services.errors import OAuthSetProtectedError, VariableDefinitionNotFound, VariableSetNotFound
+from ada_backend.services.errors import (
+    OAuthSetProtectedError,
+    ProjectNotFound,
+    ProjectNotInOrganization,
+    VariableDefinitionNotFound,
+    VariableSetNotFound,
+)
 from ada_backend.services.variables_service import (
     delete_definition_service,
     delete_set_service,
@@ -89,9 +95,8 @@ def upsert_org_variable_definition(
 ):
     try:
         return upsert_definition_service(session, organization_id, name, body)
-    except ValueError as e:
-        LOGGER.error(f"Failed to upsert variable definition {name} for org {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    except (ProjectNotFound, ProjectNotInOrganization) as e:
+        raise HTTPException(status_code=404, detail="Project not found") from e
     except IntegrityError as e:
         LOGGER.error(
             f"Integrity error upserting variable definition {name} for org {organization_id}: {str(e)}",
@@ -142,6 +147,8 @@ def get_set_ids(
 ):
     try:
         return get_set_ids_service(session, organization_id, project_id)
+    except (ProjectNotFound, ProjectNotInOrganization) as e:
+        raise HTTPException(status_code=404, detail="Project not found") from e
     except Exception as e:
         LOGGER.error(f"Failed to get set ids for org {organization_id} project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/ada_backend/services/errors.py
+++ b/ada_backend/services/errors.py
@@ -60,6 +60,13 @@ class ProjectNotFound(Exception):
         super().__init__(f"Project not found: {project_id}")
 
 
+class ProjectNotInOrganization(Exception):
+    def __init__(self, project_id: UUID, organization_id: UUID):
+        self.project_id = project_id
+        self.organization_id = organization_id
+        super().__init__(f"Project {project_id} does not belong to organization {organization_id}")
+
+
 class RunNotFound(Exception):
     def __init__(self, run_id: UUID):
         self.run_id = run_id

--- a/ada_backend/services/variables_service.py
+++ b/ada_backend/services/variables_service.py
@@ -32,7 +32,13 @@ from ada_backend.schemas.variable_schemas import (
     VariableSetListResponse,
     VariableSetResponse,
 )
-from ada_backend.services.errors import OAuthSetProtectedError, VariableDefinitionNotFound, VariableSetNotFound
+from ada_backend.services.errors import (
+    OAuthSetProtectedError,
+    ProjectNotFound,
+    ProjectNotInOrganization,
+    VariableDefinitionNotFound,
+    VariableSetNotFound,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,8 +46,10 @@ LOGGER = logging.getLogger(__name__)
 def _validate_project_ids_belong_to_org(session: Session, organization_id: UUID, project_ids: list[UUID]) -> None:
     for project_id in project_ids:
         project = get_project(session, project_id=project_id)
-        if not project or project.organization_id != organization_id:
-            raise ValueError(f"Project {project_id} does not belong to organization {organization_id}")
+        if not project:
+            raise ProjectNotFound(project_id)
+        if project.organization_id != organization_id:
+            raise ProjectNotInOrganization(project_id, organization_id)
 
 
 def definition_to_response(
@@ -163,6 +171,7 @@ def get_set_ids_service(
     organization_id: UUID,
     project_id: UUID,
 ) -> SetIdsResponse:
+    _validate_project_ids_belong_to_org(session, organization_id, [project_id])
     set_ids = list_set_ids_for_project(session, organization_id, project_id)
     return SetIdsResponse(set_ids=set_ids)
 

--- a/tests/ada_backend/test_variables_service.py
+++ b/tests/ada_backend/test_variables_service.py
@@ -8,6 +8,7 @@ import pytest
 from ada_backend.database import models as db
 from ada_backend.database.setup_db import get_db_session
 from ada_backend.schemas.variable_schemas import VariableDefinitionUpsertRequest
+from ada_backend.services.errors import ProjectNotInOrganization
 from ada_backend.services.variables_service import (
     get_set_service,
     list_definitions_service,
@@ -110,7 +111,7 @@ def test_upsert_with_cross_org_project_id_raises():
         session.flush()
 
         body = VariableDefinitionUpsertRequest(type="string", project_ids=[other_pid])
-        with pytest.raises(ValueError, match="does not belong to organization"):
+        with pytest.raises(ProjectNotInOrganization, match="does not belong to organization"):
             upsert_definition_service(session, org_id, "test_var", body)
 
 


### PR DESCRIPTION
# Validate project ownership in `get_set_ids_service`

## Summary
- Adds a project existence and ownership check before listing variable set IDs, rejecting requests with a nonexistent or cross-organization `project_id` as a 404.
- Previously, `list_set_ids_for_project` would silently return org-global set IDs for any UUID — including unrelated or fabricated project IDs — hiding invalid input from callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened project validation and ownership checks when accessing or updating variables. Requests for non-existent or mismatched projects now return clearer HTTP 404 responses instead of generic errors, improving feedback when retrieving set IDs or upserting organization-scoped variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->