### PR TITLE
feat(runs): Fix trace preview drawer width on Runs page dra-1260

### DIFF
--- a/frontend/src/components/observability/TracePreviewDrawer.vue
+++ b/frontend/src/components/observability/TracePreviewDrawer.vue
@@ -56,6 +56,7 @@ const onSpanClick = (span: Span) => {
     v-model="drawerOpen"
     location="end"
     temporary
+    width="1200"
     class="trace-preview-nav-drawer"
   >
     <div class="trace-drawer">
@@ -101,8 +102,9 @@ const onSpanClick = (span: Span) => {
 </template>
 
 <style lang="scss" scoped>
-:deep(.trace-preview-nav-drawer) {
-  inline-size: min(90vw, 1200px) !important;
+.trace-preview-nav-drawer {
+  width: min(90vw, 1200px) !important;
+  max-width: 1200px !important;
 }
 
 .trace-drawer {


### PR DESCRIPTION
# Fix trace preview drawer width on Runs page

## Summary
- Fixed the trace preview drawer opening at Vuetify's default 256px width instead of the intended 1200px, making trace details unreadable
- Added explicit width="1200" prop to VNavigationDrawer and fixed the CSS override from inline-size (logical property) to width so it properly overrides Vuetify's inline style