### PR TITLE
fix(graph): persist discarded tool inputs with explicit deactivated setup mode DRA-1194

### DIFF
--- a/frontend/src/components/studio/components/PortConfigurationEditor.vue
+++ b/frontend/src/components/studio/components/PortConfigurationEditor.vue
@@ -98,6 +98,14 @@ function getPortConfig(parameterId: string | null, portName: string, isCustom: b
   return undefined
 }
 
+function getResolvedSetupMode(
+  parameterId: string | null,
+  portName: string,
+  isCustom: boolean
+): 'user_set' | 'ai_filled' | 'deactivated' {
+  return getPortConfig(parameterId, portName, isCustom)?.setup_mode || 'ai_filled'
+}
+
 // Create a new configuration for a port
 function createConfig(
   parameterId: string | null,
@@ -404,20 +412,14 @@ function cancelEditing() {
               </div>
 
               <VChip
-                :color="
-                  getConfigTypeColor(
-                    getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'ai_filled'
-                  )
-                "
+                :color="getConfigTypeColor(getResolvedSetupMode(port.parameter_id, port.name, port.is_custom))"
                 size="x-small"
                 variant="tonal"
               >
                 {{
-                  (getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'ai_filled') ===
-                  'ai_filled'
+                  getResolvedSetupMode(port.parameter_id, port.name, port.is_custom) === 'ai_filled'
                     ? 'AI'
-                    : (getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'ai_filled') ===
-                        'user_set'
+                    : getResolvedSetupMode(port.parameter_id, port.name, port.is_custom) === 'user_set'
                       ? 'Set value'
                       : 'Discard'
                 }}
@@ -485,7 +487,7 @@ function cancelEditing() {
 
               <!-- Configuration Type Selector -->
               <VRadioGroup
-                :model-value="getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'ai_filled'"
+                :model-value="getResolvedSetupMode(port.parameter_id, port.name, port.is_custom)"
                 :disabled="readonly"
                 @update:model-value="
                   (val: any) => updateConfigType(port.parameter_id, port.name, val, port.nullable, port.is_custom)
@@ -518,7 +520,7 @@ function cancelEditing() {
 
               <!-- AI Filled Configuration -->
               <div
-                v-if="getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode === 'ai_filled'"
+                v-if="getResolvedSetupMode(port.parameter_id, port.name, port.is_custom) === 'ai_filled'"
                 class="mt-4"
               >
                 <!-- Required Toggle -->
@@ -573,7 +575,7 @@ function cancelEditing() {
 
               <!-- User Set Configuration -->
               <div
-                v-if="getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode === 'user_set'"
+                v-if="getResolvedSetupMode(port.parameter_id, port.name, port.is_custom) === 'user_set'"
                 class="mt-4"
               >
                 <div class="text-subtitle-2 mb-2">Value</div>

--- a/frontend/src/components/studio/components/PortConfigurationEditor.vue
+++ b/frontend/src/components/studio/components/PortConfigurationEditor.vue
@@ -50,7 +50,7 @@ const parameterTypes = [
 ]
 
 // Get all ports - Only show parameters with kind="input" and is_tool_input=true
-// If a parameter has no port configuration, it's "Discard" by default (user can activate it)
+// Backend read APIs synthesize missing tool-input configs as ai_filled defaults.
 const allPorts = computed(() => {
   // Filter parameters to only show those with kind="input" and is_tool_input=true
   const inputParameters = props.parameters.filter(param => param.kind === 'input' && param.is_tool_input === true)
@@ -87,7 +87,6 @@ const allPorts = computed(() => {
 })
 
 // Get configuration for a port (by parameter_id or by name for custom ports)
-// Returns undefined if no configuration exists (meaning "Discard")
 function getPortConfig(parameterId: string | null, portName: string, isCustom: boolean): PortConfiguration | undefined {
   if (isCustom) {
     // Custom port - identified by ai_name_override (backend does not use custom_port_name)
@@ -99,14 +98,18 @@ function getPortConfig(parameterId: string | null, portName: string, isCustom: b
   return undefined
 }
 
-// Create a new configuration for a port when activating it
-function createConfig(parameterId: string | null, portName: string, isCustom: boolean): PortConfiguration {
-  // Create new config when user activates a previously unused port
+// Create a new configuration for a port
+function createConfig(
+  parameterId: string | null,
+  portName: string,
+  isCustom: boolean,
+  setupMode: 'user_set' | 'ai_filled' | 'deactivated' = 'ai_filled'
+): PortConfiguration {
   const newConfig: PortConfiguration = {
     component_instance_id: props.componentInstanceId,
     parameter_id: parameterId,
     input_port_instance_id: null,
-    setup_mode: 'ai_filled', // Default to AI fills when activating
+    setup_mode: setupMode,
     field_expression_id: null,
     expression_json: null,
     ai_name_override: isCustom ? portName : null,
@@ -137,20 +140,23 @@ function updateConfigType(
   const existingConfig = getPortConfig(parameterId, portName, isCustom)
 
   if (type === 'deactivated') {
-    // Remove configuration if it exists - port becomes "Discard"
     if (existingConfig) {
-      const newConfigs = localConfigs.value.filter(c =>
-        isCustom ? !(c.ai_name_override === portName && c.parameter_id === null) : c.parameter_id !== parameterId
-      )
+      const updatedConfig: PortConfiguration = { ...existingConfig, setup_mode: 'deactivated' }
+      const newConfigs = localConfigs.value.map(c => {
+        const matches = isCustom ? c.ai_name_override === portName && c.parameter_id === null : c.parameter_id === parameterId
+
+        return matches ? updatedConfig : c
+      })
 
       emit('update:port-configurations', newConfigs)
+    } else {
+      createConfig(parameterId, portName, isCustom, 'deactivated')
     }
-    // If no config exists, port is already "Discard"
   } else {
     // Create or update configuration
     if (existingConfig) {
       // Update existing config
-      const updatedConfig = { ...existingConfig }
+      const updatedConfig: PortConfiguration = { ...existingConfig }
 
       updatedConfig.setup_mode = type
 
@@ -172,7 +178,7 @@ function updateConfigType(
       emit('update:port-configurations', newConfigs)
     } else {
       // Create new config
-      createConfig(parameterId, portName, isCustom)
+      createConfig(parameterId, portName, isCustom, type)
     }
   }
 }
@@ -400,17 +406,17 @@ function cancelEditing() {
               <VChip
                 :color="
                   getConfigTypeColor(
-                    getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'deactivated'
+                    getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'ai_filled'
                   )
                 "
                 size="x-small"
                 variant="tonal"
               >
                 {{
-                  (getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'deactivated') ===
+                  (getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'ai_filled') ===
                   'ai_filled'
                     ? 'AI'
-                    : (getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'deactivated') ===
+                    : (getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'ai_filled') ===
                         'user_set'
                       ? 'Set value'
                       : 'Discard'
@@ -479,7 +485,7 @@ function cancelEditing() {
 
               <!-- Configuration Type Selector -->
               <VRadioGroup
-                :model-value="getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'deactivated'"
+                :model-value="getPortConfig(port.parameter_id, port.name, port.is_custom)?.setup_mode || 'ai_filled'"
                 :disabled="readonly"
                 @update:model-value="
                   (val: any) => updateConfigType(port.parameter_id, port.name, val, port.nullable, port.is_custom)

--- a/frontend/src/components/studio/utils/__tests__/graphTransformer.spec.ts
+++ b/frontend/src/components/studio/utils/__tests__/graphTransformer.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Edge } from '../../types/edge.types'
+import type { PortConfiguration } from '../../types/graph.types'
+import type { Node } from '../../types/node.types'
+import { graphTransformer } from '../graphTransformer'
+
+interface TestNode extends Node {
+  data: Node['data'] & {
+    port_configurations?: PortConfiguration[]
+  }
+}
+
+function createNode(portConfigurations?: PortConfiguration[]): TestNode {
+  return {
+    id: 'node-1',
+    type: 'component',
+    data: {
+      ref: 'Test',
+      name: 'Test',
+      component_id: 'component-1',
+      component_version_id: 'component-version-1',
+      is_agent: false,
+      parameters: [
+        {
+          name: 'messages',
+          value: null,
+          display_order: null,
+          type: 'array',
+          nullable: true,
+          default: null,
+          ui_component: null,
+          ui_component_properties: null,
+          is_advanced: false,
+          parameter_group_id: null,
+          parameter_order_within_group: null,
+          parameter_group_name: null,
+          kind: 'input',
+          is_tool_input: true,
+        },
+      ],
+      tool_description: null,
+      inputs: [],
+      outputs: [],
+      can_use_function_calling: false,
+      function_callable: false,
+      tools: [],
+      subcomponents_info: [],
+      component_name: 'Test',
+      component_description: '',
+      is_start_node: true,
+      port_configurations: portConfigurations,
+    },
+    position: { x: 0, y: 0 },
+  }
+}
+
+describe('graphTransformer.fromFlow', () => {
+  it('keeps empty port_configurations arrays in the API payload', () => {
+    const result = graphTransformer.fromFlow({
+      nodes: [createNode([])],
+      edges: [] as Edge[],
+    })
+
+    expect(result.component_instances[0]).toHaveProperty('port_configurations')
+    expect(result.component_instances[0].port_configurations).toEqual([])
+  })
+
+  it('keeps non-empty user_set and ai_filled port_configurations arrays in the API payload', () => {
+    const portConfigurations: PortConfiguration[] = [
+      {
+        component_instance_id: 'node-1',
+        parameter_id: 'parameter-1',
+        input_port_instance_id: null,
+        setup_mode: 'user_set',
+        expression_json: { type: 'literal', value: 'preset' },
+        ai_name_override: null,
+        ai_description_override: null,
+        is_required_override: null,
+        custom_parameter_type: null,
+        custom_ui_component_properties: null,
+        json_schema_override: null,
+      },
+      {
+        component_instance_id: 'node-1',
+        parameter_id: 'parameter-2',
+        input_port_instance_id: null,
+        setup_mode: 'ai_filled',
+        expression_json: null,
+        ai_name_override: null,
+        ai_description_override: null,
+        is_required_override: null,
+        custom_parameter_type: null,
+        custom_ui_component_properties: null,
+        json_schema_override: null,
+      },
+    ]
+
+    const result = graphTransformer.fromFlow({
+      nodes: [createNode(portConfigurations)],
+      edges: [] as Edge[],
+    })
+
+    expect(result.component_instances[0].port_configurations).toEqual(portConfigurations)
+  })
+})

--- a/frontend/src/components/studio/utils/__tests__/graphTransformer.spec.ts
+++ b/frontend/src/components/studio/utils/__tests__/graphTransformer.spec.ts
@@ -56,6 +56,16 @@ function createNode(portConfigurations?: PortConfiguration[]): TestNode {
 }
 
 describe('graphTransformer.fromFlow', () => {
+  it('preserves empty port_configurations array in the API payload', () => {
+    const result = graphTransformer.fromFlow({
+      nodes: [createNode([])],
+      edges: [] as Edge[],
+    })
+
+    expect(result.component_instances[0]).toHaveProperty('port_configurations')
+    expect(result.component_instances[0].port_configurations).toEqual([])
+  })
+
   it('keeps explicit deactivated port_configurations in the API payload', () => {
     const portConfigurations: PortConfiguration[] = [
       {

--- a/frontend/src/components/studio/utils/__tests__/graphTransformer.spec.ts
+++ b/frontend/src/components/studio/utils/__tests__/graphTransformer.spec.ts
@@ -56,14 +56,30 @@ function createNode(portConfigurations?: PortConfiguration[]): TestNode {
 }
 
 describe('graphTransformer.fromFlow', () => {
-  it('keeps empty port_configurations arrays in the API payload', () => {
+  it('keeps explicit deactivated port_configurations in the API payload', () => {
+    const portConfigurations: PortConfiguration[] = [
+      {
+        component_instance_id: 'node-1',
+        parameter_id: 'parameter-1',
+        input_port_instance_id: null,
+        setup_mode: 'deactivated',
+        expression_json: null,
+        ai_name_override: null,
+        ai_description_override: null,
+        is_required_override: null,
+        custom_parameter_type: null,
+        custom_ui_component_properties: null,
+        json_schema_override: null,
+      },
+    ]
+
     const result = graphTransformer.fromFlow({
-      nodes: [createNode([])],
+      nodes: [createNode(portConfigurations)],
       edges: [] as Edge[],
     })
 
     expect(result.component_instances[0]).toHaveProperty('port_configurations')
-    expect(result.component_instances[0].port_configurations).toEqual([])
+    expect(result.component_instances[0].port_configurations).toEqual(portConfigurations)
   })
 
   it('keeps non-empty user_set and ai_filled port_configurations arrays in the API payload', () => {

--- a/frontend/src/components/studio/utils/graphTransformer.ts
+++ b/frontend/src/components/studio/utils/graphTransformer.ts
@@ -483,10 +483,9 @@ export const graphTransformer: GraphTransformerType = {
             (nodeData as any).field_expressions.length > 0 && {
               field_expressions: (nodeData as any).field_expressions,
             }),
-          // Include port_configurations only if they exist AND are not empty
+          // Include port_configurations even when empty so "discard all" persists
           ...((nodeData as any).port_configurations &&
-            Array.isArray((nodeData as any).port_configurations) &&
-            (nodeData as any).port_configurations.length > 0 && {
+            Array.isArray((nodeData as any).port_configurations) && {
               port_configurations: (nodeData as any).port_configurations,
             }),
           // Only include position if it was originally set by the user


### PR DESCRIPTION
## What changed

This fixes DRA-1194, where discarding a tool input in Studio did not survive a save + reload cycle.

The frontend now persists discarded tool inputs as an explicit `setup_mode: "deactivated"` port configuration. It also keeps `port_configurations` in the graph save payload even when the array is empty, so discard-related updates are not dropped by the serializer.

## Why this solution

The backend treats missing tool-input configs as `ai_filled` on read, so removing the row is not enough to make discard survive a reload. Persisting an explicit `deactivated` setup mode matches that behavior and keeps the discarded state stable.

## Validation

- `pnpm exec vitest run src/components/studio/utils/__tests__/graphTransformer.spec.ts`
- manual browser validation in local Studio against the QA fixture:
  - discard a tool input
  - save changes
  - fully reload the page
  - confirm the discarded state remains
- `pnpm typecheck` still reports pre-existing errors in `src/pages/org/[orgId]/runs.vue`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Port configurations now default to AI-filled mode when missing.
  * Empty port-configuration arrays are preserved during serialization instead of being omitted.
  * Transitions between setup modes correctly update existing entries or create new ones, and selected types are honored on creation.

* **Tests**
  * Added tests validating port-configuration handling and serialization in graph transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->