### PR TITLE
feat(graph): fix graph api v2 dra-1262

### DIFF
--- a/ada_backend/services/graph/component_instance_v2_service.py
+++ b/ada_backend/services/graph/component_instance_v2_service.py
@@ -89,16 +89,17 @@ def update_single_component(
     if not existing:
         raise ValueError(f"Component instance {instance_id} not found")
 
-    node_ids = {node.id for node in get_component_nodes(session, graph_runner_id)}
-    if instance_id not in node_ids:
+    nodes = get_component_nodes(session, graph_runner_id)
+    current_node = next((n for n in nodes if n.id == instance_id), None)
+    if current_node is None:
         raise ValueError(f"Component instance {instance_id} does not belong to graph {graph_runner_id}")
 
     label = payload.label if payload.label is not None else existing.name
-    is_start_node = payload.is_start_node if payload.is_start_node is not None else existing.is_start_node
+    is_start_node = payload.is_start_node if payload.is_start_node is not None else current_node.is_start_node
 
     instance_schema = _to_component_instance_schema(
         instance_id=instance_id,
-        component_id=existing.component_id,
+        component_id=existing.component_version.component_id,
         component_version_id=existing.component_version_id,
         label=label,
         is_start_node=is_start_node,

--- a/tests/ada_backend/services/graph/test_component_instance_v2_service.py
+++ b/tests/ada_backend/services/graph/test_component_instance_v2_service.py
@@ -68,13 +68,13 @@ class TestUpdateSingleComponent:
     ):
         mock_instance = MagicMock()
         mock_instance.name = "Old Name"
-        mock_instance.is_start_node = False
-        mock_instance.component_id = ids["component_id"]
         mock_instance.component_version_id = ids["component_version_id"]
+        mock_instance.component_version.component_id = ids["component_id"]
         mock_get_inst.return_value = mock_instance
 
         node = MagicMock()
         node.id = ids["instance_id"]
+        node.is_start_node = False
         mock_get_nodes.return_value = [node]
 
         payload = ComponentUpdateV2Schema(


### PR DESCRIPTION
#  Fix `AttributeError: 'ComponentInstance' object has no attribute 'is_start_node`' in component update v2

# Summary
Fixes a crash in `update_single_component` where `is_start_node` and `component_id` were read from the SQLAlchemy `ComponentInstance` model, which doesn't have those attributes. `is_start_node` lives on `GraphRunnerNode`, and `component_id` lives on `ComponentVersion`.
- Now reads `is_start_node` from the `ComponentNodeDTO` (which joins `GraphRunnerNod`e) and `component_id` via `existing.component_version.component_id`.
## What went wrong
In `ada_backend/services/graph/component_instance_v2_service.py`, the `update_single_component` function falls back to `existing.is_start_node` when the payload doesn't explicitly set it. But existing is a `ComponentInstance` ORM object, and `is_start_node` is a column on the `graph_runner_nodes` table (`GraphRunnerNode` model), not on `component_instances`.

The same issue existed for `existing.component_id` (next line), which would have surfaced as the next `AttributeError` once the first was fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved component instance update logic in graph operations to ensure correct start-node determination and reliable component version handling during updates, reducing inconsistencies and improving overall stability of instance updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->