### PR TITLE
feat(qa): move datasets and LLM judges to org-level scope DRA-952

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,8 @@ custom_models.json
 
 # oauth
 
+# vite cache
+frontend/.vite/
+
 # test reports
 tests/external_api_calls/external_api_calls_matrix.md

--- a/ada_backend/admin/admin.py
+++ b/ada_backend/admin/admin.py
@@ -593,6 +593,7 @@ class LLMJudgeAdmin(EnhancedModelView, model=db.LLMJudge):
     column_list = [
         "id",
         "project_id",
+        "organization_id",
         "name",
         "description",
         "evaluation_type",

--- a/ada_backend/database/alembic/versions/i8j9k0l1m2n3_qa_org_scoping_migration.py
+++ b/ada_backend/database/alembic/versions/i8j9k0l1m2n3_qa_org_scoping_migration.py
@@ -1,0 +1,276 @@
+"""Move QA datasets and LLM judges from project-scoped to organization-scoped.
+
+Adds organization_id to dataset_project and llm_judges, creates association
+tables for the many-to-many project mapping, backfills all data, and makes
+project_id nullable (to be dropped in a follow-up migration).
+
+Revision ID: i8j9k0l1m2n3
+Revises: j1k2l3m4n5o6
+Create Date: 2026-04-21
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "i8j9k0l1m2n3"
+down_revision: Union[str, None] = "j1k2l3m4n5o6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy = "migrate-first"
+
+
+def upgrade() -> None:
+    # --- 1. Add organization_id (nullable for now) ---
+    op.add_column(
+        "dataset_project",
+        sa.Column("organization_id", sa.UUID(), nullable=True),
+        schema="quality_assurance",
+    )
+    op.add_column(
+        "llm_judges",
+        sa.Column("organization_id", sa.UUID(), nullable=True),
+        schema="quality_assurance",
+    )
+
+    # --- 2. Backfill organization_id from projects.organization_id ---
+    op.execute(
+        """
+        UPDATE quality_assurance.dataset_project dp
+        SET organization_id = p.organization_id
+        FROM projects p
+        WHERE dp.project_id = p.id
+        """
+    )
+    op.execute(
+        """
+        UPDATE quality_assurance.llm_judges lj
+        SET organization_id = p.organization_id
+        FROM projects p
+        WHERE lj.project_id = p.id
+        """
+    )
+
+    # --- 3. Make organization_id non-nullable and add index ---
+    op.alter_column(
+        "dataset_project",
+        "organization_id",
+        nullable=False,
+        schema="quality_assurance",
+    )
+    op.alter_column(
+        "llm_judges",
+        "organization_id",
+        nullable=False,
+        schema="quality_assurance",
+    )
+    op.create_index(
+        op.f("ix_quality_assurance_dataset_project_organization_id"),
+        "dataset_project",
+        ["organization_id"],
+        schema="quality_assurance",
+    )
+    op.create_index(
+        op.f("ix_quality_assurance_llm_judges_organization_id"),
+        "llm_judges",
+        ["organization_id"],
+        schema="quality_assurance",
+    )
+
+    # --- 4. Create association tables ---
+    op.create_table(
+        "dataset_project_associations",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column(
+            "dataset_id",
+            sa.UUID(),
+            sa.ForeignKey("quality_assurance.dataset_project.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "project_id",
+            sa.UUID(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.UniqueConstraint("dataset_id", "project_id", name="uq_dataset_project_association"),
+        schema="quality_assurance",
+    )
+    op.create_table(
+        "llm_judge_project_associations",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column(
+            "judge_id",
+            sa.UUID(),
+            sa.ForeignKey("quality_assurance.llm_judges.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "project_id",
+            sa.UUID(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.UniqueConstraint("judge_id", "project_id", name="uq_llm_judge_project_association"),
+        schema="quality_assurance",
+    )
+
+    # --- 5. Backfill association tables from existing project_id ---
+    op.execute(
+        """
+        INSERT INTO quality_assurance.dataset_project_associations (dataset_id, project_id)
+        SELECT id, project_id
+        FROM quality_assurance.dataset_project
+        WHERE project_id IS NOT NULL
+        ON CONFLICT DO NOTHING
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO quality_assurance.llm_judge_project_associations (judge_id, project_id)
+        SELECT id, project_id
+        FROM quality_assurance.llm_judges
+        WHERE project_id IS NOT NULL
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+    # --- 6. Make project_id nullable and fix FK to SET NULL ---
+    op.alter_column(
+        "dataset_project",
+        "project_id",
+        nullable=True,
+        schema="quality_assurance",
+    )
+    op.alter_column(
+        "llm_judges",
+        "project_id",
+        nullable=True,
+        schema="quality_assurance",
+    )
+
+    op.drop_constraint(
+        "dataset_project_project_id_fkey",
+        "dataset_project",
+        schema="quality_assurance",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "dataset_project_project_id_fkey",
+        "dataset_project",
+        "projects",
+        ["project_id"],
+        ["id"],
+        source_schema="quality_assurance",
+        ondelete="SET NULL",
+    )
+
+    op.drop_constraint(
+        "llm_judges_project_id_fkey",
+        "llm_judges",
+        schema="quality_assurance",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "llm_judges_project_id_fkey",
+        "llm_judges",
+        "projects",
+        ["project_id"],
+        ["id"],
+        source_schema="quality_assurance",
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    # Backfill project_id from association tables for rows that were set to NULL
+    op.execute(
+        """
+        UPDATE quality_assurance.dataset_project dp
+        SET project_id = dpa.project_id
+        FROM quality_assurance.dataset_project_associations dpa
+        WHERE dp.id = dpa.dataset_id
+          AND dp.project_id IS NULL
+        """
+    )
+    op.execute(
+        """
+        UPDATE quality_assurance.llm_judges lj
+        SET project_id = ljpa.project_id
+        FROM quality_assurance.llm_judge_project_associations ljpa
+        WHERE lj.id = ljpa.judge_id
+          AND lj.project_id IS NULL
+        """
+    )
+
+    # Remove any rows that still lack a project_id (created after migration, no association)
+    op.execute("DELETE FROM quality_assurance.dataset_project WHERE project_id IS NULL")
+    op.execute("DELETE FROM quality_assurance.llm_judges WHERE project_id IS NULL")
+
+    op.drop_constraint(
+        "llm_judges_project_id_fkey",
+        "llm_judges",
+        schema="quality_assurance",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "llm_judges_project_id_fkey",
+        "llm_judges",
+        "projects",
+        ["project_id"],
+        ["id"],
+        source_schema="quality_assurance",
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint(
+        "dataset_project_project_id_fkey",
+        "dataset_project",
+        schema="quality_assurance",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "dataset_project_project_id_fkey",
+        "dataset_project",
+        "projects",
+        ["project_id"],
+        ["id"],
+        source_schema="quality_assurance",
+        ondelete="CASCADE",
+    )
+
+    op.alter_column(
+        "llm_judges",
+        "project_id",
+        nullable=False,
+        schema="quality_assurance",
+    )
+    op.alter_column(
+        "dataset_project",
+        "project_id",
+        nullable=False,
+        schema="quality_assurance",
+    )
+
+    op.drop_table("llm_judge_project_associations", schema="quality_assurance")
+    op.drop_table("dataset_project_associations", schema="quality_assurance")
+
+    op.drop_index(
+        op.f("ix_quality_assurance_llm_judges_organization_id"),
+        table_name="llm_judges",
+        schema="quality_assurance",
+    )
+    op.drop_index(
+        op.f("ix_quality_assurance_dataset_project_organization_id"),
+        table_name="dataset_project",
+        schema="quality_assurance",
+    )
+
+    op.drop_column("llm_judges", "organization_id", schema="quality_assurance")
+    op.drop_column("dataset_project", "organization_id", schema="quality_assurance")

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -1858,8 +1858,9 @@ class DatasetProject(Base):
 
     id = mapped_column(UUID(as_uuid=True), primary_key=True, index=True, server_default=func.gen_random_uuid())
     project_id = mapped_column(
-        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True, index=True
     )
+    organization_id = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     dataset_name = mapped_column(String, nullable=False)
     created_at = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
@@ -1868,9 +1869,34 @@ class DatasetProject(Base):
     project = relationship("Project", back_populates="datasets")
     input_groundtruths = relationship("InputGroundtruth", back_populates="dataset", cascade="all, delete-orphan")
     qa_metadata = relationship("QADatasetMetadata", back_populates="dataset", cascade="all, delete-orphan")
+    project_associations = relationship(
+        "DatasetProjectAssociation", cascade="all, delete-orphan", lazy="selectin"
+    )
 
     def __str__(self):
         return f"DatasetProject(id={self.id}, name={self.dataset_name})"
+
+
+class DatasetProjectAssociation(Base):
+    __tablename__ = "dataset_project_associations"
+    __table_args__ = (
+        sa.UniqueConstraint("dataset_id", "project_id", name="uq_dataset_project_association"),
+        {"schema": "quality_assurance"},
+    )
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    dataset_id = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("quality_assurance.dataset_project.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    project_id = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
 
 
 class QADatasetMetadata(Base):
@@ -1972,10 +1998,11 @@ class LLMJudge(Base):
     id = mapped_column(UUID(as_uuid=True), primary_key=True, index=True, server_default=func.gen_random_uuid())
     project_id = mapped_column(
         UUID(as_uuid=True),
-        ForeignKey("projects.id", ondelete="CASCADE"),
-        nullable=False,
+        ForeignKey("projects.id", ondelete="SET NULL"),
+        nullable=True,
         index=True,
     )
+    organization_id = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     name = mapped_column(String, nullable=False)
     description = mapped_column(Text, nullable=True)
     evaluation_type = mapped_column(make_pg_enum(EvaluationType), nullable=False)
@@ -1987,9 +2014,34 @@ class LLMJudge(Base):
 
     project = relationship("Project")
     evaluations = relationship("JudgeEvaluation", back_populates="judge", cascade="all, delete-orphan")
+    project_associations = relationship(
+        "LLMJudgeProjectAssociation", cascade="all, delete-orphan", lazy="selectin"
+    )
 
     def __str__(self):
         return f"LLMJudge(id={self.id}, name={self.name}, evaluation_type={self.evaluation_type})"
+
+
+class LLMJudgeProjectAssociation(Base):
+    __tablename__ = "llm_judge_project_associations"
+    __table_args__ = (
+        sa.UniqueConstraint("judge_id", "project_id", name="uq_llm_judge_project_association"),
+        {"schema": "quality_assurance"},
+    )
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    judge_id = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("quality_assurance.llm_judges.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    project_id = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
 
 
 class JudgeEvaluation(Base):

--- a/ada_backend/docs/api-reference.md
+++ b/ada_backend/docs/api-reference.md
@@ -152,7 +152,7 @@ Run input data is persisted in the `run_inputs` table (keyed by `retry_group_id`
 | GET | `.../qa/sessions/{qa_session_id}` | JWT(Member) | Get QA session |
 | WS | `/ws/qa/{project_id}/{session_id}` | JWT(Member) | Stream QA session events |
 | POST | `.../entries/from-history` | JWT(Developer) | Trace → QA entry |
-| GET | `.../datasets/{dataset_id}/export` | JWT(Member) | Export CSV |
+| POST | `.../datasets/{dataset_id}/export` | JWT(Member) | Export CSV |
 | POST | `.../datasets/{dataset_id}/import` | JWT(Developer) | Import CSV |
 
 ## QA Judges (`llm_judges_router.py`, `qa_evaluation_router.py`)

--- a/ada_backend/docs/qa-system.md
+++ b/ada_backend/docs/qa-system.md
@@ -2,13 +2,28 @@
 
 The QA system enables testing workflows against datasets of input/groundtruth pairs, with LLM-based evaluation judges.
 
+## Scoping
+
+- **Datasets** and **LLM Judges** are **organization-scoped** — shared across all projects in an org.
+- **QA Test Runs** (sessions) remain **project-scoped** — they test specific project versions.
+- **Association tables** track which datasets/judges are used in which projects.
+
 ## Datasets
 
-Datasets belong to a project and contain input/groundtruth entries. Each dataset can have custom metadata columns.
+Datasets belong to an organization and contain input/groundtruth entries. Each dataset can have custom metadata columns. Datasets can be associated with multiple projects via the `dataset_project_associations` table.
 
-- **`DatasetProject`** (`quality_assurance.dataset_project`): `project_id`, `name`
+- **`DatasetProject`** (`quality_assurance.dataset_project`): `organization_id`, `name`
+- **`DatasetProjectAssociation`** (`quality_assurance.dataset_project_associations`): `dataset_id`, `project_id` (many-to-many)
 - **`InputGroundtruth`** (`quality_assurance.input_groundtruth`): `dataset_id`, `input_data`, `groundtruth`, `position`, custom column values
 - **`QADatasetMetadata`** (`quality_assurance.qa_dataset_metadata`): custom column definitions per dataset
+
+### CRUD Endpoints (Organization-scoped)
+
+- `GET /organizations/{organization_id}/qa/datasets` — list datasets
+- `POST /organizations/{organization_id}/qa/datasets` — create datasets
+- `PATCH /organizations/{organization_id}/qa/datasets/{dataset_id}` — rename
+- `DELETE /organizations/{organization_id}/qa/datasets` — delete datasets
+- `PUT /organizations/{organization_id}/qa/datasets/{dataset_id}/projects` — set project associations
 
 ## QA Run Process
 
@@ -16,7 +31,7 @@ Datasets belong to a project and contain input/groundtruth entries. Each dataset
 
 `POST /projects/{project_id}/qa/datasets/{dataset_id}/run`
 
-1. Verify dataset belongs to the project and graph runner is bound to the same project
+1. Verify dataset is associated with the project and graph runner is bound to the same project
 2. Select specific entries or all entries in the dataset
 3. Execute the project's graph version against each entry's input
 4. Store results as `VersionOutput` records (keyed by input + graph_runner_id, no session)
@@ -55,7 +70,17 @@ Fully decoupled from the `runs` table. Uses a dedicated `QASession` model in the
 
 **Table**: `quality_assurance.llm_judges`
 
-Fields: `project_id`, `name`, `description`, `evaluation_type`, `llm_model_reference` (default `openai:gpt-5-mini`), `prompt_template`, `temperature`.
+Fields: `organization_id`, `name`, `description`, `evaluation_type`, `llm_model_reference` (default `openai:gpt-5-mini`), `prompt_template`, `temperature`.
+
+Judges can be associated with multiple projects via the `llm_judge_project_associations` table (`judge_id`, `project_id`).
+
+### CRUD Endpoints (Organization-scoped)
+
+- `GET /organizations/{organization_id}/qa/llm-judges` — list judges
+- `POST /organizations/{organization_id}/qa/llm-judges` — create judge
+- `PATCH /organizations/{organization_id}/qa/llm-judges/{judge_id}` — update
+- `DELETE /organizations/{organization_id}/qa/llm-judges` — delete judges
+- `PUT /organizations/{organization_id}/qa/llm-judges/{judge_id}/projects` — set project associations
 
 ### Evaluation Types
 
@@ -76,14 +101,14 @@ The `json_equality` type uses deterministic comparison via `run_deterministic_ev
 
 Evaluates a judge against version outputs, storing results as `JudgeEvaluation` records.
 
-## Import/Export
+## Import/Export (Organization-scoped)
 
-- **Export**: `GET .../datasets/{dataset_id}/export?graph_runner_id=...` → CSV
-- **Import**: `POST .../datasets/{dataset_id}/import` → CSV upload
+- **Export**: `POST /organizations/{organization_id}/qa/datasets/{dataset_id}/export?graph_runner_id=...` → CSV
+- **Import**: `POST /organizations/{organization_id}/qa/datasets/{dataset_id}/import` → CSV upload
 
 ## From Trace to QA
 
-`POST .../datasets/{dataset_id}/entries/from-history` — converts a trace execution into a QA dataset entry (capturing input and actual output as groundtruth).
+`POST /organizations/{organization_id}/qa/datasets/{dataset_id}/entries/from-history` — converts a trace execution into a QA dataset entry (capturing input and actual output as groundtruth).
 
 ## Key Files
 

--- a/ada_backend/repositories/llm_judges_repository.py
+++ b/ada_backend/repositories/llm_judges_repository.py
@@ -3,14 +3,20 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import EvaluationType, LLMJudge, LLMJudgeProjectAssociation
+from ada_backend.database.models import EvaluationType, LLMJudge, LLMJudgeProjectAssociation, Project
 
 
 def get_llm_judges_by_project(
     session: Session,
     project_id: UUID,
 ) -> List[LLMJudge]:
-    return session.query(LLMJudge).filter(LLMJudge.project_id == project_id).order_by(LLMJudge.created_at.desc()).all()
+    return (
+        session.query(LLMJudge)
+        .join(LLMJudgeProjectAssociation, LLMJudge.id == LLMJudgeProjectAssociation.judge_id)
+        .filter(LLMJudgeProjectAssociation.project_id == project_id)
+        .order_by(LLMJudge.created_at.desc())
+        .all()
+    )
 
 
 def get_llm_judges_by_organization(
@@ -28,8 +34,12 @@ def get_llm_judges_by_organization(
 def get_llm_judge_by_id(
     session: Session,
     judge_id: UUID,
+    organization_id: Optional[UUID] = None,
 ) -> Optional[LLMJudge]:
-    return session.query(LLMJudge).filter(LLMJudge.id == judge_id).first()
+    query = session.query(LLMJudge).filter(LLMJudge.id == judge_id)
+    if organization_id is not None:
+        query = query.filter(LLMJudge.organization_id == organization_id)
+    return query.first()
 
 
 def create_llm_judge(
@@ -109,6 +119,20 @@ def delete_llm_judges(
 
     session.commit()
     return deleted_count
+
+
+def get_valid_project_ids_for_organization(
+    session: Session,
+    project_ids: List[UUID],
+    organization_id: UUID,
+) -> set[UUID]:
+    """Return the subset of project_ids that belong to the given organization."""
+    return {
+        row[0]
+        for row in session.query(Project.id)
+        .filter(Project.id.in_(project_ids), Project.organization_id == organization_id)
+        .all()
+    }
 
 
 # Judge-Project association functions

--- a/ada_backend/repositories/llm_judges_repository.py
+++ b/ada_backend/repositories/llm_judges_repository.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import EvaluationType, LLMJudge
+from ada_backend.database.models import EvaluationType, LLMJudge, LLMJudgeProjectAssociation
 
 
 def get_llm_judges_by_project(
@@ -11,6 +11,18 @@ def get_llm_judges_by_project(
     project_id: UUID,
 ) -> List[LLMJudge]:
     return session.query(LLMJudge).filter(LLMJudge.project_id == project_id).order_by(LLMJudge.created_at.desc()).all()
+
+
+def get_llm_judges_by_organization(
+    session: Session,
+    organization_id: UUID,
+) -> List[LLMJudge]:
+    return (
+        session.query(LLMJudge)
+        .filter(LLMJudge.organization_id == organization_id)
+        .order_by(LLMJudge.created_at.desc())
+        .all()
+    )
 
 
 def get_llm_judge_by_id(
@@ -22,7 +34,7 @@ def get_llm_judge_by_id(
 
 def create_llm_judge(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     name: str,
     description: Optional[str],
     evaluation_type: EvaluationType,
@@ -31,7 +43,7 @@ def create_llm_judge(
     temperature: Optional[float] = 1.0,
 ) -> LLMJudge:
     llm_judge = LLMJudge(
-        project_id=project_id,
+        organization_id=organization_id,
         name=name,
         description=description,
         evaluation_type=evaluation_type,
@@ -49,7 +61,7 @@ def create_llm_judge(
 def update_llm_judge(
     session: Session,
     judge_id: UUID,
-    project_id: UUID,
+    organization_id: UUID,
     name: Optional[str] = None,
     description: Optional[str] = None,
     evaluation_type: Optional[EvaluationType] = None,
@@ -57,7 +69,11 @@ def update_llm_judge(
     prompt_template: Optional[str] = None,
     temperature: Optional[float] = None,
 ) -> Optional[LLMJudge]:
-    judge = session.query(LLMJudge).filter(LLMJudge.id == judge_id, LLMJudge.project_id == project_id).first()
+    judge = (
+        session.query(LLMJudge)
+        .filter(LLMJudge.id == judge_id, LLMJudge.organization_id == organization_id)
+        .first()
+    )
 
     if not judge:
         return None
@@ -83,13 +99,40 @@ def update_llm_judge(
 def delete_llm_judges(
     session: Session,
     judge_ids: List[UUID],
-    project_id: UUID,
+    organization_id: UUID,
 ) -> int:
     deleted_count = (
         session.query(LLMJudge)
-        .filter(LLMJudge.id.in_(judge_ids), LLMJudge.project_id == project_id)
+        .filter(LLMJudge.id.in_(judge_ids), LLMJudge.organization_id == organization_id)
         .delete(synchronize_session=False)
     )
 
     session.commit()
     return deleted_count
+
+
+# Judge-Project association functions
+def get_judge_project_associations(session: Session, judge_id: UUID) -> List[UUID]:
+    """Get project IDs associated with a judge."""
+    return [
+        row[0]
+        for row in session.query(LLMJudgeProjectAssociation.project_id)
+        .filter(LLMJudgeProjectAssociation.judge_id == judge_id)
+        .all()
+    ]
+
+
+def set_judge_project_associations(
+    session: Session,
+    judge_id: UUID,
+    project_ids: List[UUID],
+) -> None:
+    """Replace all project associations for a judge."""
+    session.query(LLMJudgeProjectAssociation).filter(
+        LLMJudgeProjectAssociation.judge_id == judge_id
+    ).delete(synchronize_session=False)
+
+    for project_id in project_ids:
+        session.add(LLMJudgeProjectAssociation(judge_id=judge_id, project_id=project_id))
+
+    session.commit()

--- a/ada_backend/repositories/quality_assurance_repository.py
+++ b/ada_backend/repositories/quality_assurance_repository.py
@@ -6,7 +6,13 @@ from sqlalchemy import case, func, select, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import DatasetProject, InputGroundtruth, QADatasetMetadata, VersionOutput
+from ada_backend.database.models import (
+    DatasetProject,
+    DatasetProjectAssociation,
+    InputGroundtruth,
+    QADatasetMetadata,
+    VersionOutput,
+)
 from ada_backend.schemas.input_groundtruth_schema import InputGroundtruthCreate, InputGroundtruthUpdateList
 
 LOGGER = logging.getLogger(__name__)
@@ -314,7 +320,7 @@ def clear_version_outputs_for_input_ids(
     return updated_count
 
 
-# Dataset functions
+# Dataset functions (project-scoped — kept for backward compatibility, will be removed in a follow-up PR)
 def get_datasets_by_project(
     session: Session,
     project_id: UUID,
@@ -332,9 +338,27 @@ def get_datasets_by_project(
     )
 
 
+# Dataset functions (organization-scoped)
+def get_datasets_by_organization(
+    session: Session,
+    organization_id: UUID,
+    skip: int = 0,
+    limit: int = 100,
+) -> List[DatasetProject]:
+    """Get datasets for an organization with pagination."""
+    return (
+        session.query(DatasetProject)
+        .filter(DatasetProject.organization_id == organization_id)
+        .order_by(DatasetProject.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
 def create_datasets(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     dataset_names: List[str],
 ) -> List[DatasetProject]:
     """Create multiple datasets."""
@@ -342,7 +366,7 @@ def create_datasets(
 
     for dataset_name in dataset_names:
         dataset = DatasetProject(
-            project_id=project_id,
+            organization_id=organization_id,
             dataset_name=dataset_name,
         )
         datasets.append(dataset)
@@ -350,11 +374,10 @@ def create_datasets(
     session.add_all(datasets)
     session.commit()
 
-    # Refresh all objects to get their IDs
     for dataset in datasets:
         session.refresh(dataset)
 
-    LOGGER.info(f"Created {len(datasets)} datasets for project {project_id}")
+    LOGGER.debug(f"Created {len(datasets)} datasets for organization {organization_id}")
     return datasets
 
 
@@ -362,12 +385,12 @@ def update_dataset(
     session: Session,
     dataset_id: UUID,
     dataset_name: Optional[str],
-    project_id: UUID,
+    organization_id: UUID,
 ) -> DatasetProject:
     """Update a dataset"""
     dataset = (
         session.query(DatasetProject)
-        .filter(DatasetProject.id == dataset_id, DatasetProject.project_id == project_id)
+        .filter(DatasetProject.id == dataset_id, DatasetProject.organization_id == organization_id)
         .first()
     )
 
@@ -376,35 +399,71 @@ def update_dataset(
 
     session.commit()
 
-    LOGGER.info(f"Updated dataset {dataset_id} with name '{dataset_name}' for project {project_id}")
+    LOGGER.debug(f"Updated dataset {dataset_id} with name '{dataset_name}' for organization {organization_id}")
     return dataset
 
 
 def delete_datasets(
     session: Session,
     dataset_ids: List[UUID],
-    project_id: UUID,
+    organization_id: UUID,
 ) -> int:
     """Delete multiple datasets."""
     deleted_count = (
         session.query(DatasetProject)
-        .filter(DatasetProject.id.in_(dataset_ids), DatasetProject.project_id == project_id)
+        .filter(DatasetProject.id.in_(dataset_ids), DatasetProject.organization_id == organization_id)
         .delete(synchronize_session=False)
     )
 
     session.commit()
 
-    LOGGER.info(f"Deleted {deleted_count} datasets for project {project_id}")
+    LOGGER.info(f"Deleted {deleted_count} datasets for organization {organization_id}")
     return deleted_count
+
+
+def check_dataset_belongs_to_organization(session: Session, organization_id: UUID, dataset_id: UUID) -> bool:
+    exists = session.query(
+        session.query(DatasetProject)
+        .filter(DatasetProject.id == dataset_id, DatasetProject.organization_id == organization_id)
+        .exists()
+    ).scalar()
+    return exists
 
 
 def check_dataset_belongs_to_project(session: Session, project_id: UUID, dataset_id: UUID) -> bool:
     exists = session.query(
-        session.query(DatasetProject)
-        .filter(DatasetProject.id == dataset_id, DatasetProject.project_id == project_id)
+        session.query(DatasetProjectAssociation)
+        .filter(DatasetProjectAssociation.dataset_id == dataset_id, DatasetProjectAssociation.project_id == project_id)
         .exists()
     ).scalar()
     return exists
+
+
+# Dataset-Project association functions
+def get_dataset_project_associations(session: Session, dataset_id: UUID) -> List[UUID]:
+    """Get project IDs associated with a dataset."""
+    return [
+        row[0]
+        for row in session.query(DatasetProjectAssociation.project_id)
+        .filter(DatasetProjectAssociation.dataset_id == dataset_id)
+        .all()
+    ]
+
+
+def set_dataset_project_associations(
+    session: Session,
+    dataset_id: UUID,
+    project_ids: List[UUID],
+) -> None:
+    """Replace all project associations for a dataset."""
+    session.query(DatasetProjectAssociation).filter(DatasetProjectAssociation.dataset_id == dataset_id).delete(
+        synchronize_session=False
+    )
+
+    for project_id in project_ids:
+        session.add(DatasetProjectAssociation(dataset_id=dataset_id, project_id=project_id))
+
+    session.commit()
 
 
 def get_qa_columns_by_dataset(session: Session, dataset_id: UUID) -> List[QADatasetMetadata]:

--- a/ada_backend/routers/llm_judges_router.py
+++ b/ada_backend/routers/llm_judges_router.py
@@ -10,20 +10,26 @@ from ada_backend.database.setup_db import get_db
 from ada_backend.routers.auth_router import (
     UserRights,
     get_user_from_supabase_token,
+    user_has_access_to_organization_dependency,
     user_has_access_to_project_dependency,
 )
+from ada_backend.routers.router_utils import resolve_organization_id
 from ada_backend.schemas.auth_schema import SupabaseUser
 from ada_backend.schemas.llm_judges_schema import (
     LLMJudgeCreate,
+    LLMJudgeProjectAssociationRequest,
     LLMJudgeResponse,
     LLMJudgeTemplate,
     LLMJudgeUpdate,
 )
+from ada_backend.services.errors import LLMJudgeNotFound, ProjectNotFound
 from ada_backend.services.qa.llm_judges_service import (
     create_llm_judge_service,
     delete_llm_judges_service,
     get_llm_judge_defaults_service,
+    get_llm_judges_by_organization_service,
     get_llm_judges_by_project_service,
+    set_judge_projects_service,
     update_llm_judge_service,
 )
 
@@ -32,22 +38,23 @@ LOGGER = logging.getLogger(__name__)
 
 
 @router.get(
-    "/projects/{project_id}/qa/llm-judges",
+    "/organizations/{organization_id}/qa/llm-judges",
     response_model=List[LLMJudgeResponse],
-    summary="Get LLM Judges by Project",
+    summary="Get LLM Judges by Organization",
 )
-def get_llm_judges_by_project_endpoint(
-    project_id: UUID,
+def get_llm_judges_by_organization_endpoint(
+    organization_id: UUID,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
     ],
     session: Session = Depends(get_db),
 ) -> List[LLMJudgeResponse]:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
-    return get_llm_judges_by_project_service(session=session, project_id=project_id)
+    try:
+        return get_llm_judges_by_organization_service(session=session, organization_id=organization_id)
+    except Exception as e:
+        LOGGER.error(f"Failed to get LLM judges for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.get(
@@ -59,18 +66,144 @@ def get_llm_judge_defaults(
     user: Annotated[SupabaseUser, Depends(get_user_from_supabase_token)],
     evaluation_type: EvaluationType = Query(default=EvaluationType.BOOLEAN, description="Evaluation type"),
 ) -> LLMJudgeTemplate:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     return get_llm_judge_defaults_service(evaluation_type=evaluation_type)
+
+
+@router.post(
+    "/organizations/{organization_id}/qa/llm-judges",
+    response_model=LLMJudgeResponse,
+    summary="Create LLM Judge",
+)
+def create_llm_judge_endpoint(
+    organization_id: UUID,
+    judge_data: LLMJudgeCreate,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> LLMJudgeResponse:
+    try:
+        return create_llm_judge_service(session=session, organization_id=organization_id, judge_data=judge_data)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to create LLM judge for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.patch(
+    "/organizations/{organization_id}/qa/llm-judges/{judge_id}",
+    response_model=LLMJudgeResponse,
+    summary="Update LLM Judge",
+)
+def update_llm_judge_endpoint(
+    organization_id: UUID,
+    judge_id: UUID,
+    judge_data: LLMJudgeUpdate,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> LLMJudgeResponse:
+    try:
+        return update_llm_judge_service(
+            session=session,
+            organization_id=organization_id,
+            judge_id=judge_id,
+            judge_data=judge_data,
+        )
+    except LLMJudgeNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to update LLM judge {judge_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete(
+    "/organizations/{organization_id}/qa/llm-judges",
+    status_code=204,
+    summary="Delete LLM Judges",
+)
+def delete_llm_judges_endpoint(
+    organization_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+    judge_ids: List[UUID] = Body(...),
+):
+    try:
+        delete_llm_judges_service(session=session, organization_id=organization_id, judge_ids=judge_ids)
+        return None
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to delete LLM judges for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.put(
+    "/organizations/{organization_id}/qa/llm-judges/{judge_id}/projects",
+    response_model=LLMJudgeResponse,
+    summary="Set Judge Project Associations",
+)
+def set_judge_projects_endpoint(
+    organization_id: UUID,
+    judge_id: UUID,
+    body: LLMJudgeProjectAssociationRequest,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> LLMJudgeResponse:
+    try:
+        return set_judge_projects_service(session, organization_id, judge_id, body.project_ids)
+    except LLMJudgeNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to set judge projects: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+# ── Deprecated project-scoped endpoints (use org-scoped equivalents) ──────────
+
+
+@router.get(
+    "/projects/{project_id}/qa/llm-judges",
+    response_model=List[LLMJudgeResponse],
+    summary="Get LLM Judges by Project",
+    deprecated=True,
+)
+def get_llm_judges_by_project_endpoint(
+    project_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> List[LLMJudgeResponse]:
+    try:
+        return get_llm_judges_by_project_service(session=session, project_id=project_id)
+    except Exception as e:
+        LOGGER.error(f"Failed to get LLM judges for project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
     "/projects/{project_id}/qa/llm-judges",
     response_model=LLMJudgeResponse,
-    summary="Create LLM Judge",
+    summary="Create LLM Judge (deprecated — use org-scoped endpoint)",
+    deprecated=True,
 )
-def create_llm_judge_endpoint(
+def create_llm_judge_by_project_endpoint(
     project_id: UUID,
     judge_data: LLMJudgeCreate,
     user: Annotated[
@@ -79,22 +212,30 @@ def create_llm_judge_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> LLMJudgeResponse:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
-        return create_llm_judge_service(session=session, project_id=project_id, judge_data=judge_data)
+        organization_id = resolve_organization_id(session, project_id)
+        judge_response = create_llm_judge_service(
+            session=session, organization_id=organization_id, judge_data=judge_data
+        )
+        return set_judge_projects_service(
+            session=session,
+            organization_id=organization_id,
+            judge_id=judge_response.id,
+            project_ids=[project_id],
+        )
+    except ProjectNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except ValueError as e:
-        LOGGER.error(f"Failed to create LLM judge for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
 
 
 @router.patch(
     "/projects/{project_id}/qa/llm-judges/{judge_id}",
     response_model=LLMJudgeResponse,
-    summary="Update LLM Judge",
+    summary="Update LLM Judge (deprecated — use org-scoped endpoint)",
+    deprecated=True,
 )
-def update_llm_judge_endpoint(
+def update_llm_judge_by_project_endpoint(
     project_id: UUID,
     judge_id: UUID,
     judge_data: LLMJudgeUpdate,
@@ -104,27 +245,30 @@ def update_llm_judge_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> LLMJudgeResponse:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
+        organization_id = resolve_organization_id(session, project_id)
         return update_llm_judge_service(
             session=session,
-            project_id=project_id,
+            organization_id=organization_id,
             judge_id=judge_id,
             judge_data=judge_data,
         )
+    except (ProjectNotFound, LLMJudgeNotFound) as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except ValueError as e:
-        LOGGER.error(f"Failed to update LLM judge {judge_id} for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to update LLM judge {judge_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.delete(
     "/projects/{project_id}/qa/llm-judges",
     status_code=204,
-    summary="Delete LLM Judges",
+    summary="Delete LLM Judges (deprecated — use org-scoped endpoint)",
+    deprecated=True,
 )
-def delete_llm_judges_endpoint(
+def delete_llm_judges_by_project_endpoint(
     project_id: UUID,
     user: Annotated[
         SupabaseUser,
@@ -133,12 +277,11 @@ def delete_llm_judges_endpoint(
     session: Session = Depends(get_db),
     judge_ids: List[UUID] = Body(...),
 ):
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
-        delete_llm_judges_service(session=session, project_id=project_id, judge_ids=judge_ids)
+        organization_id = resolve_organization_id(session, project_id)
+        delete_llm_judges_service(session=session, organization_id=organization_id, judge_ids=judge_ids)
         return None
+    except ProjectNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except ValueError as e:
-        LOGGER.error(f"Failed to delete LLM judges for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e

--- a/ada_backend/routers/llm_judges_router.py
+++ b/ada_backend/routers/llm_judges_router.py
@@ -164,7 +164,7 @@ def set_judge_projects_endpoint(
 ) -> LLMJudgeResponse:
     try:
         return set_judge_projects_service(session, organization_id, judge_id, body.project_ids)
-    except LLMJudgeNotFound as e:
+    except (LLMJudgeNotFound, ProjectNotFound) as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/ada_backend/routers/quality_assurance_router.py
+++ b/ada_backend/routers/quality_assurance_router.py
@@ -10,7 +10,10 @@ from sqlalchemy.orm import Session
 from ada_backend.database.models import DatasetProject, DatasetProjectAssociation, RunStatus
 from ada_backend.database.setup_db import get_db
 from ada_backend.repositories.qa_session_repository import update_qa_session_status
-from ada_backend.repositories.quality_assurance_repository import check_dataset_belongs_to_project
+from ada_backend.repositories.quality_assurance_repository import (
+    check_dataset_belongs_to_organization,
+    check_dataset_belongs_to_project,
+)
 from ada_backend.routers.auth_router import (
     UserRights,
     user_has_access_to_organization_dependency,
@@ -88,6 +91,11 @@ from ada_backend.utils.redis_client import push_qa_task
 
 router = APIRouter(tags=["Quality Assurance"])
 LOGGER = logging.getLogger(__name__)
+
+
+def _validate_dataset_in_organization(session: Session, organization_id: UUID, dataset_id: UUID) -> None:
+    if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
+        raise QADatasetNotInOrganizationError(organization_id, dataset_id)
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -348,7 +356,13 @@ def get_inputs_groundtruths_by_dataset_org_endpoint(
     page_size: int = Query(100, ge=1, le=1000, description="Number of items per page"),
 ) -> PaginatedInputGroundtruthResponse:
     try:
+        _validate_dataset_in_organization(session, organization_id, dataset_id)
         return get_inputs_groundtruths_with_version_outputs_service(session, dataset_id, page, page_size)
+    except QADatasetNotInOrganizationError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Bad request") from e
     except Exception as e:
@@ -373,7 +387,13 @@ def get_outputs_org_endpoint(
     graph_runner_id: UUID = Query(..., description="Graph runner ID to get outputs for"),
 ) -> Dict[UUID, str]:
     try:
+        _validate_dataset_in_organization(session, organization_id, dataset_id)
         return get_outputs_by_graph_runner_service(session, dataset_id, graph_runner_id)
+    except QADatasetNotInOrganizationError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Bad request") from e
     except Exception as e:
@@ -398,7 +418,13 @@ def create_input_groundtruth_org_endpoint(
     session: Session = Depends(get_db),
 ) -> InputGroundtruthResponseList:
     try:
+        _validate_dataset_in_organization(session, organization_id, dataset_id)
         return create_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
+    except QADatasetNotInOrganizationError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
+        )
     except (QADuplicatePositionError, QAPartialPositionError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except ValueError as e:
@@ -425,7 +451,13 @@ def update_input_groundtruth_org_endpoint(
     session: Session = Depends(get_db),
 ) -> InputGroundtruthResponseList:
     try:
+        _validate_dataset_in_organization(session, organization_id, dataset_id)
         return update_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
+    except QADatasetNotInOrganizationError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Bad request") from e
     except Exception as e:
@@ -449,8 +481,14 @@ def delete_input_groundtruth_org_endpoint(
     session: Session = Depends(get_db),
 ) -> dict:
     try:
+        _validate_dataset_in_organization(session, organization_id, dataset_id)
         deleted_count = delete_inputs_groundtruths_service(session, dataset_id, delete_data)
         return {"message": f"Deleted {deleted_count} input-groundtruth entries successfully"}
+    except QADatasetNotInOrganizationError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Bad request") from e
     except Exception as e:
@@ -475,10 +513,16 @@ async def create_entry_from_history_org(
     session: Session = Depends(get_db),
 ) -> List[InputGroundtruthResponse]:
     try:
+        _validate_dataset_in_organization(session, organization_id, dataset_id)
         return save_conversation_to_groundtruth_service(
             session=session,
             trace_id=trace_id,
             dataset_id=dataset_id,
+        )
+    except QADatasetNotInOrganizationError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
         )
     except (QADuplicatePositionError, QAPartialPositionError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
@@ -505,6 +549,7 @@ def export_qa_data_to_csv_org_endpoint(
     graph_runner_id: UUID = Query(..., description="Graph runner ID to filter outputs"),
 ) -> Response:
     try:
+        _validate_dataset_in_organization(session, organization_id, dataset_id)
         csv_content = export_qa_data_to_csv_service(session, dataset_id, graph_runner_id)
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
         filename = f"qa_export_{dataset_id}_{timestamp}.csv"
@@ -512,6 +557,11 @@ def export_qa_data_to_csv_org_endpoint(
             content=csv_content,
             media_type="text/csv",
             headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
+    except QADatasetNotInOrganizationError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
         )
     except CSVExportError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
@@ -536,12 +586,18 @@ async def import_qa_data_from_csv_org_endpoint(
     session: Session = Depends(get_db),
 ) -> InputGroundtruthResponseList:
     try:
+        _validate_dataset_in_organization(session, organization_id, dataset_id)
         await file.seek(0)
         return import_qa_data_from_csv_service(
             session=session,
             organization_id=organization_id,
             dataset_id=dataset_id,
             csv_file=file.file,
+        )
+    except QADatasetNotInOrganizationError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
         )
     except (
         CSVEmptyFileError,
@@ -550,8 +606,6 @@ async def import_qa_data_from_csv_org_endpoint(
         CSVNonUniquePositionError,
         CSVInvalidPositionError,
     ) as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except QADatasetNotInOrganizationError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         LOGGER.error(f"Failed to import QA data for dataset {dataset_id}: {str(e)}", exc_info=True)
@@ -577,13 +631,9 @@ def get_version_output_ids_endpoint(
     session: Session = Depends(get_db),
     input_ids: List[UUID] = Query(..., description="List of Input IDs"),
 ) -> Dict[UUID, Optional[UUID]]:
-    try:
-        return get_version_output_ids_by_input_ids_and_graph_runner_service(
-            session=session, input_ids=input_ids, graph_runner_id=graph_runner_id
-        )
-    except Exception as e:
-        LOGGER.error(f"Failed to get version output IDs: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return get_version_output_ids_by_input_ids_and_graph_runner_service(
+        session=session, input_ids=input_ids, graph_runner_id=graph_runner_id, project_id=project_id
+    )
 
 
 @router.post(
@@ -770,13 +820,13 @@ def create_dataset_endpoint(
     try:
         organization_id = resolve_organization_id(session, project_id)
         response = create_datasets_service(session, organization_id, dataset_data)
-        for dataset_resp in response.datasets:
-            session.query(DatasetProject).filter(
-                DatasetProject.id == dataset_resp.id
-            ).update({"project_id": project_id})
-            session.add(
-                DatasetProjectAssociation(dataset_id=dataset_resp.id, project_id=project_id)
-            )
+        dataset_ids = [dataset_resp.id for dataset_resp in response.datasets]
+        session.query(DatasetProject).filter(
+            DatasetProject.id.in_(dataset_ids)
+        ).update({"project_id": project_id}, synchronize_session=False)
+        session.add_all(
+            [DatasetProjectAssociation(dataset_id=did, project_id=project_id) for did in dataset_ids]
+        )
         session.commit()
         for dataset_resp in response.datasets:
             dataset_resp.project_ids = [project_id]

--- a/ada_backend/routers/quality_assurance_router.py
+++ b/ada_backend/routers/quality_assurance_router.py
@@ -7,15 +7,22 @@ from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, Upload
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import RunStatus
+from ada_backend.database.models import DatasetProject, DatasetProjectAssociation, RunStatus
 from ada_backend.database.setup_db import get_db
 from ada_backend.repositories.qa_session_repository import update_qa_session_status
-from ada_backend.routers.auth_router import UserRights, user_has_access_to_project_dependency
+from ada_backend.repositories.quality_assurance_repository import check_dataset_belongs_to_project
+from ada_backend.routers.auth_router import (
+    UserRights,
+    user_has_access_to_organization_dependency,
+    user_has_access_to_project_dependency,
+)
+from ada_backend.routers.router_utils import resolve_organization_id
 from ada_backend.schemas.auth_schema import SupabaseUser
 from ada_backend.schemas.dataset_schema import (
     DatasetCreateList,
     DatasetDeleteList,
     DatasetListResponse,
+    DatasetProjectAssociationRequest,
     DatasetResponse,
 )
 from ada_backend.schemas.input_groundtruth_schema import (
@@ -31,11 +38,28 @@ from ada_backend.schemas.input_groundtruth_schema import (
     QASessionResponseSchema,
 )
 from ada_backend.schemas.qa_metadata_schema import QAColumnResponse
-from ada_backend.services.qa.qa_error import QADatasetNotInProjectError
+from ada_backend.services.errors import GraphNotBoundToProjectError, ProjectNotFound
+from ada_backend.services.qa.qa_error import (
+    CSVEmptyFileError,
+    CSVExportError,
+    CSVInvalidJSONError,
+    CSVInvalidPositionError,
+    CSVMissingDatasetColumnError,
+    CSVNonUniquePositionError,
+    QAColumnNotFoundError,
+    QADatasetNotInOrganizationError,
+    QADatasetNotInProjectError,
+    QADuplicatePositionError,
+    QAPartialPositionError,
+)
 from ada_backend.services.qa.qa_metadata_service import (
+    create_qa_column_project_service,
     create_qa_column_service,
+    delete_qa_column_project_service,
     delete_qa_column_service,
+    get_qa_columns_by_dataset_project_service,
     get_qa_columns_by_dataset_service,
+    rename_qa_column_project_service,
     rename_qa_column_service,
 )
 from ada_backend.services.qa.quality_assurance_service import (
@@ -45,6 +69,7 @@ from ada_backend.services.qa.quality_assurance_service import (
     delete_datasets_service,
     delete_inputs_groundtruths_service,
     export_qa_data_to_csv_service,
+    get_datasets_by_organization_service,
     get_datasets_by_project_service,
     get_inputs_groundtruths_with_version_outputs_service,
     get_outputs_by_graph_runner_service,
@@ -54,6 +79,7 @@ from ada_backend.services.qa.quality_assurance_service import (
     list_qa_sessions_service,
     run_qa_service,
     save_conversation_to_groundtruth_service,
+    set_dataset_projects_service,
     update_dataset_service,
     update_inputs_groundtruths_service,
     validate_qa_run_request,
@@ -64,286 +90,477 @@ router = APIRouter(tags=["Quality Assurance"])
 LOGGER = logging.getLogger(__name__)
 
 
-# Dataset endpoints
+# ══════════════════════════════════════════════════════════════════════
+# Organization-scoped endpoints
+# ══════════════════════════════════════════════════════════════════════
+
+# ── Organization-scoped dataset CRUD ─────────────────────────────────
+
 @router.get(
-    "/projects/{project_id}/qa/datasets",
+    "/organizations/{organization_id}/qa/datasets",
     response_model=List[DatasetResponse],
-    summary="Get Datasets by Project",
+    summary="Get Datasets by Organization",
     tags=["Quality Assurance"],
 )
-def get_datasets_by_project_endpoint(
-    project_id: UUID,
+def get_datasets_by_organization_endpoint(
+    organization_id: UUID,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
     ],
     session: Session = Depends(get_db),
 ) -> List[DatasetResponse]:
-    """
-    Get all datasets for a project.
-
-    This endpoint allows users to retrieve all datasets associated with a specific project
-    for quality assurance purposes.
-    """
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
-        return get_datasets_by_project_service(session, project_id)
+        return get_datasets_by_organization_service(session, organization_id)
     except ValueError as e:
-        LOGGER.error(f"Failed to get datasets for project {project_id}: {str(e)}", exc_info=True)
+        LOGGER.error(f"Failed to get datasets for organization {organization_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to get datasets for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
-    "/projects/{project_id}/qa/datasets",
+    "/organizations/{organization_id}/qa/datasets",
     response_model=DatasetListResponse,
-    summary="Create Datasets",
+    summary="Create Datasets (Organization)",
     tags=["Quality Assurance"],
 )
-def create_dataset_endpoint(
-    project_id: UUID,
+def create_dataset_by_organization_endpoint(
+    organization_id: UUID,
     dataset_data: DatasetCreateList,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
     ],
     session: Session = Depends(get_db),
 ) -> DatasetListResponse:
-    """
-    Create datasets for a project.
-
-    This endpoint allows users to create multiple datasets for quality assurance purposes.
-    All datasets will be associated with the specified project.
-    """
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
-        return create_datasets_service(session, project_id, dataset_data)
+        return create_datasets_service(session, organization_id, dataset_data)
     except ValueError as e:
-        LOGGER.error(f"Failed to create datasets for project {project_id}: {str(e)}", exc_info=True)
+        LOGGER.error(f"Failed to create datasets for organization {organization_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to create datasets for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.patch(
-    "/projects/{project_id}/qa/datasets/{dataset_id}",
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}",
     response_model=DatasetResponse,
-    summary="Update Dataset",
+    summary="Update Dataset (Organization)",
     tags=["Quality Assurance"],
 )
-def update_dataset_endpoint(
-    project_id: UUID,
+def update_dataset_by_organization_endpoint(
+    organization_id: UUID,
     dataset_id: UUID,
     dataset_name: str,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
     ],
     session: Session = Depends(get_db),
 ) -> DatasetResponse:
-    """
-    Update dataset.
-
-    This endpoint allows users to update a single dataset.
-    Only the fields provided in the request will be updated.
-    """
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
-        return update_dataset_service(session, project_id, dataset_id, dataset_name)
+        return update_dataset_service(session, organization_id, dataset_id, dataset_name)
     except ValueError as e:
         LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.delete(
-    "/projects/{project_id}/qa/datasets",
-    summary="Delete Datasets",
+    "/organizations/{organization_id}/qa/datasets",
+    summary="Delete Datasets (Organization)",
     tags=["Quality Assurance"],
 )
-def delete_dataset_endpoint(
-    project_id: UUID,
+def delete_dataset_by_organization_endpoint(
+    organization_id: UUID,
     delete_data: DatasetDeleteList,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
     ],
     session: Session = Depends(get_db),
 ) -> dict:
-    """
-    Delete datasets.
-
-    This endpoint allows users to delete multiple datasets at once.
-    This action cannot be undone.
-    """
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
-        deleted_count = delete_datasets_service(session, project_id, delete_data)
+        deleted_count = delete_datasets_service(session, organization_id, delete_data)
         return {"message": f"Deleted {deleted_count} datasets successfully"}
     except ValueError as e:
-        LOGGER.error(f"Failed to delete datasets for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
+        LOGGER.error(f"Failed to delete datasets for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to delete datasets for organization {organization_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
-# QA Metadata (Custom Columns) endpoints
-@router.get(
-    "/projects/{project_id}/qa/datasets/{dataset_id}/custom-columns",
-    response_model=List[QAColumnResponse],
-    summary="Get Custom Columns for Dataset",
+@router.put(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/projects",
+    response_model=DatasetResponse,
+    summary="Set Dataset Project Associations",
     tags=["Quality Assurance"],
 )
-def get_columns_by_dataset_endpoint(
-    project_id: UUID,
+def set_dataset_projects_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    body: DatasetProjectAssociationRequest,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> DatasetResponse:
+    try:
+        return set_dataset_projects_service(session, organization_id, dataset_id, body.project_ids)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to set dataset projects: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+# ── Organization-scoped QA Metadata (Custom Columns) ────────────────
+
+@router.get(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns",
+    response_model=List[QAColumnResponse],
+    summary="Get Custom Columns for Dataset (Organization)",
+    tags=["Quality Assurance"],
+)
+def get_columns_by_dataset_org_endpoint(
+    organization_id: UUID,
     dataset_id: UUID,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
     ],
     session: Session = Depends(get_db),
 ) -> List[QAColumnResponse]:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
-    return get_qa_columns_by_dataset_service(session, project_id, dataset_id)
+    try:
+        return get_qa_columns_by_dataset_service(session, organization_id, dataset_id)
+    except QADatasetNotInOrganizationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to get columns for dataset {dataset_id} in org {organization_id}: {str(e)}", exc_info=True
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
-    "/projects/{project_id}/qa/datasets/{dataset_id}/custom-columns",
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns",
     response_model=QAColumnResponse,
-    summary="Add Custom Column to Dataset",
+    summary="Add Custom Column to Dataset (Organization)",
     tags=["Quality Assurance"],
 )
-def add_column_to_dataset_endpoint(
-    project_id: UUID,
+def add_column_to_dataset_org_endpoint(
+    organization_id: UUID,
     dataset_id: UUID,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
     ],
     session: Session = Depends(get_db),
     column_name: str = Body(..., embed=True),
 ) -> QAColumnResponse:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
-    return create_qa_column_service(session, project_id, dataset_id, column_name)
+    try:
+        return create_qa_column_service(session, organization_id, dataset_id, column_name)
+    except QADatasetNotInOrganizationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to add column to dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.patch(
-    "/projects/{project_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}",
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}",
     response_model=QAColumnResponse,
-    summary="Rename Custom Column",
+    summary="Rename Custom Column (Organization)",
     tags=["Quality Assurance"],
 )
-def rename_column_endpoint(
-    project_id: UUID,
+def rename_column_org_endpoint(
+    organization_id: UUID,
     dataset_id: UUID,
     column_id: UUID,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
     ],
     session: Session = Depends(get_db),
     column_name: str = Body(..., embed=True),
 ) -> QAColumnResponse:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
-    return rename_qa_column_service(session, project_id, dataset_id, column_id, column_name)
+    try:
+        return rename_qa_column_service(session, organization_id, dataset_id, column_id, column_name)
+    except QADatasetNotInOrganizationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except QAColumnNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to rename column {column_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.delete(
-    "/projects/{project_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}",
-    summary="Delete Custom Column",
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}",
+    summary="Delete Custom Column (Organization)",
     tags=["Quality Assurance"],
 )
-def delete_column_endpoint(
-    project_id: UUID,
+def delete_column_org_endpoint(
+    organization_id: UUID,
     dataset_id: UUID,
     column_id: UUID,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
     ],
     session: Session = Depends(get_db),
 ) -> dict:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
+    try:
+        return delete_qa_column_service(session, organization_id, dataset_id, column_id)
+    except QADatasetNotInOrganizationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except QAColumnNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to delete column {column_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
-    return delete_qa_column_service(session, project_id, dataset_id, column_id)
 
+# ── Organization-scoped entries, CSV import/export ───────────────────
 
-# Input Groundtruth endpoints
 @router.get(
-    "/projects/{project_id}/qa/datasets/{dataset_id}/entries",
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/entries",
     response_model=PaginatedInputGroundtruthResponse,
-    summary="Get Input-Groundtruth Entries by Dataset",
+    summary="Get Input-Groundtruth Entries by Dataset (Organization)",
     tags=["Quality Assurance"],
 )
-def get_inputs_groundtruths_by_dataset_endpoint(
-    project_id: UUID,
+def get_inputs_groundtruths_by_dataset_org_endpoint(
+    organization_id: UUID,
     dataset_id: UUID,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
     ],
     session: Session = Depends(get_db),
     page: int = Query(1, ge=1, description="Page number (1-based)"),
     page_size: int = Query(100, ge=1, le=1000, description="Number of items per page"),
 ) -> PaginatedInputGroundtruthResponse:
-    """
-    Get all input-groundtruth entries for a dataset WITHOUT outputs.
-
-    This endpoint returns only the base input-groundtruth pairs for a dataset.
-    Use the /outputs endpoint to get outputs for a specific graph_runner.
-    """
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
         return get_inputs_groundtruths_with_version_outputs_service(session, dataset_id, page, page_size)
     except ValueError as e:
-        LOGGER.error(f"Failed to get input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to get entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.get(
-    "/projects/{project_id}/qa/datasets/{dataset_id}/outputs",
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/outputs",
     response_model=Dict[UUID, str],
-    summary="Get Outputs for a Graph Runner",
+    summary="Get Outputs for a Graph Runner (Organization)",
     tags=["Quality Assurance"],
 )
-def get_outputs_endpoint(
-    project_id: UUID,
+def get_outputs_org_endpoint(
+    organization_id: UUID,
     dataset_id: UUID,
     user: Annotated[
         SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
     ],
     session: Session = Depends(get_db),
     graph_runner_id: UUID = Query(..., description="Graph runner ID to get outputs for"),
 ) -> Dict[UUID, str]:
-    """
-    Get outputs for a specific graph_runner.
-
-    Returns a dictionary mapping input_id (UUID) to output (string) for the specified graph_runner.
-    """
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
         return get_outputs_by_graph_runner_service(session, dataset_id, graph_runner_id)
     except ValueError as e:
-        LOGGER.error(
-            f"Failed to get outputs for graph runner {graph_runner_id} and dataset {dataset_id}: {str(e)}",
-            exc_info=True,
-        )
         raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to get outputs for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
+
+@router.post(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/entries",
+    response_model=InputGroundtruthResponseList,
+    summary="Create Input-Groundtruth Entries (Organization)",
+    tags=["Quality Assurance"],
+)
+def create_input_groundtruth_org_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    input_groundtruth_data: InputGroundtruthCreateList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> InputGroundtruthResponseList:
+    try:
+        return create_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
+    except (QADuplicatePositionError, QAPartialPositionError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to create entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.patch(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/entries",
+    response_model=InputGroundtruthResponseList,
+    summary="Update Input-Groundtruth Entries (Organization)",
+    tags=["Quality Assurance"],
+)
+def update_input_groundtruth_org_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    input_groundtruth_data: InputGroundtruthUpdateList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> InputGroundtruthResponseList:
+    try:
+        return update_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to update entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/entries",
+    summary="Delete Input-Groundtruth Entries (Organization)",
+    tags=["Quality Assurance"],
+)
+def delete_input_groundtruth_org_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    delete_data: InputGroundtruthDeleteList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> dict:
+    try:
+        deleted_count = delete_inputs_groundtruths_service(session, dataset_id, delete_data)
+        return {"message": f"Deleted {deleted_count} input-groundtruth entries successfully"}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to delete entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/entries/from-history",
+    response_model=List[InputGroundtruthResponse],
+    summary="Create Entry from History (Organization)",
+    tags=["Quality Assurance"],
+)
+async def create_entry_from_history_org(
+    organization_id: UUID,
+    dataset_id: UUID,
+    trace_id: str,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> List[InputGroundtruthResponse]:
+    try:
+        return save_conversation_to_groundtruth_service(
+            session=session,
+            trace_id=trace_id,
+            dataset_id=dataset_id,
+        )
+    except (QADuplicatePositionError, QAPartialPositionError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to save trace {trace_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/export",
+    summary="Export QA Data to CSV (Organization)",
+    tags=["Quality Assurance"],
+)
+def export_qa_data_to_csv_org_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+    graph_runner_id: UUID = Query(..., description="Graph runner ID to filter outputs"),
+) -> Response:
+    try:
+        csv_content = export_qa_data_to_csv_service(session, dataset_id, graph_runner_id)
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        filename = f"qa_export_{dataset_id}_{timestamp}.csv"
+        return Response(
+            content=csv_content,
+            media_type="text/csv",
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
+    except CSVExportError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post(
+    "/organizations/{organization_id}/qa/datasets/{dataset_id}/import",
+    response_model=InputGroundtruthResponseList,
+    summary="Import QA Data from CSV (Organization)",
+    tags=["Quality Assurance"],
+)
+async def import_qa_data_from_csv_org_endpoint(
+    organization_id: UUID,
+    dataset_id: UUID,
+    file: Annotated[UploadFile, File(..., description="CSV file to import")],
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> InputGroundtruthResponseList:
+    try:
+        await file.seek(0)
+        return import_qa_data_from_csv_service(
+            session=session,
+            organization_id=organization_id,
+            dataset_id=dataset_id,
+            csv_file=file.file,
+        )
+    except (
+        CSVEmptyFileError,
+        CSVInvalidJSONError,
+        CSVMissingDatasetColumnError,
+        CSVNonUniquePositionError,
+        CSVInvalidPositionError,
+    ) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except QADatasetNotInOrganizationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to import QA data for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Project-scoped QA runs and sessions (NOT deprecated)
+# ══════════════════════════════════════════════════════════════════════
 
 @router.get(
     "/projects/{project_id}/qa/version-outputs",
@@ -360,111 +577,15 @@ def get_version_output_ids_endpoint(
     session: Session = Depends(get_db),
     input_ids: List[UUID] = Query(..., description="List of Input IDs"),
 ) -> Dict[UUID, Optional[UUID]]:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
-    return get_version_output_ids_by_input_ids_and_graph_runner_service(
-        session=session, input_ids=input_ids, graph_runner_id=graph_runner_id
-    )
-
-
-@router.post(
-    "/projects/{project_id}/qa/datasets/{dataset_id}/entries",
-    response_model=InputGroundtruthResponseList,
-    summary="Create Input-Groundtruth Entries",
-    tags=["Quality Assurance"],
-)
-def create_input_groundtruth_endpoint(
-    project_id: UUID,
-    dataset_id: UUID,
-    input_groundtruth_data: InputGroundtruthCreateList,
-    user: Annotated[
-        SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
-    ],
-    session: Session = Depends(get_db),
-) -> InputGroundtruthResponseList:
-    """
-    Create input-groundtruth entries.
-
-    This endpoint allows users to create multiple input-groundtruth pairs for quality assurance purposes.
-    All entries will be associated with the specified dataset.
-    """
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
-        return create_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
-    except ValueError as e:
-        LOGGER.error(f"Failed to create input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
+        return get_version_output_ids_by_input_ids_and_graph_runner_service(
+            session=session, input_ids=input_ids, graph_runner_id=graph_runner_id
+        )
+    except Exception as e:
+        LOGGER.error(f"Failed to get version output IDs: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
-@router.patch(
-    "/projects/{project_id}/qa/datasets/{dataset_id}/entries",
-    response_model=InputGroundtruthResponseList,
-    summary="Update Input-Groundtruth Entries",
-    tags=["Quality Assurance"],
-)
-def update_input_groundtruth_endpoint(
-    project_id: UUID,
-    dataset_id: UUID,
-    input_groundtruth_data: InputGroundtruthUpdateList,
-    user: Annotated[
-        SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
-    ],
-    session: Session = Depends(get_db),
-) -> InputGroundtruthResponseList:
-    """
-    Update input-groundtruth entries.
-
-    This endpoint allows users to update multiple input-groundtruth pairs.
-    Only the fields provided in the request will be updated.
-    """
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
-    try:
-        return update_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
-    except ValueError as e:
-        LOGGER.error(f"Failed to update input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
-
-
-@router.delete(
-    "/projects/{project_id}/qa/datasets/{dataset_id}/entries",
-    summary="Delete Input-Groundtruth Entries",
-    tags=["Quality Assurance"],
-)
-def delete_input_groundtruth_endpoint(
-    project_id: UUID,
-    dataset_id: UUID,
-    delete_data: InputGroundtruthDeleteList,
-    user: Annotated[
-        SupabaseUser,
-        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
-    ],
-    session: Session = Depends(get_db),
-) -> dict:
-    """
-    Delete input-groundtruth entries.
-
-    This endpoint allows users to delete multiple input-groundtruth pairs at once.
-    This action cannot be undone.
-    """
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
-    try:
-        deleted_count = delete_inputs_groundtruths_service(session, dataset_id, delete_data)
-        return {"message": f"Deleted {deleted_count} input-groundtruth entries successfully"}
-    except ValueError as e:
-        LOGGER.error(f"Failed to delete input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
-
-
-# QA Run endpoint
 @router.post(
     "/projects/{project_id}/qa/datasets/{dataset_id}/run",
     response_model=QARunResponse,
@@ -481,39 +602,17 @@ async def run_qa_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> QARunResponse:
-    """
-    Run QA process on inputs from a dataset.
-
-    This endpoint allows users to run a project on input entries from a dataset.
-    You can either run on specific entries by providing input_ids, or run on all
-    entries in the dataset by setting run_all=True.
-
-    The project will be executed using the specified graph_runner_id to run a specific version.
-    Results are stored in the VersionOutput table.
-
-    Parameters:
-    - graph_runner_id: Specific graph runner ID to execute (required)
-    - input_ids: List of specific input IDs to run (optional if run_all=True)
-    - run_all: Boolean flag to run on all entries in the dataset (optional, default=False)
-
-    Note:
-    - You must specify either input_ids OR set run_all=True, but not both.
-
-    The input and output fields are stored as strings but can be easily cast to JSON
-    for function processing when needed.
-    """
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
         return await run_qa_service(session, project_id, dataset_id, run_request)
     except QADatasetNotInProjectError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
+    except GraphNotBoundToProjectError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except ValueError as e:
-        LOGGER.error(
-            f"Failed to run QA process on dataset {dataset_id} for project {project_id}: {str(e)}", exc_info=True
-        )
         raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to run QA on dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
@@ -533,9 +632,6 @@ async def run_qa_async_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> QASessionAcceptedSchema:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
-
     try:
         validate_qa_run_request(session, project_id, dataset_id, run_request)
     except QADatasetNotInProjectError as e:
@@ -582,8 +678,6 @@ def list_qa_sessions_endpoint(
     session: Session = Depends(get_db),
     dataset_id: Optional[UUID] = Query(None, description="Filter by dataset"),
 ) -> List[QASessionResponseSchema]:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
     return list_qa_sessions_service(session, project_id, dataset_id)
 
 
@@ -602,16 +696,536 @@ def get_qa_session_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> QASessionResponseSchema:
-    if not user.id:
-        raise HTTPException(status_code=400, detail="User ID not found")
     try:
         return get_qa_session_service(session, qa_session_id, project_id)
     except ValueError:
         raise HTTPException(status_code=404, detail="QA session not found")
 
 
+# ══════════════════════════════════════════════════════════════════════
+# Deprecated project-scoped endpoints (use org-scoped equivalents)
+# ══════════════════════════════════════════════════════════════════════
+
+# ── Deprecated dataset CRUD ──────────────────────────────────────────
+
+@router.get(
+    "/projects/{project_id}/qa/datasets",
+    deprecated=True,
+    response_model=List[DatasetResponse],
+    summary="Get Datasets by Project",
+    tags=["Quality Assurance"],
+)
+def get_datasets_by_project_endpoint(
+    project_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> List[DatasetResponse]:
+    """
+    Get all datasets for a project.
+
+    This endpoint allows users to retrieve all datasets associated with a specific project
+    for quality assurance purposes.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return get_datasets_by_project_service(session, project_id)
+    except ValueError as e:
+        LOGGER.error(f"Failed to get datasets for project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to get datasets for project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post(
+    "/projects/{project_id}/qa/datasets",
+    deprecated=True,
+    response_model=DatasetListResponse,
+    summary="Create Datasets",
+    tags=["Quality Assurance"],
+)
+def create_dataset_endpoint(
+    project_id: UUID,
+    dataset_data: DatasetCreateList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> DatasetListResponse:
+    """
+    Create datasets for a project.
+
+    This endpoint allows users to create multiple datasets for quality assurance purposes.
+    All datasets will be associated with the specified project.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        organization_id = resolve_organization_id(session, project_id)
+        response = create_datasets_service(session, organization_id, dataset_data)
+        for dataset_resp in response.datasets:
+            session.query(DatasetProject).filter(
+                DatasetProject.id == dataset_resp.id
+            ).update({"project_id": project_id})
+            session.add(
+                DatasetProjectAssociation(dataset_id=dataset_resp.id, project_id=project_id)
+            )
+        session.commit()
+        for dataset_resp in response.datasets:
+            dataset_resp.project_ids = [project_id]
+        return response
+    except ProjectNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except ValueError as e:
+        LOGGER.error(f"Failed to create datasets for project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to create datasets for project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.patch(
+    "/projects/{project_id}/qa/datasets/{dataset_id}",
+    deprecated=True,
+    response_model=DatasetResponse,
+    summary="Update Dataset",
+    tags=["Quality Assurance"],
+)
+def update_dataset_endpoint(
+    project_id: UUID,
+    dataset_id: UUID,
+    dataset_name: str,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> DatasetResponse:
+    """
+    Update dataset.
+
+    This endpoint allows users to update a single dataset.
+    Only the fields provided in the request will be updated.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        organization_id = resolve_organization_id(session, project_id)
+        if not check_dataset_belongs_to_project(session, project_id, dataset_id):
+            raise QADatasetNotInProjectError(project_id, dataset_id)
+        return update_dataset_service(session, organization_id, dataset_id, dataset_name)
+    except ProjectNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except QADatasetNotInProjectError:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Dataset {dataset_id} is not associated with project {project_id}",
+        )
+    except ValueError as e:
+        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete(
+    "/projects/{project_id}/qa/datasets",
+    deprecated=True,
+    summary="Delete Datasets",
+    tags=["Quality Assurance"],
+)
+def delete_dataset_endpoint(
+    project_id: UUID,
+    delete_data: DatasetDeleteList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> dict:
+    """
+    Delete datasets.
+
+    This endpoint allows users to delete multiple datasets at once.
+    This action cannot be undone.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        organization_id = resolve_organization_id(session, project_id)
+        for dataset_id in delete_data.dataset_ids:
+            if not check_dataset_belongs_to_project(session, project_id, dataset_id):
+                raise QADatasetNotInProjectError(project_id, dataset_id)
+        deleted_count = delete_datasets_service(session, organization_id, delete_data)
+        return {"message": f"Deleted {deleted_count} datasets successfully"}
+    except ProjectNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except QADatasetNotInProjectError as e:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Dataset {e.dataset_id} is not associated with project {project_id}",
+        ) from e
+    except ValueError as e:
+        LOGGER.error(f"Failed to delete datasets for project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to delete datasets for project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+# ── Deprecated custom columns ────────────────────────────────────────
+
+@router.get(
+    "/projects/{project_id}/qa/datasets/{dataset_id}/custom-columns",
+    deprecated=True,
+    response_model=List[QAColumnResponse],
+    summary="Get Custom Columns for Dataset",
+    tags=["Quality Assurance"],
+)
+def get_columns_by_dataset_endpoint(
+    project_id: UUID,
+    dataset_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> List[QAColumnResponse]:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return get_qa_columns_by_dataset_project_service(session, project_id, dataset_id)
+    except QADatasetNotInProjectError as e:
+        LOGGER.error(
+            f"Failed to get columns for dataset {dataset_id} in project {project_id}: {str(e)}", exc_info=True
+        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to get columns for dataset {dataset_id} in project {project_id}: {str(e)}", exc_info=True
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post(
+    "/projects/{project_id}/qa/datasets/{dataset_id}/custom-columns",
+    deprecated=True,
+    response_model=QAColumnResponse,
+    summary="Add Custom Column to Dataset",
+    tags=["Quality Assurance"],
+)
+def add_column_to_dataset_endpoint(
+    project_id: UUID,
+    dataset_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+    column_name: str = Body(..., embed=True),
+) -> QAColumnResponse:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return create_qa_column_project_service(session, project_id, dataset_id, column_name)
+    except QADatasetNotInProjectError as e:
+        LOGGER.error(f"Failed to add column to dataset {dataset_id} for project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to add column to dataset {dataset_id} for project {project_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.patch(
+    "/projects/{project_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}",
+    deprecated=True,
+    response_model=QAColumnResponse,
+    summary="Rename Custom Column",
+    tags=["Quality Assurance"],
+)
+def rename_column_endpoint(
+    project_id: UUID,
+    dataset_id: UUID,
+    column_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+    column_name: str = Body(..., embed=True),
+) -> QAColumnResponse:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return rename_qa_column_project_service(session, project_id, dataset_id, column_id, column_name)
+    except QADatasetNotInProjectError as e:
+        LOGGER.error(
+            f"Failed to rename column {column_id} in dataset {dataset_id} for project {project_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except QAColumnNotFoundError as e:
+        LOGGER.error(
+            f"Failed to rename column {column_id} in dataset {dataset_id} for project {project_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to rename column {column_id} in dataset {dataset_id} for project {project_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete(
+    "/projects/{project_id}/qa/datasets/{dataset_id}/custom-columns/{column_id}",
+    deprecated=True,
+    summary="Delete Custom Column",
+    tags=["Quality Assurance"],
+)
+def delete_column_endpoint(
+    project_id: UUID,
+    dataset_id: UUID,
+    column_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> dict:
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return delete_qa_column_project_service(session, project_id, dataset_id, column_id)
+    except QADatasetNotInProjectError as e:
+        LOGGER.error(
+            f"Failed to delete column {column_id} from dataset {dataset_id} for project {project_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except QAColumnNotFoundError as e:
+        LOGGER.error(
+            f"Failed to delete column {column_id} from dataset {dataset_id} for project {project_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to delete column {column_id} from dataset {dataset_id} for project {project_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+# ── Deprecated entries, CSV import/export ────────────────────────────
+
+@router.get(
+    "/projects/{project_id}/qa/datasets/{dataset_id}/entries",
+    deprecated=True,
+    response_model=PaginatedInputGroundtruthResponse,
+    summary="Get Input-Groundtruth Entries by Dataset",
+    tags=["Quality Assurance"],
+)
+def get_inputs_groundtruths_by_dataset_endpoint(
+    project_id: UUID,
+    dataset_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+    page: int = Query(1, ge=1, description="Page number (1-based)"),
+    page_size: int = Query(100, ge=1, le=1000, description="Number of items per page"),
+) -> PaginatedInputGroundtruthResponse:
+    """
+    Get all input-groundtruth entries for a dataset WITHOUT outputs.
+
+    This endpoint returns only the base input-groundtruth pairs for a dataset.
+    Use the /outputs endpoint to get outputs for a specific graph_runner.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return get_inputs_groundtruths_with_version_outputs_service(session, dataset_id, page, page_size)
+    except ValueError as e:
+        LOGGER.error(f"Failed to get input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to get input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.get(
+    "/projects/{project_id}/qa/datasets/{dataset_id}/outputs",
+    deprecated=True,
+    response_model=Dict[UUID, str],
+    summary="Get Outputs for a Graph Runner",
+    tags=["Quality Assurance"],
+)
+def get_outputs_endpoint(
+    project_id: UUID,
+    dataset_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    session: Session = Depends(get_db),
+    graph_runner_id: UUID = Query(..., description="Graph runner ID to get outputs for"),
+) -> Dict[UUID, str]:
+    """
+    Get outputs for a specific graph_runner.
+
+    Returns a dictionary mapping input_id (UUID) to output (string) for the specified graph_runner.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return get_outputs_by_graph_runner_service(session, dataset_id, graph_runner_id)
+    except ValueError as e:
+        LOGGER.error(
+            f"Failed to get outputs for graph runner {graph_runner_id} and dataset {dataset_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(
+            f"Failed to get outputs for graph runner {graph_runner_id} and dataset {dataset_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post(
+    "/projects/{project_id}/qa/datasets/{dataset_id}/entries",
+    deprecated=True,
+    response_model=InputGroundtruthResponseList,
+    summary="Create Input-Groundtruth Entries",
+    tags=["Quality Assurance"],
+)
+def create_input_groundtruth_endpoint(
+    project_id: UUID,
+    dataset_id: UUID,
+    input_groundtruth_data: InputGroundtruthCreateList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> InputGroundtruthResponseList:
+    """
+    Create input-groundtruth entries.
+
+    This endpoint allows users to create multiple input-groundtruth pairs for quality assurance purposes.
+    All entries will be associated with the specified dataset.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return create_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
+    except (QADuplicatePositionError, QAPartialPositionError) as e:
+        LOGGER.error(f"Failed to create input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except ValueError as e:
+        LOGGER.error(f"Failed to create input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to create input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.patch(
+    "/projects/{project_id}/qa/datasets/{dataset_id}/entries",
+    deprecated=True,
+    response_model=InputGroundtruthResponseList,
+    summary="Update Input-Groundtruth Entries",
+    tags=["Quality Assurance"],
+)
+def update_input_groundtruth_endpoint(
+    project_id: UUID,
+    dataset_id: UUID,
+    input_groundtruth_data: InputGroundtruthUpdateList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> InputGroundtruthResponseList:
+    """
+    Update input-groundtruth entries.
+
+    This endpoint allows users to update multiple input-groundtruth pairs.
+    Only the fields provided in the request will be updated.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        return update_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
+    except ValueError as e:
+        LOGGER.error(f"Failed to update input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to update input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete(
+    "/projects/{project_id}/qa/datasets/{dataset_id}/entries",
+    deprecated=True,
+    summary="Delete Input-Groundtruth Entries",
+    tags=["Quality Assurance"],
+)
+def delete_input_groundtruth_endpoint(
+    project_id: UUID,
+    dataset_id: UUID,
+    delete_data: InputGroundtruthDeleteList,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> dict:
+    """
+    Delete input-groundtruth entries.
+
+    This endpoint allows users to delete multiple input-groundtruth pairs at once.
+    This action cannot be undone.
+    """
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    try:
+        deleted_count = delete_inputs_groundtruths_service(session, dataset_id, delete_data)
+        return {"message": f"Deleted {deleted_count} input-groundtruth entries successfully"}
+    except ValueError as e:
+        LOGGER.error(f"Failed to delete input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Bad request") from e
+    except Exception as e:
+        LOGGER.error(f"Failed to delete input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
 @router.post(
     "/projects/{project_id}/qa/datasets/{dataset_id}/entries/from-history",
+    deprecated=True,
     response_model=List[InputGroundtruthResponse],
     summary="Create Entry from History",
     tags=["Quality Assurance"],
@@ -637,8 +1251,9 @@ async def create_entry_from_history(
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-@router.get(
+@router.post(
     "/projects/{project_id}/qa/datasets/{dataset_id}/export",
+    deprecated=True,
     summary="Export QA Data to CSV",
     tags=["Quality Assurance"],
 )
@@ -667,6 +1282,7 @@ def export_qa_data_to_csv_endpoint(
 
 @router.post(
     "/projects/{project_id}/qa/datasets/{dataset_id}/import",
+    deprecated=True,
     response_model=InputGroundtruthResponseList,
     summary="Import QA Data from CSV",
     tags=["Quality Assurance"],
@@ -686,10 +1302,30 @@ async def import_qa_data_from_csv_endpoint(
 
     await file.seek(0)
 
-    result = import_qa_data_from_csv_service(
-        session=session,
-        project_id=project_id,
-        dataset_id=dataset_id,
-        csv_file=file.file,
-    )
-    return result
+    try:
+        organization_id = resolve_organization_id(session, project_id)
+        result = import_qa_data_from_csv_service(
+            session=session,
+            organization_id=organization_id,
+            dataset_id=dataset_id,
+            csv_file=file.file,
+        )
+        return result
+    except ProjectNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except (
+        CSVEmptyFileError,
+        CSVInvalidJSONError,
+        CSVMissingDatasetColumnError,
+        CSVNonUniquePositionError,
+        CSVInvalidPositionError,
+    ) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except QADatasetNotInProjectError as e:
+        LOGGER.error(
+            f"Failed to import QA data for dataset {dataset_id} in project {project_id}: {str(e)}", exc_info=True
+        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        LOGGER.error(f"Failed to import QA data for dataset {dataset_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/ada_backend/routers/router_utils.py
+++ b/ada_backend/routers/router_utils.py
@@ -1,0 +1,14 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ada_backend.database.models import Project
+from ada_backend.services.errors import ProjectNotFound
+
+
+def resolve_organization_id(session: Session, project_id: UUID) -> UUID:
+    """Look up the organization_id that owns the given project."""
+    org_id = session.query(Project.organization_id).filter(Project.id == project_id).scalar()
+    if org_id is None:
+        raise ProjectNotFound(f"Project {project_id} not found")
+    return org_id

--- a/ada_backend/schemas/dataset_schema.py
+++ b/ada_backend/schemas/dataset_schema.py
@@ -28,8 +28,9 @@ class DatasetResponse(BaseModel):
     """Schema for dataset response."""
 
     id: UUID
-    project_id: UUID
+    organization_id: UUID
     dataset_name: str
+    project_ids: List[UUID] = []
     created_at: datetime
     updated_at: datetime
 
@@ -41,3 +42,9 @@ class DatasetListResponse(BaseModel):
     """Schema for multiple dataset responses."""
 
     datasets: List[DatasetResponse]
+
+
+class DatasetProjectAssociationRequest(BaseModel):
+    """Schema for associating/disassociating datasets with projects."""
+
+    project_ids: List[UUID]

--- a/ada_backend/schemas/llm_judges_schema.py
+++ b/ada_backend/schemas/llm_judges_schema.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -20,7 +20,8 @@ class LLMJudgeResponse(LLMJudgeCreate):
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
-    project_id: UUID
+    organization_id: UUID
+    project_ids: List[UUID] = []
     created_at: datetime
     updated_at: datetime
 
@@ -39,3 +40,9 @@ class LLMJudgeTemplate(BaseModel):
     llm_model_reference: Optional[str] = None
     prompt_template: str
     temperature: Optional[float] = None
+
+
+class LLMJudgeProjectAssociationRequest(BaseModel):
+    """Schema for associating/disassociating judges with projects."""
+
+    project_ids: List[UUID]

--- a/ada_backend/services/errors.py
+++ b/ada_backend/services/errors.py
@@ -169,10 +169,13 @@ class EnvironmentNotFound(ServiceError):
 class LLMJudgeNotFound(ServiceError):
     status_code = 404
 
-    def __init__(self, judge_id: UUID, project_id: UUID):
+    def __init__(self, judge_id: UUID, organization_id: UUID | None = None):
         self.judge_id = judge_id
-        self.project_id = project_id
-        super().__init__(f"LLM judge {judge_id} not found in project {project_id}")
+        self.organization_id = organization_id
+        if organization_id is not None:
+            super().__init__(f"LLM judge {judge_id} not found in organization {organization_id}")
+        else:
+            super().__init__(f"LLM judge {judge_id} not found")
 
 
 class SourceNotFound(ServiceError):

--- a/ada_backend/services/qa/llm_judges_service.py
+++ b/ada_backend/services/qa/llm_judges_service.py
@@ -4,13 +4,14 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import EvaluationType, LLMJudge
+from ada_backend.database.models import EvaluationType
 from ada_backend.repositories.llm_judges_repository import (
     create_llm_judge,
     delete_llm_judges,
-    get_judge_project_associations,
+    get_llm_judge_by_id,
     get_llm_judges_by_organization,
     get_llm_judges_by_project,
+    get_valid_project_ids_for_organization,
     set_judge_project_associations,
     update_llm_judge,
 )
@@ -20,7 +21,7 @@ from ada_backend.schemas.llm_judges_schema import (
     LLMJudgeTemplate,
     LLMJudgeUpdate,
 )
-from ada_backend.services.errors import LLMJudgeNotFound
+from ada_backend.services.errors import LLMJudgeNotFound, ProjectNotFound
 from ada_backend.services.qa.utils import (
     DEFAULT_BOOLEAN_PROMPT,
     DEFAULT_FREE_TEXT_PROMPT,
@@ -31,8 +32,7 @@ from ada_backend.services.qa.utils import (
 LOGGER = logging.getLogger(__name__)
 
 
-def _judge_to_response(session: Session, judge) -> LLMJudgeResponse:
-    project_ids = get_judge_project_associations(session, judge.id)
+def _judge_to_response(judge) -> LLMJudgeResponse:
     return LLMJudgeResponse(
         id=judge.id,
         organization_id=judge.organization_id,
@@ -42,7 +42,7 @@ def _judge_to_response(session: Session, judge) -> LLMJudgeResponse:
         llm_model_reference=judge.llm_model_reference,
         prompt_template=judge.prompt_template,
         temperature=judge.temperature,
-        project_ids=project_ids,
+        project_ids=[assoc.project_id for assoc in judge.project_associations],
         created_at=judge.created_at,
         updated_at=judge.updated_at,
     )
@@ -54,7 +54,7 @@ def get_llm_judges_by_project_service(
 ) -> List[LLMJudgeResponse]:
     try:
         judges = get_llm_judges_by_project(session=session, project_id=project_id)
-        return [LLMJudgeResponse.model_validate(judge) for judge in judges]
+        return [_judge_to_response(judge) for judge in judges]
     except Exception as e:
         LOGGER.error(f"Error in get_llm_judges_by_project_service for project {project_id}: {str(e)}")
         raise ValueError(f"Failed to list LLM judges: {str(e)}") from e
@@ -66,7 +66,7 @@ def get_llm_judges_by_organization_service(
 ) -> List[LLMJudgeResponse]:
     try:
         judges = get_llm_judges_by_organization(session=session, organization_id=organization_id)
-        return [_judge_to_response(session, judge) for judge in judges]
+        return [_judge_to_response(judge) for judge in judges]
     except Exception as e:
         LOGGER.error(f"Error in get_llm_judges_by_organization_service for org {organization_id}: {str(e)}")
         raise ValueError(f"Failed to list LLM judges: {str(e)}") from e
@@ -109,7 +109,7 @@ def create_llm_judge_service(
             temperature=judge_data.temperature,
         )
         LOGGER.info(f"Created LLM judge {llm_judge.id} for organization {organization_id}")
-        return _judge_to_response(session, llm_judge)
+        return _judge_to_response(llm_judge)
     except Exception as e:
         LOGGER.error(f"Error in create_llm_judge_service for organization {organization_id}: {str(e)}")
         raise ValueError(f"Failed to create LLM judge: {str(e)}") from e
@@ -136,7 +136,7 @@ def update_llm_judge_service(
         if not updated_judge:
             raise LLMJudgeNotFound(judge_id=judge_id, organization_id=organization_id)
         LOGGER.info(f"Updated LLM judge {judge_id} for organization {organization_id}")
-        return _judge_to_response(session, updated_judge)
+        return _judge_to_response(updated_judge)
     except LLMJudgeNotFound:
         raise
     except Exception as e:
@@ -167,11 +167,16 @@ def set_judge_projects_service(
     judge_id: UUID,
     project_ids: List[UUID],
 ) -> LLMJudgeResponse:
-    judge = (
-        session.query(LLMJudge).filter(LLMJudge.id == judge_id, LLMJudge.organization_id == organization_id).first()
-    )
+    judge = get_llm_judge_by_id(session, judge_id, organization_id=organization_id)
     if not judge:
         raise LLMJudgeNotFound(judge_id=judge_id, organization_id=organization_id)
 
+    if project_ids:
+        valid_ids = get_valid_project_ids_for_organization(session, project_ids, organization_id)
+        invalid_ids = set(project_ids) - valid_ids
+        if invalid_ids:
+            raise ProjectNotFound(project_id=next(iter(invalid_ids)))
+
     set_judge_project_associations(session, judge_id, project_ids)
-    return _judge_to_response(session, judge)
+    session.refresh(judge)
+    return _judge_to_response(judge)

--- a/ada_backend/services/qa/llm_judges_service.py
+++ b/ada_backend/services/qa/llm_judges_service.py
@@ -4,11 +4,14 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import EvaluationType
+from ada_backend.database.models import EvaluationType, LLMJudge
 from ada_backend.repositories.llm_judges_repository import (
     create_llm_judge,
     delete_llm_judges,
+    get_judge_project_associations,
+    get_llm_judges_by_organization,
     get_llm_judges_by_project,
+    set_judge_project_associations,
     update_llm_judge,
 )
 from ada_backend.schemas.llm_judges_schema import (
@@ -28,6 +31,23 @@ from ada_backend.services.qa.utils import (
 LOGGER = logging.getLogger(__name__)
 
 
+def _judge_to_response(session: Session, judge) -> LLMJudgeResponse:
+    project_ids = get_judge_project_associations(session, judge.id)
+    return LLMJudgeResponse(
+        id=judge.id,
+        organization_id=judge.organization_id,
+        name=judge.name,
+        description=judge.description,
+        evaluation_type=judge.evaluation_type,
+        llm_model_reference=judge.llm_model_reference,
+        prompt_template=judge.prompt_template,
+        temperature=judge.temperature,
+        project_ids=project_ids,
+        created_at=judge.created_at,
+        updated_at=judge.updated_at,
+    )
+
+
 def get_llm_judges_by_project_service(
     session: Session,
     project_id: UUID,
@@ -37,6 +57,18 @@ def get_llm_judges_by_project_service(
         return [LLMJudgeResponse.model_validate(judge) for judge in judges]
     except Exception as e:
         LOGGER.error(f"Error in get_llm_judges_by_project_service for project {project_id}: {str(e)}")
+        raise ValueError(f"Failed to list LLM judges: {str(e)}") from e
+
+
+def get_llm_judges_by_organization_service(
+    session: Session,
+    organization_id: UUID,
+) -> List[LLMJudgeResponse]:
+    try:
+        judges = get_llm_judges_by_organization(session=session, organization_id=organization_id)
+        return [_judge_to_response(session, judge) for judge in judges]
+    except Exception as e:
+        LOGGER.error(f"Error in get_llm_judges_by_organization_service for org {organization_id}: {str(e)}")
         raise ValueError(f"Failed to list LLM judges: {str(e)}") from e
 
 
@@ -62,13 +94,13 @@ def get_llm_judge_defaults_service(
 
 def create_llm_judge_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     judge_data: LLMJudgeCreate,
 ) -> LLMJudgeResponse:
     try:
         llm_judge = create_llm_judge(
             session=session,
-            project_id=project_id,
+            organization_id=organization_id,
             name=judge_data.name,
             description=judge_data.description,
             evaluation_type=judge_data.evaluation_type,
@@ -76,16 +108,16 @@ def create_llm_judge_service(
             prompt_template=judge_data.prompt_template,
             temperature=judge_data.temperature,
         )
-        LOGGER.info(f"Created LLM judge {llm_judge.id} for project {project_id}")
-        return LLMJudgeResponse.model_validate(llm_judge)
+        LOGGER.info(f"Created LLM judge {llm_judge.id} for organization {organization_id}")
+        return _judge_to_response(session, llm_judge)
     except Exception as e:
-        LOGGER.error(f"Error in create_llm_judge_service for project {project_id}: {str(e)}")
+        LOGGER.error(f"Error in create_llm_judge_service for organization {organization_id}: {str(e)}")
         raise ValueError(f"Failed to create LLM judge: {str(e)}") from e
 
 
 def update_llm_judge_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     judge_id: UUID,
     judge_data: LLMJudgeUpdate,
 ) -> LLMJudgeResponse:
@@ -93,7 +125,7 @@ def update_llm_judge_service(
         updated_judge = update_llm_judge(
             session=session,
             judge_id=judge_id,
-            project_id=project_id,
+            organization_id=organization_id,
             name=judge_data.name,
             description=judge_data.description,
             evaluation_type=judge_data.evaluation_type,
@@ -102,9 +134,9 @@ def update_llm_judge_service(
             temperature=judge_data.temperature,
         )
         if not updated_judge:
-            raise LLMJudgeNotFound(judge_id=judge_id, project_id=project_id)
-        LOGGER.info(f"Updated LLM judge {judge_id} for project {project_id}")
-        return LLMJudgeResponse.model_validate(updated_judge)
+            raise LLMJudgeNotFound(judge_id=judge_id, organization_id=organization_id)
+        LOGGER.info(f"Updated LLM judge {judge_id} for organization {organization_id}")
+        return _judge_to_response(session, updated_judge)
     except LLMJudgeNotFound:
         raise
     except Exception as e:
@@ -114,16 +146,32 @@ def update_llm_judge_service(
 
 def delete_llm_judges_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     judge_ids: List[UUID],
 ) -> None:
     try:
         deleted_count = delete_llm_judges(
             session=session,
             judge_ids=judge_ids,
-            project_id=project_id,
+            organization_id=organization_id,
         )
-        LOGGER.info(f"Deleted {deleted_count} LLM judges for project {project_id}")
+        LOGGER.info(f"Deleted {deleted_count} LLM judges for organization {organization_id}")
     except Exception as e:
-        LOGGER.error(f"Error in delete_llm_judges_service for project {project_id}: {str(e)}")
+        LOGGER.error(f"Error in delete_llm_judges_service for organization {organization_id}: {str(e)}")
         raise ValueError(f"Failed to delete LLM judges: {str(e)}") from e
+
+
+def set_judge_projects_service(
+    session: Session,
+    organization_id: UUID,
+    judge_id: UUID,
+    project_ids: List[UUID],
+) -> LLMJudgeResponse:
+    judge = (
+        session.query(LLMJudge).filter(LLMJudge.id == judge_id, LLMJudge.organization_id == organization_id).first()
+    )
+    if not judge:
+        raise LLMJudgeNotFound(judge_id=judge_id, organization_id=organization_id)
+
+    set_judge_project_associations(session, judge_id, project_ids)
+    return _judge_to_response(session, judge)

--- a/ada_backend/services/qa/qa_error.py
+++ b/ada_backend/services/qa/qa_error.py
@@ -115,6 +115,15 @@ class QADatasetNotInProjectError(QAServiceError):
         super().__init__(f"Dataset {dataset_id} not found in project {project_id}")
 
 
+class QADatasetNotInOrganizationError(QAServiceError):
+    """Raised when a dataset does not belong to the given organization"""
+
+    def __init__(self, organization_id: UUID, dataset_id: UUID):
+        self.organization_id = organization_id
+        self.dataset_id = dataset_id
+        super().__init__(f"Dataset {dataset_id} not found in organization {organization_id}")
+
+
 class QAColumnNotFoundError(QAServiceError):
     status_code = 404
 

--- a/ada_backend/services/qa/qa_evaluation_service.py
+++ b/ada_backend/services/qa/qa_evaluation_service.py
@@ -74,7 +74,7 @@ def _setup_judge_evaluation_context(
         judge_id=judge_id,
     )
     if not judge:
-        raise LLMJudgeNotFound(judge_id, project_id)
+        raise LLMJudgeNotFound(judge_id)
 
     version_output_data = get_version_output(
         session=session,
@@ -145,7 +145,7 @@ async def run_judge_evaluation_service(
     try:
         judge = get_llm_judge_by_id(session=session, judge_id=judge_id)
         if not judge:
-            raise LLMJudgeNotFound(judge_id, project_id)
+            raise LLMJudgeNotFound(judge_id)
 
         # TODO: Deterministic evaluations will have their own dedicated service and endpoint
         # - The function as it was before was EXACTLY what is in the "else" :

--- a/ada_backend/services/qa/qa_metadata_service.py
+++ b/ada_backend/services/qa/qa_metadata_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from ada_backend.repositories.quality_assurance_repository import (
     check_column_exist,
+    check_dataset_belongs_to_organization,
     check_dataset_belongs_to_project,
     create_custom_column,
     delete_custom_column,
@@ -16,110 +17,126 @@ from ada_backend.repositories.quality_assurance_repository import (
     rename_custom_column,
 )
 from ada_backend.schemas.qa_metadata_schema import QAColumnResponse
-from ada_backend.services.qa.qa_error import QAColumnNotFoundError, QADatasetNotInProjectError
+from ada_backend.services.qa.qa_error import (
+    QAColumnNotFoundError,
+    QADatasetNotInOrganizationError,
+    QADatasetNotInProjectError,
+)
 
 LOGGER = logging.getLogger(__name__)
 
 
+# ── Internal helpers ──────────────────────────────────────────────────
+
+def _validate_dataset_ownership_org(session: Session, organization_id: UUID, dataset_id: UUID) -> None:
+    if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
+        raise QADatasetNotInOrganizationError(organization_id, dataset_id)
+
+
+def _validate_dataset_ownership_project(session: Session, project_id: UUID, dataset_id: UUID) -> None:
+    if not check_dataset_belongs_to_project(session, project_id, dataset_id):
+        raise QADatasetNotInProjectError(project_id, dataset_id)
+
+
+def _validate_column_exists(session: Session, dataset_id: UUID, column_id: UUID) -> None:
+    if not check_column_exist(session, dataset_id, column_id):
+        raise QAColumnNotFoundError(dataset_id, column_id)
+
+
+# ── Core operations (ownership-agnostic) ──────────────────────────────
+
+def _get_columns(session: Session, dataset_id: UUID) -> List[QAColumnResponse]:
+    columns = get_qa_columns_by_dataset(session, dataset_id)
+    return [QAColumnResponse.model_validate(col) for col in columns]
+
+
+def _create_column(session: Session, dataset_id: UUID, column_name: str) -> QAColumnResponse:
+    max_position = get_dataset_custom_columns_display_max_position(session, dataset_id)
+    new_position = (max_position + 1) if max_position is not None else 0
+    column_id = uuid.uuid4()
+    qa_metadata = create_custom_column(
+        session=session,
+        dataset_id=dataset_id,
+        column_id=column_id,
+        column_name=column_name,
+        column_display_position=new_position,
+    )
+    return QAColumnResponse.model_validate(qa_metadata)
+
+
+def _rename_column(session: Session, dataset_id: UUID, column_id: UUID, column_name: str) -> QAColumnResponse:
+    _validate_column_exists(session, dataset_id, column_id)
+    qa_metadata = rename_custom_column(
+        session=session,
+        dataset_id=dataset_id,
+        column_id=column_id,
+        column_name=column_name,
+    )
+    return QAColumnResponse.model_validate(qa_metadata)
+
+
+def _delete_column(session: Session, dataset_id: UUID, column_id: UUID) -> dict:
+    _validate_column_exists(session, dataset_id, column_id)
+    remove_column_value_from_custom_column(session, dataset_id, column_id)
+    delete_custom_column(session, dataset_id, column_id)
+    return {"message": f"Deleted column {column_id} successfully"}
+
+
+# ── Organization-scoped public API ────────────────────────────────────
+
 def get_qa_columns_by_dataset_service(
-    session: Session,
-    project_id: UUID,
-    dataset_id: UUID,
+    session: Session, organization_id: UUID, dataset_id: UUID,
 ) -> List[QAColumnResponse]:
-    try:
-        dataset_existence = check_dataset_belongs_to_project(session, project_id, dataset_id)
-        if not dataset_existence:
-            raise QADatasetNotInProjectError(project_id, dataset_id)
-
-        columns = get_qa_columns_by_dataset(session, dataset_id)
-
-        return [QAColumnResponse.model_validate(col) for col in columns]
-    except QADatasetNotInProjectError:
-        raise
+    _validate_dataset_ownership_org(session, organization_id, dataset_id)
+    return _get_columns(session, dataset_id)
 
 
 def create_qa_column_service(
-    session: Session,
-    project_id: UUID,
-    dataset_id: UUID,
-    column_name: str,
+    session: Session, organization_id: UUID, dataset_id: UUID, column_name: str,
 ) -> QAColumnResponse:
-    try:
-        dataset_existence = check_dataset_belongs_to_project(session, project_id, dataset_id)
-        if not dataset_existence:
-            raise QADatasetNotInProjectError(project_id, dataset_id)
-
-        max_position = get_dataset_custom_columns_display_max_position(session, dataset_id)
-        new_position = (max_position + 1) if max_position is not None else 0
-
-        column_id = uuid.uuid4()
-
-        qa_metadata = create_custom_column(
-            session=session,
-            dataset_id=dataset_id,
-            column_id=column_id,
-            column_name=column_name,
-            column_display_position=new_position,
-        )
-
-        return QAColumnResponse.model_validate(qa_metadata)
-    except QADatasetNotInProjectError:
-        LOGGER.error(f"Dataset {dataset_id} not found in project {project_id}")
-        raise
+    _validate_dataset_ownership_org(session, organization_id, dataset_id)
+    return _create_column(session, dataset_id, column_name)
 
 
 def rename_qa_column_service(
-    session: Session,
-    project_id: UUID,
-    dataset_id: UUID,
-    column_id: UUID,
-    column_name: str,
+    session: Session, organization_id: UUID, dataset_id: UUID, column_id: UUID, column_name: str,
 ) -> QAColumnResponse:
-    try:
-        dataset_existence = check_dataset_belongs_to_project(session, project_id, dataset_id)
-        if not dataset_existence:
-            raise QADatasetNotInProjectError(project_id, dataset_id)
-
-        column_existence = check_column_exist(session, dataset_id, column_id)
-        if not column_existence:
-            raise QAColumnNotFoundError(dataset_id, column_id)
-
-        qa_metadata = rename_custom_column(
-            session=session,
-            dataset_id=dataset_id,
-            column_id=column_id,
-            column_name=column_name,
-        )
-
-        LOGGER.info(
-            f"Renamed QA column {column_id} to '{column_name}' for dataset {dataset_id} in project {project_id}"
-        )
-
-        return QAColumnResponse.model_validate(qa_metadata)
-    except (QADatasetNotInProjectError, QAColumnNotFoundError):
-        raise
+    _validate_dataset_ownership_org(session, organization_id, dataset_id)
+    return _rename_column(session, dataset_id, column_id, column_name)
 
 
 def delete_qa_column_service(
-    session: Session,
-    project_id: UUID,
-    dataset_id: UUID,
-    column_id: UUID,
+    session: Session, organization_id: UUID, dataset_id: UUID, column_id: UUID,
 ) -> dict:
-    try:
-        dataset_existence = check_dataset_belongs_to_project(session, project_id, dataset_id)
-        if not dataset_existence:
-            raise QADatasetNotInProjectError(project_id, dataset_id)
+    _validate_dataset_ownership_org(session, organization_id, dataset_id)
+    return _delete_column(session, dataset_id, column_id)
 
-        column_existence = check_column_exist(session, dataset_id, column_id)
-        if not column_existence:
-            raise QAColumnNotFoundError(dataset_id, column_id)
 
-        remove_column_value_from_custom_column(session, dataset_id, column_id)
-        delete_custom_column(session, dataset_id, column_id)
+# ── Deprecated project-scoped public API ──────────────────────────────
 
-        LOGGER.info(f"Deleted QA column {column_id} from dataset {dataset_id} in project {project_id}")
+def get_qa_columns_by_dataset_project_service(
+    session: Session, project_id: UUID, dataset_id: UUID,
+) -> List[QAColumnResponse]:
+    _validate_dataset_ownership_project(session, project_id, dataset_id)
+    return _get_columns(session, dataset_id)
 
-        return {"message": f"Deleted column {column_id} successfully"}
-    except (QADatasetNotInProjectError, QAColumnNotFoundError):
-        raise
+
+def create_qa_column_project_service(
+    session: Session, project_id: UUID, dataset_id: UUID, column_name: str,
+) -> QAColumnResponse:
+    _validate_dataset_ownership_project(session, project_id, dataset_id)
+    return _create_column(session, dataset_id, column_name)
+
+
+def rename_qa_column_project_service(
+    session: Session, project_id: UUID, dataset_id: UUID, column_id: UUID, column_name: str,
+) -> QAColumnResponse:
+    _validate_dataset_ownership_project(session, project_id, dataset_id)
+    return _rename_column(session, dataset_id, column_id, column_name)
+
+
+def delete_qa_column_project_service(
+    session: Session, project_id: UUID, dataset_id: UUID, column_id: UUID,
+) -> dict:
+    _validate_dataset_ownership_project(session, project_id, dataset_id)
+    return _delete_column(session, dataset_id, column_id)

--- a/ada_backend/services/qa/quality_assurance_service.py
+++ b/ada_backend/services/qa/quality_assurance_service.py
@@ -156,7 +156,9 @@ def get_version_output_ids_by_input_ids_and_graph_runner_service(
     session: Session,
     input_ids: List[UUID],
     graph_runner_id: UUID,
+    project_id: UUID,
 ) -> Dict[UUID, Optional[UUID]]:
+    _validate_env_binding(session, project_id, graph_runner_id)
     return get_version_output_ids_by_input_ids_and_graph_runner(
         session=session, input_ids=input_ids, graph_runner_id=graph_runner_id
     )

--- a/ada_backend/services/qa/quality_assurance_service.py
+++ b/ada_backend/services/qa/quality_assurance_service.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import CallType, QASession, RunStatus
+from ada_backend.database.models import CallType, DatasetProject, Project, QASession, RunStatus
 from ada_backend.database.setup_db import get_db_session
 from ada_backend.repositories.env_repository import get_env_relationship_by_graph_runner_id
 from ada_backend.repositories.qa_evaluation_repository import delete_evaluations_for_input_ids
@@ -21,12 +21,15 @@ from ada_backend.repositories.qa_session_repository import (
     update_qa_session_status,
 )
 from ada_backend.repositories.quality_assurance_repository import (
+    check_dataset_belongs_to_organization,
     check_dataset_belongs_to_project,
     clear_version_outputs_for_input_ids,
     create_datasets,
     create_inputs_groundtruths,
     delete_datasets,
     delete_inputs_groundtruths,
+    get_dataset_project_associations,
+    get_datasets_by_organization,
     get_datasets_by_project,
     get_inputs_groundtruths_by_dataset,
     get_inputs_groundtruths_by_ids,
@@ -35,6 +38,7 @@ from ada_backend.repositories.quality_assurance_repository import (
     get_positions_of_dataset,
     get_qa_columns_by_dataset,
     get_version_output_ids_by_input_ids_and_graph_runner,
+    set_dataset_project_associations,
     update_dataset,
     update_inputs_groundtruths,
     upsert_version_output,
@@ -579,20 +583,22 @@ def delete_inputs_groundtruths_service(
         raise ValueError(f"Failed to delete input-groundtruth entries: {str(e)}") from e
 
 
+def _dataset_to_response(session: Session, dataset) -> DatasetResponse:
+    project_ids = get_dataset_project_associations(session, dataset.id)
+    return DatasetResponse(
+        id=dataset.id,
+        organization_id=dataset.organization_id,
+        dataset_name=dataset.dataset_name,
+        project_ids=project_ids,
+        created_at=dataset.created_at,
+        updated_at=dataset.updated_at,
+    )
+
+
 def get_datasets_by_project_service(
     session: Session,
     project_id: UUID,
 ) -> List[DatasetResponse]:
-    """
-    Get all datasets for a project.
-
-    Args:
-        session (Session): SQLAlchemy session
-        project_id (UUID): ID of the project
-
-    Returns:
-        List[DatasetResponse]: List of datasets
-    """
     try:
         datasets = get_datasets_by_project(session, project_id)
         return [DatasetResponse.model_validate(dataset) for dataset in datasets]
@@ -601,31 +607,34 @@ def get_datasets_by_project_service(
         raise ValueError(f"Failed to get datasets: {str(e)}") from e
 
 
+def get_datasets_by_organization_service(
+    session: Session,
+    organization_id: UUID,
+) -> List[DatasetResponse]:
+    try:
+        datasets = get_datasets_by_organization(session, organization_id)
+        return [_dataset_to_response(session, dataset) for dataset in datasets]
+    except Exception as e:
+        LOGGER.error(f"Error in get_datasets_by_organization_service: {str(e)}")
+        raise ValueError(f"Failed to get datasets: {str(e)}") from e
+
+
 def create_datasets_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     datasets_data: DatasetCreateList,
 ) -> DatasetListResponse:
-    """
-    Create datasets.
-
-    Args:
-        session (Session): SQLAlchemy session
-        project_id (UUID): ID of the project
-        datasets_data (DatasetCreateList): Dataset data to create
-
-    Returns:
-        DatasetListResponse: The created datasets
-    """
     try:
         created_datasets = create_datasets(
             session,
-            project_id,
+            organization_id,
             datasets_data.datasets_name,
         )
 
-        LOGGER.info(f"Created {len(created_datasets)} datasets for project {project_id}")
-        return DatasetListResponse(datasets=[DatasetResponse.model_validate(dataset) for dataset in created_datasets])
+        LOGGER.info(f"Created {len(created_datasets)} datasets for organization {organization_id}")
+        return DatasetListResponse(
+            datasets=[_dataset_to_response(session, dataset) for dataset in created_datasets]
+        )
     except Exception as e:
         LOGGER.error(f"Error in create_datasets_service: {str(e)}")
         raise ValueError(f"Failed to create datasets: {str(e)}") from e
@@ -633,36 +642,26 @@ def create_datasets_service(
 
 def update_dataset_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     dataset_id: UUID,
     dataset_name: str,
 ) -> DatasetResponse:
-    """
-    Update a single dataset.
-
-    Args:
-        session (Session): SQLAlchemy session
-        project_id (UUID): ID of the project
-        dataset_id (UUID): ID of the dataset to update
-        dataset_name (str): New name for the dataset
-
-    Returns:
-        DatasetResponse: The updated dataset
-    """
-    if not check_dataset_belongs_to_project(session, project_id, dataset_id):
-        LOGGER.error(f"Failed to update dataset {dataset_id}: Dataset {dataset_id} not found in project {project_id}")
-        raise QADatasetNotInProjectError(project_id, dataset_id)
+    if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
+        LOGGER.error(
+            f"Failed to update dataset {dataset_id}: not found in organization {organization_id}"
+        )
+        raise ValueError(f"Dataset {dataset_id} not found in organization {organization_id}")
 
     try:
         updated_dataset = update_dataset(
             session,
             dataset_id,
             dataset_name,
-            project_id,
+            organization_id,
         )
 
-        LOGGER.info(f"Updated dataset {dataset_id} with name '{dataset_name}' for project {project_id}")
-        return DatasetResponse.model_validate(updated_dataset)
+        LOGGER.info(f"Updated dataset {dataset_id} with name '{dataset_name}' for organization {organization_id}")
+        return _dataset_to_response(session, updated_dataset)
     except Exception as e:
         LOGGER.error(f"Error in update_dataset_service: {str(e)}")
         raise ValueError(f"Failed to update dataset: {str(e)}") from e
@@ -670,40 +669,54 @@ def update_dataset_service(
 
 def delete_datasets_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     delete_data: DatasetDeleteList,
 ) -> int:
-    """
-    Delete multiple datasets.
-
-    Args:
-        session (Session): SQLAlchemy session
-        project_id (UUID): ID of the project
-        delete_data (DatasetDeleteList): IDs of datasets to delete
-
-    Returns:
-        int: Number of deleted datasets
-    """
     for dataset_id in delete_data.dataset_ids:
-        if not check_dataset_belongs_to_project(session, project_id, dataset_id):
+        if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
             LOGGER.error(
-                f"Failed to delete datasets for project {project_id}: "
-                f"Dataset {dataset_id} not found in project {project_id}"
+                f"Failed to delete datasets for organization {organization_id}: "
+                f"Dataset {dataset_id} not found in organization {organization_id}"
             )
-            raise QADatasetNotInProjectError(project_id, dataset_id)
+            raise ValueError(f"Dataset {dataset_id} not found in organization {organization_id}")
 
     try:
         deleted_count = delete_datasets(
             session,
             delete_data.dataset_ids,
-            project_id,
+            organization_id,
         )
 
-        LOGGER.info(f"Deleted {deleted_count} datasets for project {project_id}")
+        LOGGER.info(f"Deleted {deleted_count} datasets for organization {organization_id}")
         return deleted_count
     except Exception as e:
         LOGGER.error(f"Error in delete_datasets_service: {str(e)}")
         raise ValueError(f"Failed to delete datasets: {str(e)}") from e
+
+
+def set_dataset_projects_service(
+    session: Session,
+    organization_id: UUID,
+    dataset_id: UUID,
+    project_ids: List[UUID],
+) -> DatasetResponse:
+    if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
+        raise ValueError(f"Dataset {dataset_id} not found in organization {organization_id}")
+
+    if project_ids:
+        projects = session.query(Project.id, Project.organization_id).filter(Project.id.in_(project_ids)).all()
+        found_ids = {p.id for p in projects}
+        missing = set(project_ids) - found_ids
+        if missing:
+            raise ValueError(f"Projects not found: {sorted(missing)}")
+        foreign = {p.id for p in projects if p.organization_id != organization_id}
+        if foreign:
+            raise ValueError(f"Projects do not belong to organization {organization_id}: {sorted(foreign)}")
+
+    set_dataset_project_associations(session, dataset_id, project_ids)
+
+    dataset = session.query(DatasetProject).filter(DatasetProject.id == dataset_id).first()
+    return _dataset_to_response(session, dataset)
 
 
 def save_conversation_to_groundtruth_service(
@@ -788,7 +801,7 @@ def export_qa_data_to_csv_service(
 
 def import_qa_data_from_csv_service(
     session: Session,
-    project_id: UUID,
+    organization_id: UUID,
     dataset_id: UUID,
     csv_file: BinaryIO,
 ) -> InputGroundtruthResponseList:
@@ -813,7 +826,7 @@ def import_qa_data_from_csv_service(
         for column_name in custom_columns_to_add:
             create_qa_column_service(
                 session=session,
-                project_id=project_id,
+                organization_id=organization_id,
                 dataset_id=dataset_id,
                 column_name=column_name,
             )

--- a/frontend/src/api/qa.ts
+++ b/frontend/src/api/qa.ts
@@ -10,61 +10,72 @@ interface QAProcessRunPayload {
 }
 
 export const qaApi = {
-  getDatasets: (projectId: string) => $api(`/projects/${projectId}/qa/datasets`),
+  // Organization-scoped dataset CRUD
+  getDatasets: (orgId: string) => $api(`/organizations/${orgId}/qa/datasets`),
 
-  createDatasets: (projectId: string, data: { datasets_name: string[] }) =>
-    $api(`/projects/${projectId}/qa/datasets`, { method: 'POST', body: data }),
+  createDatasets: (orgId: string, data: { datasets_name: string[] }) =>
+    $api(`/organizations/${orgId}/qa/datasets`, { method: 'POST', body: data }),
 
-  updateDataset: (projectId: string, datasetId: string, datasetName: string) =>
-    $api(`/projects/${projectId}/qa/datasets/${datasetId}`, {
+  updateDataset: (orgId: string, datasetId: string, datasetName: string) =>
+    $api(`/organizations/${orgId}/qa/datasets/${datasetId}`, {
       method: 'PATCH',
       query: { dataset_name: datasetName },
     }),
 
-  deleteDatasets: (projectId: string, data: { dataset_ids: string[] }) =>
-    $api(`/projects/${projectId}/qa/datasets`, { method: 'DELETE', body: data }),
+  deleteDatasets: (orgId: string, data: { dataset_ids: string[] }) =>
+    $api(`/organizations/${orgId}/qa/datasets`, { method: 'DELETE', body: data }),
 
-  getInputGroundtruths: (projectId: string, datasetId: string, params?: { page?: number; page_size?: number }) =>
-    $api(`/projects/${projectId}/qa/datasets/${datasetId}/entries`, { query: params }),
+  setDatasetProjects: (orgId: string, datasetId: string, projectIds: string[]) =>
+    $api(`/organizations/${orgId}/qa/datasets/${datasetId}/projects`, {
+      method: 'PUT',
+      body: { project_ids: projectIds },
+    }),
 
-  getOutputs: (projectId: string, datasetId: string, graphRunnerId: string) =>
-    $api(`/projects/${projectId}/qa/datasets/${datasetId}/outputs`, { query: { graph_runner_id: graphRunnerId } }),
+  // Organization-scoped entries
+  getInputGroundtruths: (orgId: string, datasetId: string, params?: { page?: number; page_size?: number }) =>
+    $api(`/organizations/${orgId}/qa/datasets/${datasetId}/entries`, { query: params }),
 
-  saveTraceToQA: (projectId: string, traceId: string, datasetId: string) =>
-    $api(`/projects/${projectId}/qa/datasets/${datasetId}/entries/from-history`, {
+  getOutputs: (orgId: string, datasetId: string, graphRunnerId: string) =>
+    $api(`/organizations/${orgId}/qa/datasets/${datasetId}/outputs`, { query: { graph_runner_id: graphRunnerId } }),
+
+  saveTraceToQA: (orgId: string, traceId: string, datasetId: string) =>
+    $api(`/organizations/${orgId}/qa/datasets/${datasetId}/entries/from-history`, {
       method: 'POST',
-      query: {
-        trace_id: traceId,
-      },
+      query: { trace_id: traceId },
     }),
 
   createInputGroundtruths: (
-    projectId: string,
+    orgId: string,
     datasetId: string,
     data: { inputs_groundtruths: Array<{ input: any; groundtruth: string }> }
-  ) => $api(`/projects/${projectId}/qa/datasets/${datasetId}/entries`, { method: 'POST', body: data }),
+  ) => $api(`/organizations/${orgId}/qa/datasets/${datasetId}/entries`, { method: 'POST', body: data }),
 
   updateInputGroundtruths: (
-    projectId: string,
+    orgId: string,
     datasetId: string,
     data: { inputs_groundtruths: Array<{ id: string; input?: any; groundtruth?: string }> }
-  ) => $api(`/projects/${projectId}/qa/datasets/${datasetId}/entries`, { method: 'PATCH', body: data }),
+  ) => $api(`/organizations/${orgId}/qa/datasets/${datasetId}/entries`, { method: 'PATCH', body: data }),
 
-  deleteInputGroundtruths: (projectId: string, datasetId: string, data: { input_groundtruth_ids: string[] }) =>
-    $api(`/projects/${projectId}/qa/datasets/${datasetId}/entries`, { method: 'DELETE', body: data }),
+  deleteInputGroundtruths: (orgId: string, datasetId: string, data: { input_groundtruth_ids: string[] }) =>
+    $api(`/organizations/${orgId}/qa/datasets/${datasetId}/entries`, { method: 'DELETE', body: data }),
 
-  getCustomColumns: (projectId: string, datasetId: string) =>
-    $api(`/projects/${projectId}/qa/datasets/${datasetId}/custom-columns`),
+  // Organization-scoped custom columns
+  getCustomColumns: (orgId: string, datasetId: string) =>
+    $api(`/organizations/${orgId}/qa/datasets/${datasetId}/custom-columns`),
 
-  createCustomColumn: (projectId: string, datasetId: string, data: { column_name: string }) =>
-    $api(`/projects/${projectId}/qa/datasets/${datasetId}/custom-columns`, { method: 'POST', body: data }),
+  createCustomColumn: (orgId: string, datasetId: string, data: { column_name: string }) =>
+    $api(`/organizations/${orgId}/qa/datasets/${datasetId}/custom-columns`, { method: 'POST', body: data }),
 
-  renameCustomColumn: (projectId: string, datasetId: string, columnId: string, data: { column_name: string }) =>
-    $api(`/projects/${projectId}/qa/datasets/${datasetId}/custom-columns/${columnId}`, { method: 'PATCH', body: data }),
+  renameCustomColumn: (orgId: string, datasetId: string, columnId: string, data: { column_name: string }) =>
+    $api(`/organizations/${orgId}/qa/datasets/${datasetId}/custom-columns/${columnId}`, {
+      method: 'PATCH',
+      body: data,
+    }),
 
-  deleteCustomColumn: (projectId: string, datasetId: string, columnId: string) =>
-    $api(`/projects/${projectId}/qa/datasets/${datasetId}/custom-columns/${columnId}`, { method: 'DELETE' }),
+  deleteCustomColumn: (orgId: string, datasetId: string, columnId: string) =>
+    $api(`/organizations/${orgId}/qa/datasets/${datasetId}/custom-columns/${columnId}`, { method: 'DELETE' }),
 
+  // Project-scoped QA runs (unchanged)
   runQAProcess: (projectId: string, datasetId: string, data: QAProcessRunPayload) =>
     $api(`/projects/${projectId}/qa/datasets/${datasetId}/run`, { method: 'POST', body: data }),
 
@@ -80,15 +91,15 @@ export const qaApi = {
   getQASessions: (projectId: string, datasetId: string): Promise<QASession[]> =>
     $api<QASession[]>(`/projects/${projectId}/qa/sessions`, { query: { dataset_id: datasetId } }),
 
-  // Uses raw fetch because $api doesn't support blob responses for file downloads
-  exportToCSV: async (projectId: string, datasetId: string, graphRunnerId: string) => {
+  // Organization-scoped CSV export/import
+  exportToCSV: async (orgId: string, datasetId: string, graphRunnerId: string) => {
     const authHeaders = await getAuthHeaders()
-    const path = `/projects/${projectId}/qa/datasets/${datasetId}/export`
+    const path = `/organizations/${orgId}/qa/datasets/${datasetId}/export`
     const url = `${getApiBaseUrl()}${path}?graph_runner_id=${encodeURIComponent(graphRunnerId)}`
 
     try {
       const response = await fetch(url, {
-        method: 'GET',
+        method: 'POST',
         headers: authHeaders,
       })
 
@@ -147,7 +158,7 @@ export const qaApi = {
     } catch (error: unknown) {
       logger.error('CSV Export Error', {
         url,
-        projectId,
+        orgId,
         datasetId,
         graphRunnerId,
         error,
@@ -156,14 +167,13 @@ export const qaApi = {
     }
   },
 
-  importFromCSV: async (projectId: string, datasetId: string, file: File) => {
+  importFromCSV: async (orgId: string, datasetId: string, file: File) => {
     if (!file.name.toLowerCase().endsWith('.csv')) throw new Error('File must be a CSV file')
 
     const formData = new FormData()
-
     formData.append('file', file)
 
-    return $api(`/projects/${projectId}/qa/datasets/${datasetId}/import`, {
+    return $api(`/organizations/${orgId}/qa/datasets/${datasetId}/import`, {
       method: 'POST',
       body: formData,
     })
@@ -171,20 +181,28 @@ export const qaApi = {
 }
 
 export const qaEvaluationApi = {
-  getLLMJudges: (projectId: string) => $api(`/projects/${projectId}/qa/llm-judges`),
+  // Organization-scoped judge CRUD
+  getLLMJudges: (orgId: string) => $api(`/organizations/${orgId}/qa/llm-judges`),
 
   getLLMJudgeDefaults: (evaluationType?: 'boolean' | 'score' | 'free_text' | 'json_equality') =>
     $api('/qa/llm-judges/defaults', { query: evaluationType ? { evaluation_type: evaluationType } : {} }),
 
-  createLLMJudge: (projectId: string, data: LLMJudgeCreate) =>
-    $api(`/projects/${projectId}/qa/llm-judges`, { method: 'POST', body: data }),
+  createLLMJudge: (orgId: string, data: LLMJudgeCreate) =>
+    $api(`/organizations/${orgId}/qa/llm-judges`, { method: 'POST', body: data }),
 
-  updateLLMJudge: (projectId: string, judgeId: string, data: LLMJudgeUpdate) =>
-    $api(`/projects/${projectId}/qa/llm-judges/${judgeId}`, { method: 'PATCH', body: data }),
+  updateLLMJudge: (orgId: string, judgeId: string, data: LLMJudgeUpdate) =>
+    $api(`/organizations/${orgId}/qa/llm-judges/${judgeId}`, { method: 'PATCH', body: data }),
 
-  deleteLLMJudges: (projectId: string, judgeIds: string[]) =>
-    $api(`/projects/${projectId}/qa/llm-judges`, { method: 'DELETE', body: judgeIds }),
+  deleteLLMJudges: (orgId: string, judgeIds: string[]) =>
+    $api(`/organizations/${orgId}/qa/llm-judges`, { method: 'DELETE', body: judgeIds }),
 
+  setJudgeProjects: (orgId: string, judgeId: string, projectIds: string[]) =>
+    $api(`/organizations/${orgId}/qa/llm-judges/${judgeId}/projects`, {
+      method: 'PUT',
+      body: { project_ids: projectIds },
+    }),
+
+  // Project-scoped evaluations (unchanged)
   runJudgeEvaluation: (projectId: string, judgeId: string, versionOutputId: string) =>
     $api(`/projects/${projectId}/qa/llm-judges/${judgeId}/evaluations/run`, {
       method: 'POST',

--- a/frontend/src/components/observability/UniversalObservabilityDrawer.vue
+++ b/frontend/src/components/observability/UniversalObservabilityDrawer.vue
@@ -3,6 +3,7 @@ import SaveToQADialog from '@/components/qa/SaveToQADialog.vue'
 import { type TraceListParams, useTraceDetailsQuery, useTracesQuery } from '@/composables/queries/useObservabilityQuery'
 import { DATE_RANGES, formatDuration, useDateRangeFilter } from '@/composables/useDateRangeFilter'
 import { useSaveToQA } from '@/composables/useSaveToQA'
+import { useSelectedOrg } from '@/composables/useSelectedOrg'
 import { useSpanIconMap } from '@/composables/useSpanIconMap'
 import type { CallType, Span } from '@/types/observability'
 import { formatDateCalendar, formatNumberWithSpaces } from '@/utils/formatters'
@@ -76,6 +77,7 @@ const getMessageCount = (span: any): number => {
 }
 
 // Save to QA composable
+const { selectedOrgId } = useSelectedOrg()
 const projectIdRef = computed(() => props.projectId)
 const spanIconMap = useSpanIconMap(projectIdRef)
 
@@ -94,6 +96,7 @@ const {
   saveToQA,
   createDataset,
 } = useSaveToQA({
+  orgId: selectedOrgId,
   projectId: projectIdRef,
   getConversationData: () => {
     if (!traceToSave.value) return null

--- a/frontend/src/components/qa/QADatasetTable.vue
+++ b/frontend/src/components/qa/QADatasetTable.vue
@@ -27,10 +27,12 @@ const t = reactive(composable)
       :datasets="t.datasetOptions"
       :versions="t.versionOptions"
       :can-manage-datasets="t.canManageDatasets"
+      :unlinked-datasets="t.unlinkedDatasetOptions"
       @dataset-change="t.onDatasetChange"
       @version-change="t.onVersionChange"
       @create-dataset="t.showCreateDatasetDialog = true"
-      @delete-dataset="t.openDeleteDatasetDialog"
+      @add-existing-dataset="t.addDatasetToProject"
+      @remove-dataset="t.openRemoveDatasetDialog"
       @import-csv="t.triggerFileInput"
       @export-csv="t.exportDatasetToCSV"
     />
@@ -271,6 +273,24 @@ const t = reactive(composable)
 
     <!-- Dialogs -->
     <QACreateDatasetDialog v-model="t.showCreateDatasetDialog" :loading="t.creating" @create="t.createNewDataset" />
+
+    <VDialog v-model="t.showRemoveDatasetDialog" max-width="var(--dnr-dialog-sm)">
+      <VCard>
+        <VCardTitle>Remove Dataset from Project</VCardTitle>
+        <VCardText>
+          <p>
+            Remove "{{ t.currentDataset?.dataset_name }}" from this project?
+            The dataset will still be available in the organization and can be re-added later.
+          </p>
+        </VCardText>
+        <VCardActions>
+          <VSpacer />
+          <VBtn variant="text" @click="t.showRemoveDatasetDialog = false"> Cancel </VBtn>
+          <VBtn color="warning" @click="t.confirmRemoveDatasetFromProject"> Remove </VBtn>
+        </VCardActions>
+      </VCard>
+    </VDialog>
+
     <QACreateColumnDialog
       v-model="t.showCreateColumnDialog"
       :loading="t.creatingColumn"
@@ -317,12 +337,6 @@ const t = reactive(composable)
       @save="t.saveEditedTestCase"
     />
 
-    <QADeleteDatasetDialog
-      v-model="t.showDeleteDatasetDialog"
-      :dataset-name="t.currentDataset?.dataset_name || ''"
-      :loading="t.deleteDatasetLoading"
-      @confirm="t.confirmDeleteDataset"
-    />
     <QABulkDeleteDialog
       v-model="t.showBulkDeleteDialog"
       :count="t.selected.length"

--- a/frontend/src/components/qa/QADatasetTableHeader.vue
+++ b/frontend/src/components/qa/QADatasetTableHeader.vue
@@ -1,24 +1,13 @@
 <script setup lang="ts">
-// 1. Vue/core imports
-
-// 2. Third-party libraries (none here)
-
-// 3. Local components (none here)
-
-// 4. Composables (none here)
-
-// 5. Utils/helpers (none here)
-
-// 6. Types
 import type { QADataset, QAVersion } from '@/types/qa'
 
-// Props & Emits
 interface Props {
   currentDataset: QADataset | null
   currentVersion: QAVersion | null
   datasets: Array<{ title: string; value: string }>
   versions: Array<{ title: string; value: string; env?: string }>
   canManageDatasets: boolean
+  unlinkedDatasets: Array<{ title: string; value: string }>
 }
 
 const props = defineProps<Props>()
@@ -27,12 +16,12 @@ const emit = defineEmits<{
   'dataset-change': [datasetId: string]
   'version-change': [versionId: string]
   'create-dataset': []
-  'delete-dataset': []
+  'add-existing-dataset': [datasetId: string]
+  'remove-dataset': []
   'import-csv': []
   'export-csv': []
 }>()
 
-// Methods
 const handleDatasetChange = (datasetId: string) => {
   emit('dataset-change', datasetId)
 }
@@ -106,22 +95,60 @@ const handleVersionChange = (versionId: string) => {
           </template>
         </VSelect>
 
-        <!-- Create Dataset Button -->
-        <VBtn color="primary" variant="outlined" @click="emit('create-dataset')">
-          <VIcon icon="tabler-plus" class="me-2" />
-          Create Dataset
-        </VBtn>
+        <!-- Add Dataset (split button) -->
+        <div v-if="canManageDatasets" class="d-flex split-btn-wrapper">
+          <VMenu location="bottom end" :close-on-content-click="true">
+            <template #activator="{ props: menuProps }">
+              <VBtn color="primary" variant="outlined" v-bind="menuProps" class="split-btn-main">
+                <VIcon icon="tabler-plus" class="me-2" />
+                Add Dataset
+              </VBtn>
+            </template>
 
-        <!-- Delete Dataset Button (Admin only) -->
+            <VList density="compact" min-width="220">
+              <VListSubheader v-if="unlinkedDatasets.length > 0">Existing datasets</VListSubheader>
+              <VListItem
+                v-for="ds in unlinkedDatasets"
+                :key="ds.value"
+                @click="emit('add-existing-dataset', ds.value)"
+              >
+                <template #prepend>
+                  <VIcon icon="tabler-database" size="18" />
+                </template>
+                <VListItemTitle>{{ ds.title }}</VListItemTitle>
+              </VListItem>
+
+              <VListItem
+                v-if="unlinkedDatasets.length === 0"
+                disabled
+              >
+                <VListItemTitle class="text-medium-emphasis text-body-2">
+                  No other datasets in this organization
+                </VListItemTitle>
+              </VListItem>
+
+              <VDivider class="my-1" />
+
+              <VListItem @click="emit('create-dataset')">
+                <template #prepend>
+                  <VIcon icon="tabler-file-plus" size="18" />
+                </template>
+                <VListItemTitle>Create New Dataset</VListItemTitle>
+              </VListItem>
+            </VList>
+          </VMenu>
+        </div>
+
+        <!-- Remove Dataset from Project -->
         <VBtn
           v-if="canManageDatasets"
-          color="error"
+          color="warning"
           variant="outlined"
           :disabled="!currentDataset"
-          @click="emit('delete-dataset')"
+          @click="emit('remove-dataset')"
         >
-          <VIcon icon="tabler-trash" class="me-2" />
-          Delete Dataset
+          <VIcon icon="tabler-unlink" class="me-2" />
+          Remove from Project
         </VBtn>
 
         <!-- CSV Import/Export Menu -->
@@ -173,3 +200,15 @@ const handleVersionChange = (versionId: string) => {
     </VCardTitle>
   </VCard>
 </template>
+
+<style lang="scss" scoped>
+.split-btn-wrapper {
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.split-btn-main {
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
+}
+</style>

--- a/frontend/src/components/qa/QALLMJudgesManager.vue
+++ b/frontend/src/components/qa/QALLMJudgesManager.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useProjectAssociation } from '@/composables/useProjectAssociation'
 import { useQAEvaluation } from '@/composables/useQAEvaluation'
 import { useQAEvents } from '@/composables/useQAEvents'
 import { useSelectedOrg } from '@/composables/useSelectedOrg'
@@ -11,16 +12,33 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const { selectedOrgRole } = useSelectedOrg()
+const { selectedOrgId, selectedOrgRole } = useSelectedOrg()
 const { emitJudgesUpdated } = useQAEvents()
 
-const { judges, loadingStates, fetchLLMJudges, fetchLLMJudgeDefaults, createJudge, updateJudge, deleteJudges } =
-  useQAEvaluation()
+const {
+  judges: allOrgJudges,
+  loadingStates,
+  fetchLLMJudges,
+  fetchLLMJudgeDefaults,
+  createJudge,
+  updateJudge,
+  setJudgeProjects,
+} = useQAEvaluation()
+
+const orgId = computed(() => selectedOrgId.value || '')
+const projectIdRef = computed(() => props.projectId)
+
+const judgeAssoc = useProjectAssociation({
+  projectId: projectIdRef,
+  allItems: allOrgJudges,
+})
+
+const judges = computed(() => judgeAssoc.linkedItems(allOrgJudges.value))
+const unlinkedJudges = computed(() => judgeAssoc.unlinkedItems(allOrgJudges.value))
 
 const showCreateDialog = ref(false)
-const showDeleteAllDialog = ref(false)
-const showDeleteSingleJudgeDialog = ref(false)
-const judgeToDelete = ref<LLMJudge | null>(null)
+const showRemoveJudgeDialog = ref(false)
+const judgeToRemove = ref<LLMJudge | null>(null)
 const editingJudge = ref<LLMJudge | null>(null)
 const judgeForm = ref()
 
@@ -31,7 +49,6 @@ const evaluationTypeOptions = [
   { title: 'JSON Equality', value: 'json_equality' as EvaluationType },
 ]
 
-// Store templates in memory by evaluation type to preserve user edits
 const templatesByType = ref<Record<EvaluationType, string>>({
   boolean: '',
   score: '',
@@ -49,14 +66,11 @@ const judgeFormData = ref<LLMJudgeCreate>({
 const onEvaluationTypeChange = async () => {
   const newType = judgeFormData.value.evaluation_type
 
-  // If we already have a template in memory for this type, use it
   if (templatesByType.value[newType]) {
     judgeFormData.value.prompt_template = templatesByType.value[newType]
-
     return
   }
 
-  // Otherwise, fetch the default template for this evaluation type
   const defaultsData = await fetchLLMJudgeDefaults(newType)
   if (defaultsData?.prompt_template) {
     judgeFormData.value.prompt_template = defaultsData.prompt_template
@@ -64,7 +78,7 @@ const onEvaluationTypeChange = async () => {
   }
 }
 
-const canDeleteJudges = computed(() => {
+const canManageJudges = computed(() => {
   const role = selectedOrgRole.value?.toLowerCase()
   return ['admin', 'developer'].includes(role)
 })
@@ -86,7 +100,6 @@ const evaluationTypeHint = computed(() => {
 })
 
 const resetForm = async () => {
-  // Reset templates in memory
   templatesByType.value = {
     boolean: '',
     score: '',
@@ -94,7 +107,6 @@ const resetForm = async () => {
     json_equality: '',
   }
 
-  // Force refresh defaults from backend when creating new judge
   const defaultsData = await fetchLLMJudgeDefaults('boolean')
 
   if (defaultsData) {
@@ -130,7 +142,6 @@ const openDialog = async () => {
 const openEditDialog = (judge: LLMJudge) => {
   editingJudge.value = judge
 
-  // Reset templates in memory
   templatesByType.value = {
     boolean: '',
     score: '',
@@ -145,15 +156,13 @@ const openEditDialog = (judge: LLMJudge) => {
     prompt_template: judge.prompt_template,
   }
 
-  // Store the current template in memory
   templatesByType.value[judge.evaluation_type] = judge.prompt_template
   showCreateDialog.value = true
 }
 
 const saveJudge = async () => {
-  if (!props.projectId) return
+  if (!orgId.value) return
 
-  // Store current template in memory before saving
   templatesByType.value[judgeFormData.value.evaluation_type] = judgeFormData.value.prompt_template
 
   const isValid = await judgeForm.value?.validate()
@@ -167,11 +176,8 @@ const saveJudge = async () => {
       prompt_template: judgeFormData.value.prompt_template,
     }
 
-    const success = await updateJudge(props.projectId, editingJudge.value.id, updateData)
-    if (success) {
-      // Emit event to notify other components (e.g., QADatasetTable) to refresh judges
-      emitJudgesUpdated({ projectId: props.projectId })
-    }
+    const success = await updateJudge(orgId.value, editingJudge.value.id, updateData)
+    if (success) emitJudgesUpdated({ projectId: props.projectId })
   } else {
     const dataToSend: LLMJudgeCreate = {
       name: judgeFormData.value.name,
@@ -180,9 +186,14 @@ const saveJudge = async () => {
       prompt_template: judgeFormData.value.prompt_template,
     }
 
-    const success = await createJudge(props.projectId, dataToSend)
-    if (success) {
-      // Emit event to notify other components (e.g., QADatasetTable) to refresh judges
+    const createdJudge = await createJudge(orgId.value, dataToSend)
+    if (createdJudge) {
+      if (props.projectId) {
+        const existingIds = createdJudge.project_ids || []
+        if (!existingIds.includes(props.projectId)) {
+          await setJudgeProjects(orgId.value, createdJudge.id, [...existingIds, props.projectId])
+        }
+      }
       emitJudgesUpdated({ projectId: props.projectId })
     }
   }
@@ -190,55 +201,42 @@ const saveJudge = async () => {
   await closeDialog()
 }
 
-const openDeleteAllDialog = () => {
-  if (judges.value.length === 0) return
-  showDeleteAllDialog.value = true
+const addExistingJudge = async (judgeId: string) => {
+  if (!orgId.value) return
+  const projectIds = judgeAssoc.buildAddProjectIds(judgeId)
+  if (!projectIds) return
+  await setJudgeProjects(orgId.value, judgeId, projectIds)
+  emitJudgesUpdated({ projectId: props.projectId })
 }
 
-const confirmDeleteAll = async () => {
-  if (!props.projectId || judges.value.length === 0) return
-
-  const allJudgeIds = judges.value.map(j => j.id)
-
-  const success = await deleteJudges(props.projectId, allJudgeIds)
-  if (success) {
-    // Emit event to notify other components (e.g., QADatasetTable) to refresh judges
-    emitJudgesUpdated({ projectId: props.projectId })
-  }
-  showDeleteAllDialog.value = false
+const openRemoveJudgeDialog = (judge: LLMJudge) => {
+  judgeToRemove.value = judge
+  showRemoveJudgeDialog.value = true
 }
 
-const openDeleteSingleJudgeDialog = (judge: LLMJudge) => {
-  judgeToDelete.value = judge
-  showDeleteSingleJudgeDialog.value = true
-}
-
-const confirmDeleteSingleJudge = async () => {
-  if (!props.projectId || !judgeToDelete.value) return
-
-  const success = await deleteJudges(props.projectId, [judgeToDelete.value.id])
-  if (success) {
-    // Emit event to notify other components (e.g., QADatasetTable) to refresh judges
-    emitJudgesUpdated({ projectId: props.projectId })
-  }
-  judgeToDelete.value = null
-  showDeleteSingleJudgeDialog.value = false
+const confirmRemoveJudge = async () => {
+  if (!orgId.value || !judgeToRemove.value) return
+  const projectIds = judgeAssoc.buildRemoveProjectIds(judgeToRemove.value.id)
+  if (!projectIds) return
+  await setJudgeProjects(orgId.value, judgeToRemove.value.id, projectIds)
+  emitJudgesUpdated({ projectId: props.projectId })
+  judgeToRemove.value = null
+  showRemoveJudgeDialog.value = false
 }
 
 onMounted(async () => {
-  if (props.projectId) {
-    await Promise.all([fetchLLMJudges(props.projectId), fetchLLMJudgeDefaults()])
+  if (orgId.value) {
+    await Promise.all([fetchLLMJudges(orgId.value), fetchLLMJudgeDefaults()])
   }
 })
 
 watch(
-  () => props.projectId,
-  newProjectId => {
-    if (newProjectId) fetchLLMJudges(newProjectId)
+  () => orgId.value,
+  newOrgId => {
+    if (newOrgId) fetchLLMJudges(newOrgId)
   }
 )
 
-// Watch for prompt template changes and save to memory
 watch(
   () => judgeFormData.value.prompt_template,
   newTemplate => {
@@ -258,21 +256,47 @@ watch(
         </div>
 
         <div class="d-flex align-center gap-2">
-          <VBtn color="primary" variant="outlined" @click="openDialog">
-            <VIcon icon="tabler-plus" class="me-2" />
-            Create Judge
-          </VBtn>
+          <!-- Add Judge (split button) -->
+          <VMenu location="bottom end" :close-on-content-click="true">
+            <template #activator="{ props: menuProps }">
+              <VBtn color="primary" variant="outlined" v-bind="menuProps">
+                <VIcon icon="tabler-plus" class="me-2" />
+                Add Judge
+              </VBtn>
+            </template>
 
-          <VBtn
-            v-if="canDeleteJudges"
-            color="error"
-            variant="outlined"
-            :disabled="judges.length === 0"
-            @click="openDeleteAllDialog"
-          >
-            <VIcon icon="tabler-trash" class="me-2" />
-            Delete All
-          </VBtn>
+            <VList density="compact" min-width="220">
+              <VListSubheader v-if="unlinkedJudges.length > 0">Existing judges</VListSubheader>
+              <VListItem
+                v-for="judge in unlinkedJudges"
+                :key="judge.id"
+                @click="addExistingJudge(judge.id)"
+              >
+                <template #prepend>
+                  <VIcon icon="tabler-gavel" size="18" />
+                </template>
+                <VListItemTitle>{{ judge.name }}</VListItemTitle>
+                <VListItemSubtitle>
+                  <VChip size="x-small" variant="tonal">{{ judge.evaluation_type }}</VChip>
+                </VListItemSubtitle>
+              </VListItem>
+
+              <VListItem v-if="unlinkedJudges.length === 0" disabled>
+                <VListItemTitle class="text-medium-emphasis text-body-2">
+                  No other judges in this organization
+                </VListItemTitle>
+              </VListItem>
+
+              <VDivider class="my-1" />
+
+              <VListItem @click="openDialog">
+                <template #prepend>
+                  <VIcon icon="tabler-file-plus" size="18" />
+                </template>
+                <VListItemTitle>Create New Judge</VListItemTitle>
+              </VListItem>
+            </VList>
+          </VMenu>
         </div>
       </VCardTitle>
 
@@ -301,14 +325,15 @@ watch(
                   <VIcon icon="tabler-edit" />
                 </VBtn>
                 <VBtn
-                  v-if="canDeleteJudges"
+                  v-if="canManageJudges"
                   icon
                   size="small"
                   variant="text"
-                  color="error"
-                  @click.stop="openDeleteSingleJudgeDialog(judge)"
+                  color="warning"
+                  @click.stop="openRemoveJudgeDialog(judge)"
                 >
-                  <VIcon icon="tabler-trash" />
+                  <VIcon icon="tabler-unlink" />
+                  <VTooltip activator="parent">Remove from project</VTooltip>
                 </VBtn>
               </div>
             </template>
@@ -318,7 +343,7 @@ watch(
         <div v-else class="text-center pa-8">
           <VIcon icon="tabler-gavel-off" size="64" class="mb-4 text-disabled" />
           <h3 class="text-h6 mb-2">No LLM Judges</h3>
-          <p class="text-body-2 mb-4">Create an LLM judge to evaluate your test cases</p>
+          <p class="text-body-2 mb-4">Add an LLM judge to evaluate your test cases</p>
           <VBtn color="primary" @click="openDialog">
             <VIcon icon="tabler-plus" class="me-2" />
             Create Judge
@@ -393,30 +418,19 @@ watch(
       </VCard>
     </VDialog>
 
-    <VDialog v-model="showDeleteAllDialog" max-width="var(--dnr-dialog-sm)">
+    <VDialog v-model="showRemoveJudgeDialog" max-width="var(--dnr-dialog-sm)">
       <VCard>
-        <VCardTitle>Delete All LLM Judges</VCardTitle>
+        <VCardTitle>Remove LLM Judge</VCardTitle>
         <VCardText>
-          <p>Are you sure you want to delete all {{ judges.length }} LLM judges? This action cannot be undone.</p>
+          <p>
+            Remove "{{ judgeToRemove?.name }}" from this project?
+            The judge will still be available in the organization and can be re-added later.
+          </p>
         </VCardText>
         <VCardActions>
           <VSpacer />
-          <VBtn variant="text" @click="showDeleteAllDialog = false"> Cancel </VBtn>
-          <VBtn color="error" :loading="loadingStates.deleting" @click="confirmDeleteAll"> Delete All </VBtn>
-        </VCardActions>
-      </VCard>
-    </VDialog>
-
-    <VDialog v-model="showDeleteSingleJudgeDialog" max-width="var(--dnr-dialog-sm)">
-      <VCard>
-        <VCardTitle>Delete LLM Judge</VCardTitle>
-        <VCardText>
-          <p>Are you sure you want to delete "{{ judgeToDelete?.name }}"? This action cannot be undone.</p>
-        </VCardText>
-        <VCardActions>
-          <VSpacer />
-          <VBtn variant="text" @click="showDeleteSingleJudgeDialog = false"> Cancel </VBtn>
-          <VBtn color="error" :loading="loadingStates.deleting" @click="confirmDeleteSingleJudge"> Delete </VBtn>
+          <VBtn variant="text" @click="showRemoveJudgeDialog = false"> Cancel </VBtn>
+          <VBtn color="warning" @click="confirmRemoveJudge"> Remove </VBtn>
         </VCardActions>
       </VCard>
     </VDialog>

--- a/frontend/src/composables/queries/useQAQuery.ts
+++ b/frontend/src/composables/queries/useQAQuery.ts
@@ -16,24 +16,24 @@ import { logNetworkCall, logQueryStart } from '@/utils/queryLogger'
 export type { QADataset, QATestCaseUI, QAVersion }
 
 /**
- * Fetches QA datasets for a project
+ * Fetches QA datasets for an organization
  */
-export function useQADatasetsQuery(projectId: Ref<string | undefined>) {
-  const queryKey = computed(() => ['qa-datasets', projectId.value] as const)
+export function useQADatasetsQuery(orgId: Ref<string | undefined>) {
+  const queryKey = computed(() => ['qa-datasets', orgId.value] as const)
 
   return useQuery<QADataset[]>({
     queryKey,
     queryFn: async () => {
-      logQueryStart(['qa-datasets', projectId.value], 'useQADatasetsQuery')
+      logQueryStart(['qa-datasets', orgId.value], 'useQADatasetsQuery')
 
-      if (!projectId.value) {
+      if (!orgId.value) {
         return []
       }
 
-      const data = await scopeoApi.qa.getDatasets(projectId.value)
+      const data = await scopeoApi.qa.getDatasets(orgId.value)
       return data || []
     },
-    enabled: computed(() => !!projectId.value),
+    enabled: computed(() => !!orgId.value),
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 30,
     refetchOnMount: true,
@@ -69,12 +69,13 @@ export function useQAVersionsQuery(projectId: Ref<string | undefined>) {
  * Includes full transformation logic with pagination, sorting, outputs, and version_output_ids
  */
 export function useQAInputGroundtruthsQuery(
+  orgId: Ref<string | undefined>,
   projectId: Ref<string | undefined>,
   datasetId: Ref<string | undefined>,
   graphRunnerId: Ref<string | undefined>
 ) {
   const queryKey = computed(
-    () => ['qa-input-groundtruths', projectId.value, datasetId.value, graphRunnerId.value] as const
+    () => ['qa-input-groundtruths', orgId.value, datasetId.value, graphRunnerId.value] as const
   )
 
   const query = useQuery<{ testCases: QATestCaseUI[]; lastLoadedAt: string }>({
@@ -82,11 +83,11 @@ export function useQAInputGroundtruthsQuery(
     refetchOnWindowFocus: false,
     queryFn: async () => {
       logQueryStart(
-        ['qa-input-groundtruths', projectId.value, datasetId.value, graphRunnerId.value],
+        ['qa-input-groundtruths', orgId.value, datasetId.value, graphRunnerId.value],
         'useQAInputGroundtruthsQuery'
       )
 
-      if (!projectId.value || !datasetId.value) {
+      if (!orgId.value || !datasetId.value) {
         return { testCases: [], lastLoadedAt: new Date().toISOString() }
       }
 
@@ -97,7 +98,7 @@ export function useQAInputGroundtruthsQuery(
       let hasMore = true
 
       while (hasMore) {
-        const baseResp = await scopeoApi.qa.getInputGroundtruths(projectId.value, datasetId.value, {
+        const baseResp = await scopeoApi.qa.getInputGroundtruths(orgId.value, datasetId.value, {
           page,
           page_size: pageSize,
         })
@@ -144,7 +145,7 @@ export function useQAInputGroundtruthsQuery(
       // If graphRunnerId is provided, fetch outputs and version_output_ids
       if (graphRunnerId.value) {
         // Get outputs (Dict[input_id, output])
-        const outputsResp = await scopeoApi.qa.getOutputs(projectId.value, datasetId.value, graphRunnerId.value)
+        const outputsResp = await scopeoApi.qa.getOutputs(orgId.value, datasetId.value, graphRunnerId.value)
         const outputsDict: Record<string, string> = outputsResp || {}
 
         // Get all input IDs from the test cases
@@ -199,7 +200,7 @@ export function useQAInputGroundtruthsQuery(
 
       return { testCases: initialCases, lastLoadedAt: new Date().toISOString() }
     },
-    enabled: computed(() => !!projectId.value && !!datasetId.value),
+    enabled: computed(() => !!orgId.value && !!datasetId.value),
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 30,
     refetchOnMount: true,
@@ -223,11 +224,11 @@ export function useCreateQADatasetMutation() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ projectId, data }: { projectId: string; data: any }) => {
-      return await scopeoApi.qa.createDatasets(projectId, data)
+    mutationFn: async ({ orgId, data }: { orgId: string; data: any }) => {
+      return await scopeoApi.qa.createDatasets(orgId, data)
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['qa-datasets', variables.projectId] })
+      queryClient.invalidateQueries({ queryKey: ['qa-datasets', variables.orgId] })
     },
   })
 }
@@ -239,13 +240,13 @@ export function useDeleteQADatasetMutation() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ projectId, datasetIds }: { projectId: string; datasetIds: string[] }) => {
-      return await scopeoApi.qa.deleteDatasets(projectId, { dataset_ids: datasetIds })
+    mutationFn: async ({ orgId, datasetIds }: { orgId: string; datasetIds: string[] }) => {
+      return await scopeoApi.qa.deleteDatasets(orgId, { dataset_ids: datasetIds })
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['qa-datasets', variables.projectId] })
+      queryClient.invalidateQueries({ queryKey: ['qa-datasets', variables.orgId] })
       variables.datasetIds.forEach(datasetId => {
-        queryClient.invalidateQueries({ queryKey: ['qa-input-groundtruths', variables.projectId, datasetId] })
+        queryClient.invalidateQueries({ queryKey: ['qa-input-groundtruths', variables.orgId, datasetId] })
       })
     },
   })
@@ -259,11 +260,11 @@ export function useAddInputGroundtruthMutation() {
 
   return useMutation({
     mutationFn: async ({
-      projectId,
+      orgId,
       datasetId,
       data,
     }: {
-      projectId: string
+      orgId: string
       datasetId: string
       data: {
         inputs_groundtruths: Array<{
@@ -273,11 +274,11 @@ export function useAddInputGroundtruthMutation() {
         }>
       }
     }) => {
-      return await scopeoApi.qa.createInputGroundtruths(projectId, datasetId, data)
+      return await scopeoApi.qa.createInputGroundtruths(orgId, datasetId, data)
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: ['qa-input-groundtruths', variables.projectId, variables.datasetId],
+        queryKey: ['qa-input-groundtruths', variables.orgId, variables.datasetId],
       })
     },
   })
@@ -289,11 +290,11 @@ export function useAddInputGroundtruthMutation() {
 export function useUpdateInputGroundtruthMutation() {
   return useMutation({
     mutationFn: async ({
-      projectId,
+      orgId,
       datasetId,
       data,
     }: {
-      projectId: string
+      orgId: string
       datasetId: string
       data: {
         inputs_groundtruths: Array<{
@@ -304,7 +305,7 @@ export function useUpdateInputGroundtruthMutation() {
         }>
       }
     }) => {
-      return await scopeoApi.qa.updateInputGroundtruths(projectId, datasetId, data)
+      return await scopeoApi.qa.updateInputGroundtruths(orgId, datasetId, data)
     },
     // No onSuccess/cache patch — the local ref in QADatasetTable is the source of truth
     // while editing. Patching the cache here would trigger the queryTestCases watcher
@@ -320,19 +321,19 @@ export function useDeleteInputGroundtruthMutation() {
 
   return useMutation({
     mutationFn: async ({
-      projectId,
+      orgId,
       datasetId,
       entryIds,
     }: {
-      projectId: string
+      orgId: string
       datasetId: string
       entryIds: string[]
     }) => {
-      return await scopeoApi.qa.deleteInputGroundtruths(projectId, datasetId, { input_groundtruth_ids: entryIds })
+      return await scopeoApi.qa.deleteInputGroundtruths(orgId, datasetId, { input_groundtruth_ids: entryIds })
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: ['qa-input-groundtruths', variables.projectId, variables.datasetId],
+        queryKey: ['qa-input-groundtruths', variables.orgId, variables.datasetId],
       })
     },
   })
@@ -364,22 +365,22 @@ export function useRunQAProcessMutation() {
 /**
  * Fetches custom columns for a dataset
  */
-export function useQACustomColumnsQuery(projectId: Ref<string | undefined>, datasetId: Ref<string | undefined>) {
-  const queryKey = computed(() => ['qa-custom-columns', projectId.value, datasetId.value] as const)
+export function useQACustomColumnsQuery(orgId: Ref<string | undefined>, datasetId: Ref<string | undefined>) {
+  const queryKey = computed(() => ['qa-custom-columns', orgId.value, datasetId.value] as const)
 
   return useQuery<QAColumnListResponse>({
     queryKey,
     queryFn: async () => {
-      logQueryStart(['qa-custom-columns', projectId.value, datasetId.value], 'useQACustomColumnsQuery')
+      logQueryStart(['qa-custom-columns', orgId.value, datasetId.value], 'useQACustomColumnsQuery')
 
-      if (!projectId.value || !datasetId.value) {
+      if (!orgId.value || !datasetId.value) {
         return []
       }
 
-      const data = await scopeoApi.qa.getCustomColumns(projectId.value, datasetId.value)
+      const data = await scopeoApi.qa.getCustomColumns(orgId.value, datasetId.value)
       return data || []
     },
-    enabled: computed(() => !!projectId.value && !!datasetId.value),
+    enabled: computed(() => !!orgId.value && !!datasetId.value),
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 30,
     refetchOnMount: true,
@@ -394,19 +395,19 @@ export function useCreateQACustomColumnMutation() {
 
   return useMutation({
     mutationFn: async ({
-      projectId,
+      orgId,
       datasetId,
       data,
     }: {
-      projectId: string
+      orgId: string
       datasetId: string
       data: QAColumnCreate
     }) => {
-      return await scopeoApi.qa.createCustomColumn(projectId, datasetId, data)
+      return await scopeoApi.qa.createCustomColumn(orgId, datasetId, data)
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: ['qa-custom-columns', variables.projectId, variables.datasetId],
+        queryKey: ['qa-custom-columns', variables.orgId, variables.datasetId],
       })
     },
   })
@@ -420,21 +421,21 @@ export function useRenameQACustomColumnMutation() {
 
   return useMutation({
     mutationFn: async ({
-      projectId,
+      orgId,
       datasetId,
       columnId,
       data,
     }: {
-      projectId: string
+      orgId: string
       datasetId: string
       columnId: string
       data: QAColumnRename
     }) => {
-      return await scopeoApi.qa.renameCustomColumn(projectId, datasetId, columnId, data)
+      return await scopeoApi.qa.renameCustomColumn(orgId, datasetId, columnId, data)
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: ['qa-custom-columns', variables.projectId, variables.datasetId],
+        queryKey: ['qa-custom-columns', variables.orgId, variables.datasetId],
       })
     },
   })
@@ -448,24 +449,71 @@ export function useDeleteQACustomColumnMutation() {
 
   return useMutation({
     mutationFn: async ({
-      projectId,
+      orgId,
       datasetId,
       columnId,
     }: {
-      projectId: string
+      orgId: string
       datasetId: string
       columnId: string
     }) => {
-      return await scopeoApi.qa.deleteCustomColumn(projectId, datasetId, columnId)
+      return await scopeoApi.qa.deleteCustomColumn(orgId, datasetId, columnId)
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: ['qa-custom-columns', variables.projectId, variables.datasetId],
+        queryKey: ['qa-custom-columns', variables.orgId, variables.datasetId],
       })
-      // Also invalidate entries since deleting a column affects the data
       queryClient.invalidateQueries({
-        queryKey: ['qa-input-groundtruths', variables.projectId, variables.datasetId],
+        queryKey: ['qa-input-groundtruths', variables.orgId, variables.datasetId],
       })
+    },
+  })
+}
+
+/**
+ * Mutation to set which projects a dataset belongs to
+ */
+export function useSetDatasetProjectsMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      orgId,
+      datasetId,
+      projectIds,
+    }: {
+      orgId: string
+      datasetId: string
+      projectIds: string[]
+    }) => {
+      return await scopeoApi.qa.setDatasetProjects(orgId, datasetId, projectIds)
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['qa-datasets', variables.orgId] })
+    },
+  })
+}
+
+/**
+ * Mutation to set which projects a judge belongs to
+ */
+export function useSetJudgeProjectsMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      orgId,
+      judgeId,
+      projectIds,
+    }: {
+      orgId: string
+      judgeId: string
+      projectIds: string[]
+    }) => {
+      return await qaEvaluationApi.setJudgeProjects(orgId, judgeId, projectIds)
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['qa-judges', variables.orgId] })
     },
   })
 }

--- a/frontend/src/composables/usePlaygroundSession.ts
+++ b/frontend/src/composables/usePlaygroundSession.ts
@@ -233,6 +233,7 @@ export function usePlaygroundSession(props: {
   const messageToSave = ref<{ message: any; index: number } | null>(null)
 
   const qa = useSaveToQA({
+    orgId: selectedOrgId,
     projectId: projectIdRef,
     getConversationData: () => {
       if (!messageToSave.value) return null

--- a/frontend/src/composables/useProjectAssociation.ts
+++ b/frontend/src/composables/useProjectAssociation.ts
@@ -1,0 +1,33 @@
+import type { ComputedRef } from 'vue'
+
+interface HasProjectIds {
+  id: string
+  project_ids?: string[]
+}
+
+export function useProjectAssociation<T extends HasProjectIds>(opts: {
+  projectId: ComputedRef<string>
+  allItems: ComputedRef<T[]>
+}) {
+  const { projectId, allItems } = opts
+
+  const linkedItems = (items: T[]) =>
+    items.filter(i => i.project_ids?.includes(projectId.value))
+
+  const unlinkedItems = (items: T[]) =>
+    items.filter(i => !i.project_ids?.includes(projectId.value))
+
+  const buildAddProjectIds = (itemId: string): string[] | null => {
+    const item = allItems.value.find(i => i.id === itemId)
+    if (!item) return null
+    return [...(item.project_ids || []), projectId.value]
+  }
+
+  const buildRemoveProjectIds = (itemId: string): string[] | null => {
+    const item = allItems.value.find(i => i.id === itemId)
+    if (!item) return null
+    return (item.project_ids || []).filter(pid => pid !== projectId.value)
+  }
+
+  return { linkedItems, unlinkedItems, buildAddProjectIds, buildRemoveProjectIds }
+}

--- a/frontend/src/composables/useQADatasetTable.ts
+++ b/frontend/src/composables/useQADatasetTable.ts
@@ -17,9 +17,11 @@ import {
   useRenameQACustomColumnMutation,
   useRunQAProcessAsyncMutation,
   useRunQAProcessMutation,
+  useSetDatasetProjectsMutation,
   useUpdateInputGroundtruthMutation,
 } from '@/composables/queries/useQAQuery'
 import { useQAColumnVisibility } from '@/composables/useQAColumnVisibility'
+import { useProjectAssociation } from '@/composables/useProjectAssociation'
 import { useQAEvaluation } from '@/composables/useQAEvaluation'
 import { useQAEventsListener } from '@/composables/useQAEvents'
 import { useQANotifications } from '@/composables/useQANotifications'
@@ -36,13 +38,15 @@ interface Props {
 
 export function useQADatasetTable(props: Props) {
   const route = useRoute()
-  const { isOrgAdmin } = useSelectedOrg()
+  const { isOrgAdmin, selectedOrgId } = useSelectedOrg()
   const notifications = useQANotifications()
   const { showSuccess, showError, showWarning, showInfo } = notifications
 
   // --- Core computed ---
+  const orgId = computed(() => selectedOrgId.value || '')
   const projectId = computed(() => props.projectId || (route.params.id as string))
   const projectIdRef = computed(() => projectId.value)
+  const orgIdRef = computed(() => orgId.value)
 
   // --- Selection state ---
   const currentDataset = ref<QADataset | null>(null)
@@ -55,10 +59,13 @@ export function useQADatasetTable(props: Props) {
   const graphRunnerIdRef = computed(() => currentVersion.value?.graph_runner_id)
 
   // --- Queries ---
-  const { data: datasetsData, isLoading: datasetsLoading, refetch: refetchDatasets } = useQADatasetsQuery(projectIdRef)
-  const datasets = computed(() => datasetsData.value || [])
+  const { data: datasetsData, isLoading: datasetsLoading, refetch: refetchDatasets } = useQADatasetsQuery(orgIdRef)
+  const allOrgDatasets = computed(() => datasetsData.value || [])
+  const datasetAssoc = useProjectAssociation({ projectId, allItems: allOrgDatasets })
+  const datasets = computed(() => datasetAssoc.linkedItems(allOrgDatasets.value))
+  const unlinkedDatasets = computed(() => datasetAssoc.unlinkedItems(allOrgDatasets.value))
 
-  const { data: customColumnsData, refetch: refetchCustomColumns } = useQACustomColumnsQuery(projectIdRef, datasetIdRef)
+  const { data: customColumnsData, refetch: refetchCustomColumns } = useQACustomColumnsQuery(orgIdRef, datasetIdRef)
   const columnVisibility = useQAColumnVisibility(datasetIdRef)
 
   const customColumns = computed(() => {
@@ -78,7 +85,7 @@ export function useQADatasetTable(props: Props) {
     lastLoadedAt,
     isLoading: entriesLoading,
     refetch: refetchTestCases,
-  } = useQAInputGroundtruthsQuery(projectIdRef, datasetIdRef, graphRunnerIdRef)
+  } = useQAInputGroundtruthsQuery(orgIdRef, projectIdRef, datasetIdRef, graphRunnerIdRef)
 
   // --- Local mutable test cases ---
   const testCases = ref<QATestCaseUI[]>([])
@@ -119,6 +126,7 @@ export function useQADatasetTable(props: Props) {
   // --- Mutations ---
   const { mutateAsync: createDatasetMutation, isPending: creating } = useCreateQADatasetMutation()
   const { mutateAsync: deleteDatasetMutation } = useDeleteQADatasetMutation()
+  const { mutateAsync: setDatasetProjectsMutation } = useSetDatasetProjectsMutation()
   const { mutateAsync: addInputGroundtruthMutation } = useAddInputGroundtruthMutation()
   const { mutateAsync: updateInputGroundtruthMutation, isPending: updating } = useUpdateInputGroundtruthMutation()
   const { mutateAsync: deleteInputGroundtruthMutation } = useDeleteInputGroundtruthMutation()
@@ -132,7 +140,7 @@ export function useQADatasetTable(props: Props) {
 
   // --- QA Evaluation ---
   const {
-    judges,
+    judges: allOrgJudges,
     fetchLLMJudges,
     runEvaluations,
     fetchEvaluationsForVersionOutput,
@@ -140,8 +148,13 @@ export function useQADatasetTable(props: Props) {
     deleteEvaluationsForInputGroundtruth,
   } = useQAEvaluation()
 
+  const judges = computed(() =>
+    allOrgJudges.value.filter(j => j.project_ids?.includes(projectId.value))
+  )
+
   // --- Sub-composables ---
   const editing = useQATestCaseEditing({
+    orgId,
     projectId,
     currentDataset,
     testCases,
@@ -194,11 +207,13 @@ export function useQADatasetTable(props: Props) {
   })
 
   const crud = useQATestCaseCrud({
+    orgId,
     projectId,
     currentDataset,
     currentVersion,
     testCases,
     datasets,
+    allOrgDatasets,
     customColumns,
     allCustomColumns,
     columnVisibility,
@@ -209,6 +224,7 @@ export function useQADatasetTable(props: Props) {
     removeTestCases,
     createDatasetMutation,
     deleteDatasetMutation,
+    setDatasetProjectsMutation,
     addInputGroundtruthMutation,
     updateInputGroundtruthMutation,
     deleteInputGroundtruthMutation,
@@ -252,6 +268,10 @@ export function useQADatasetTable(props: Props) {
   // --- Options ---
   const datasetOptions = computed(() => datasets.value.map(d => ({ title: d.dataset_name, value: d.id })))
 
+  const unlinkedDatasetOptions = computed(() =>
+    unlinkedDatasets.value.map(d => ({ title: d.dataset_name, value: d.id }))
+  )
+
   const versionOptions = computed(() =>
     versions.value.map((v, i) => ({
       title: v.tag_name || (v.env === 'draft' ? '-' : `Version ${i + 1}`),
@@ -261,6 +281,31 @@ export function useQADatasetTable(props: Props) {
   )
 
   const hasDatasets = computed(() => datasets.value.length > 0)
+
+  const addDatasetToProject = async (datasetId: string) => {
+    if (!orgId.value) return
+    const projectIds = datasetAssoc.buildAddProjectIds(datasetId)
+    if (!projectIds) return
+    await setDatasetProjectsMutation({ orgId: orgId.value, datasetId, projectIds })
+    await refetchDatasets()
+    currentDataset.value = datasets.value.find(d => d.id === datasetId) || currentDataset.value
+  }
+
+  const showRemoveDatasetDialog = ref(false)
+
+  const openRemoveDatasetDialog = () => {
+    if (currentDataset.value) showRemoveDatasetDialog.value = true
+  }
+
+  const confirmRemoveDatasetFromProject = async () => {
+    if (!orgId.value || !currentDataset.value) return
+    const projectIds = datasetAssoc.buildRemoveProjectIds(currentDataset.value.id)
+    if (!projectIds) return
+    await setDatasetProjectsMutation({ orgId: orgId.value, datasetId: currentDataset.value.id, projectIds })
+    await refetchDatasets()
+    showRemoveDatasetDialog.value = false
+    currentDataset.value = datasets.value[0] || null
+  }
 
   // --- Status banner ---
   const isBusy = computed(() => loading.value || entriesLoading.value || updating.value)
@@ -378,12 +423,12 @@ export function useQADatasetTable(props: Props) {
   }
 
   const handleQAJudgesUpdated = async (event: { projectId: string }) => {
-    if (projectId.value && event.projectId === projectId.value) await fetchLLMJudges(projectId.value)
+    if (projectId.value && event.projectId === projectId.value && orgId.value) await fetchLLMJudges(orgId.value)
   }
 
   // --- Lifecycle ---
   onMounted(async () => {
-    if (projectId.value) await fetchLLMJudges(projectId.value)
+    if (orgId.value) await fetchLLMJudges(orgId.value)
     setupListeners(handleQAJudgesUpdated, handleQAConversationSaved, handleQADatasetCreated)
     autoSelectVersion()
     autoSelectDataset()
@@ -403,13 +448,15 @@ export function useQADatasetTable(props: Props) {
   }
 
   watch(
-    () => projectId.value,
-    newProjectId => {
-      if (!newProjectId) return
+    () => orgId.value,
+    async newOrgId => {
+      if (!newOrgId) return
       currentDataset.value = null
       currentVersion.value = null
       columnVisibility.clearCache()
-      fetchLLMJudges(newProjectId)
+      await fetchLLMJudges(newOrgId)
+      autoSelectDataset()
+      autoSelectVersion()
     }
   )
 
@@ -420,6 +467,7 @@ export function useQADatasetTable(props: Props) {
 
   // --- Return ---
   return {
+    orgId,
     projectId,
     currentDataset,
     currentVersion,
@@ -439,7 +487,12 @@ export function useQADatasetTable(props: Props) {
     canManageDatasets,
     hasDatasets,
     datasetOptions,
+    unlinkedDatasetOptions,
     versionOptions,
+    addDatasetToProject,
+    showRemoveDatasetDialog,
+    openRemoveDatasetDialog,
+    confirmRemoveDatasetFromProject,
     headers,
     isBusy,
     statusText,

--- a/frontend/src/composables/useQAEvaluation.ts
+++ b/frontend/src/composables/useQAEvaluation.ts
@@ -25,9 +25,9 @@ export function useQAEvaluation() {
     evaluating: false,
   })
 
-  const fetchLLMJudges = async (projectId: string) => {
-    if (!projectId) {
-      error.value = 'No project ID provided'
+  const fetchLLMJudges = async (orgId: string) => {
+    if (!orgId) {
+      error.value = 'No organization ID provided'
 
       return
     }
@@ -36,7 +36,7 @@ export function useQAEvaluation() {
     error.value = null
 
     try {
-      const data = await qaEvaluationApi.getLLMJudges(projectId)
+      const data = await qaEvaluationApi.getLLMJudges(orgId)
 
       judges.value = data || []
     } catch (err: unknown) {
@@ -58,34 +58,34 @@ export function useQAEvaluation() {
     }
   }
 
-  const createJudge = async (projectId: string, judgeData: LLMJudgeCreate): Promise<boolean> => {
-    if (!projectId) {
-      error.value = 'No project ID provided'
+  const createJudge = async (orgId: string, judgeData: LLMJudgeCreate): Promise<LLMJudge | null> => {
+    if (!orgId) {
+      error.value = 'No organization ID provided'
 
-      return false
+      return null
     }
 
     loadingStates.value.creating = true
     error.value = null
 
     try {
-      await qaEvaluationApi.createLLMJudge(projectId, judgeData)
-      await fetchLLMJudges(projectId)
+      const created: LLMJudge = await qaEvaluationApi.createLLMJudge(orgId, judgeData)
+      await fetchLLMJudges(orgId)
 
-      return true
+      return created
     } catch (err: unknown) {
-      logger.error('[QA Judge] Failed to create judge', { projectId, name: judgeData.name, error: err })
+      logger.error('[QA Judge] Failed to create judge', { orgId, name: judgeData.name, error: err })
       error.value = err instanceof Error ? err.message : 'Failed to create LLM judge'
 
-      return false
+      return null
     } finally {
       loadingStates.value.creating = false
     }
   }
 
-  const updateJudge = async (projectId: string, judgeId: string, judgeData: LLMJudgeUpdate): Promise<boolean> => {
-    if (!projectId || !judgeId) {
-      error.value = 'Project ID and Judge ID are required'
+  const updateJudge = async (orgId: string, judgeId: string, judgeData: LLMJudgeUpdate): Promise<boolean> => {
+    if (!orgId || !judgeId) {
+      error.value = 'Organization ID and Judge ID are required'
 
       return false
     }
@@ -94,8 +94,8 @@ export function useQAEvaluation() {
     error.value = null
 
     try {
-      await qaEvaluationApi.updateLLMJudge(projectId, judgeId, judgeData)
-      await fetchLLMJudges(projectId)
+      await qaEvaluationApi.updateLLMJudge(orgId, judgeId, judgeData)
+      await fetchLLMJudges(orgId)
 
       return true
     } catch (err: unknown) {
@@ -107,9 +107,9 @@ export function useQAEvaluation() {
     }
   }
 
-  const deleteJudges = async (projectId: string, judgeIds: string[]): Promise<boolean> => {
-    if (!projectId || !judgeIds.length) {
-      error.value = 'Project ID and Judge IDs are required'
+  const deleteJudges = async (orgId: string, judgeIds: string[]): Promise<boolean> => {
+    if (!orgId || !judgeIds.length) {
+      error.value = 'Organization ID and Judge IDs are required'
 
       return false
     }
@@ -118,12 +118,12 @@ export function useQAEvaluation() {
     error.value = null
 
     try {
-      await qaEvaluationApi.deleteLLMJudges(projectId, judgeIds)
-      await fetchLLMJudges(projectId)
+      await qaEvaluationApi.deleteLLMJudges(orgId, judgeIds)
+      await fetchLLMJudges(orgId)
 
       return true
     } catch (err: unknown) {
-      logger.error('[QA Judge] Failed to delete judges', { projectId, count: judgeIds.length, error: err })
+      logger.error('[QA Judge] Failed to delete judges', { orgId, count: judgeIds.length, error: err })
       error.value = err instanceof Error ? err.message : 'Failed to delete LLM judges'
 
       return false
@@ -300,6 +300,23 @@ export function useQAEvaluation() {
     }
   }
 
+  const setJudgeProjects = async (orgId: string, judgeId: string, projectIds: string[]): Promise<boolean> => {
+    if (!orgId || !judgeId) {
+      error.value = 'Organization ID and Judge ID are required'
+      return false
+    }
+    error.value = null
+    try {
+      await qaEvaluationApi.setJudgeProjects(orgId, judgeId, projectIds)
+      await fetchLLMJudges(orgId)
+      return true
+    } catch (err: unknown) {
+      logger.error('[QA Judge] Failed to set judge projects', { orgId, judgeId, error: err })
+      error.value = err instanceof Error ? err.message : 'Failed to update judge projects'
+      return false
+    }
+  }
+
   watch(
     () => selectedOrgId.value,
     () => {
@@ -317,6 +334,7 @@ export function useQAEvaluation() {
     createJudge,
     updateJudge,
     deleteJudges,
+    setJudgeProjects,
     runEvaluations,
     fetchEvaluationsForVersionOutput,
     deleteEvaluationsForVersionOutput,

--- a/frontend/src/composables/useQATestCaseCrud.ts
+++ b/frontend/src/composables/useQATestCaseCrud.ts
@@ -45,11 +45,13 @@ export const extractErrorMessage = (error: unknown, defaultMessage: string): str
 // --- Deps interface ---
 
 interface CrudDeps {
+  orgId: ComputedRef<string>
   projectId: ComputedRef<string>
   currentDataset: Ref<QADataset | null>
   currentVersion: Ref<{ id: string; graph_runner_id?: string | null } | null>
   testCases: Ref<QATestCaseUI[]>
   datasets: ComputedRef<QADataset[]>
+  allOrgDatasets: ComputedRef<QADataset[]>
   customColumns: ComputedRef<QACustomColumn[]>
   allCustomColumns: ComputedRef<QACustomColumn[]>
   columnVisibility: {
@@ -63,31 +65,36 @@ interface CrudDeps {
   pushTestCases: (newCases: QATestCaseUI[]) => void
   removeTestCases: (ids: string[]) => void
 
-  createDatasetMutation: (args: { projectId: string; data: { datasets_name: string[] } }) => Promise<unknown>
-  deleteDatasetMutation: (args: { projectId: string; datasetIds: string[] }) => Promise<unknown>
+  createDatasetMutation: (args: { orgId: string; data: { datasets_name: string[] } }) => Promise<unknown>
+  deleteDatasetMutation: (args: { orgId: string; datasetIds: string[] }) => Promise<unknown>
+  setDatasetProjectsMutation: (args: {
+    orgId: string
+    datasetId: string
+    projectIds: string[]
+  }) => Promise<unknown>
   addInputGroundtruthMutation: (args: {
-    projectId: string
+    orgId: string
     datasetId: string
     data: { inputs_groundtruths: any[] }
   }) => Promise<any>
   updateInputGroundtruthMutation: (args: {
-    projectId: string
+    orgId: string
     datasetId: string
     data: { inputs_groundtruths: any[] }
   }) => Promise<unknown>
   deleteInputGroundtruthMutation: (args: {
-    projectId: string
+    orgId: string
     datasetId: string
     entryIds: string[]
   }) => Promise<unknown>
   createCustomColumnMutation: (args: {
-    projectId: string
+    orgId: string
     datasetId: string
     data: { column_name: string }
   }) => Promise<{ column_id?: string } | null>
-  deleteCustomColumnMutation: (args: { projectId: string; datasetId: string; columnId: string }) => Promise<unknown>
+  deleteCustomColumnMutation: (args: { orgId: string; datasetId: string; columnId: string }) => Promise<unknown>
   renameCustomColumnMutation: (args: {
-    projectId: string
+    orgId: string
     datasetId: string
     columnId: string
     data: { column_name: string }
@@ -104,11 +111,13 @@ interface CrudDeps {
 
 export function useQATestCaseCrud(deps: CrudDeps) {
   const {
+    orgId,
     projectId,
     currentDataset,
     currentVersion,
     testCases,
     datasets,
+    allOrgDatasets,
     customColumns,
     allCustomColumns,
     columnVisibility,
@@ -119,6 +128,7 @@ export function useQATestCaseCrud(deps: CrudDeps) {
     removeTestCases,
     createDatasetMutation,
     deleteDatasetMutation,
+    setDatasetProjectsMutation,
     addInputGroundtruthMutation,
     updateInputGroundtruthMutation,
     deleteInputGroundtruthMutation,
@@ -142,13 +152,13 @@ export function useQATestCaseCrud(deps: CrudDeps) {
   }
 
   const confirmDeleteDataset = async () => {
-    if (!projectId.value || !currentDataset.value) return
+    if (!orgId.value || !currentDataset.value) return
     try {
       deleteDatasetLoading.value = true
 
       const deletedId = currentDataset.value.id
 
-      await deleteDatasetMutation({ projectId: projectId.value, datasetIds: [deletedId] })
+      await deleteDatasetMutation({ orgId: orgId.value, datasetIds: [deletedId] })
       await refetchDatasets()
       if (currentDataset.value?.id === deletedId) currentDataset.value = datasets.value[0] || null
       showDeleteDatasetDialog.value = false
@@ -162,9 +172,9 @@ export function useQATestCaseCrud(deps: CrudDeps) {
   const testCaseToDelete = ref<QATestCaseUI | null>(null)
 
   const deleteSelectedTestCase = async () => {
-    if (!projectId.value || !currentDataset.value || !testCaseToDelete.value) return
+    if (!orgId.value || !currentDataset.value || !testCaseToDelete.value) return
     await deleteInputGroundtruthMutation({
-      projectId: projectId.value,
+      orgId: orgId.value,
       datasetId: currentDataset.value.id,
       entryIds: [testCaseToDelete.value.id],
     })
@@ -183,14 +193,14 @@ export function useQATestCaseCrud(deps: CrudDeps) {
   }
 
   const deleteSelectedTestCases = async () => {
-    if (!projectId.value || !currentDataset.value || !selected.value.length) return
+    if (!orgId.value || !currentDataset.value || !selected.value.length) return
     try {
       bulkDeleteLoading.value = true
 
       const ids = [...selected.value]
 
       await deleteInputGroundtruthMutation({
-        projectId: projectId.value,
+        orgId: orgId.value,
         datasetId: currentDataset.value.id,
         entryIds: ids,
       })
@@ -228,7 +238,7 @@ export function useQATestCaseCrud(deps: CrudDeps) {
   }
 
   const saveNewTestCase = async () => {
-    if (!projectId.value || !currentDataset.value) return
+    if (!orgId.value || !currentDataset.value) return
     const validMessages = addTestCaseMessages.value.filter(m => m.content.trim())
     if (!validMessages.length) return
 
@@ -259,7 +269,7 @@ export function useQATestCaseCrud(deps: CrudDeps) {
       const datasetId = currentDataset.value.id
 
       const result = await addInputGroundtruthMutation({
-        projectId: projectId.value,
+        orgId: orgId.value,
         datasetId,
         data: { inputs_groundtruths: [newEntry] },
       })
@@ -309,7 +319,7 @@ export function useQATestCaseCrud(deps: CrudDeps) {
   }
 
   const saveEditedTestCase = async () => {
-    if (!projectId.value || !currentDataset.value || !editingTestCase.value) return
+    if (!orgId.value || !currentDataset.value || !editingTestCase.value) return
     const tcId = editingTestCase.value.id
 
     editingTestCaseLoading.value = true
@@ -326,7 +336,7 @@ export function useQATestCaseCrud(deps: CrudDeps) {
 
       patchTestCase(tcId, { evaluations: [], output: null, version_output_id: null, status: 'Pending' })
       await updateInputGroundtruthMutation({
-        projectId: projectId.value,
+        orgId: orgId.value,
         datasetId: currentDataset.value.id,
         data: { inputs_groundtruths: [{ id: tcId, input: inputObj }] },
       })
@@ -348,11 +358,11 @@ export function useQATestCaseCrud(deps: CrudDeps) {
   const editingColumnName = ref('')
 
   const createCustomColumn = async (name: string) => {
-    if (!projectId.value || !currentDataset.value || !name.trim()) return
+    if (!orgId.value || !currentDataset.value || !name.trim()) return
     creatingColumn.value = true
     try {
       const newCol = await createCustomColumnMutation({
-        projectId: projectId.value,
+        orgId: orgId.value,
         datasetId: currentDataset.value.id,
         data: { column_name: name.trim() },
       })
@@ -384,7 +394,7 @@ export function useQATestCaseCrud(deps: CrudDeps) {
   }
 
   const saveEditingColumnName = async () => {
-    if (!editingColumnId.value || !editingColumnName.value.trim() || !projectId.value || !currentDataset.value) {
+    if (!editingColumnId.value || !editingColumnName.value.trim() || !orgId.value || !currentDataset.value) {
       cancelEditingColumnName()
       return
     }
@@ -397,7 +407,7 @@ export function useQATestCaseCrud(deps: CrudDeps) {
     const newName = editingColumnName.value.trim()
     try {
       await renameCustomColumnMutation({
-        projectId: projectId.value,
+        orgId: orgId.value,
         datasetId: currentDataset.value.id,
         columnId,
         data: { column_name: newName },
@@ -424,11 +434,11 @@ export function useQATestCaseCrud(deps: CrudDeps) {
   }
 
   const deleteCustomColumn = async () => {
-    if (!projectId.value || !currentDataset.value || !columnToDelete.value) return
+    if (!orgId.value || !currentDataset.value || !columnToDelete.value) return
     deletingColumn.value = true
     try {
       await deleteCustomColumnMutation({
-        projectId: projectId.value,
+        orgId: orgId.value,
         datasetId: currentDataset.value.id,
         columnId: columnToDelete.value.column_id,
       })
@@ -454,15 +464,28 @@ export function useQATestCaseCrud(deps: CrudDeps) {
   const showCreateDatasetDialog = ref(false)
 
   const createNewDataset = async (name: string) => {
-    if (!projectId.value || !name.trim()) return
+    if (!orgId.value || !name.trim()) return
     const createdName = name.trim()
 
-    await createDatasetMutation({ projectId: projectId.value, data: { datasets_name: [createdName] } })
+    await createDatasetMutation({ orgId: orgId.value, data: { datasets_name: [createdName] } })
     await refetchDatasets()
-    showCreateDatasetDialog.value = false
 
-    const justCreated = datasets.value.find(d => d.dataset_name === createdName)
-    if (justCreated) currentDataset.value = justCreated
+    const justCreated = allOrgDatasets.value.find(d => d.dataset_name === createdName)
+    if (justCreated && projectId.value) {
+      const existingIds = justCreated.project_ids || []
+      if (!existingIds.includes(projectId.value)) {
+        await setDatasetProjectsMutation({
+          orgId: orgId.value,
+          datasetId: justCreated.id,
+          projectIds: [...existingIds, projectId.value],
+        })
+        await refetchDatasets()
+      }
+    }
+
+    showCreateDatasetDialog.value = false
+    const updated = datasets.value.find(d => d.dataset_name === createdName)
+    if (updated) currentDataset.value = updated
   }
 
   // --- CSV ---
@@ -475,11 +498,11 @@ export function useQATestCaseCrud(deps: CrudDeps) {
   }
 
   const exportDatasetToCSV = async () => {
-    if (!projectId.value || !currentDataset.value || !currentVersion.value) return
+    if (!orgId.value || !currentDataset.value || !currentVersion.value) return
     exportingCSV.value = true
     try {
       await scopeoApi.qa.exportToCSV(
-        projectId.value,
+        orgId.value,
         currentDataset.value.id,
         currentVersion.value?.graph_runner_id || ''
       )
@@ -495,7 +518,7 @@ export function useQATestCaseCrud(deps: CrudDeps) {
     const target = event.target as HTMLInputElement
     const file = target.files?.[0]
     if (!file) return
-    if (!projectId.value || !currentDataset.value) {
+    if (!orgId.value || !currentDataset.value) {
       showError('Please select a dataset first')
       return
     }
@@ -511,7 +534,7 @@ export function useQATestCaseCrud(deps: CrudDeps) {
 
     importingCSV.value = true
     try {
-      const result = await scopeoApi.qa.importFromCSV(projectId.value, currentDataset.value.id, file)
+      const result = await scopeoApi.qa.importFromCSV(orgId.value, currentDataset.value.id, file)
 
       await refetchCustomColumns()
       if (currentVersion.value) await refetchTestCases()

--- a/frontend/src/composables/useQATestCaseEditing.ts
+++ b/frontend/src/composables/useQATestCaseEditing.ts
@@ -5,13 +5,14 @@ import type { QATestCaseUI, QAVersion } from '@/composables/queries/useQAQuery'
 export type EditableField = 'input' | 'groundtruth' | `custom-${string}`
 
 interface EditingDeps {
+  orgId: ComputedRef<string>
   projectId: ComputedRef<string>
   currentDataset: Ref<{ id: string } | null>
   testCases: Ref<QATestCaseUI[]>
   versions: ComputedRef<QAVersion[]>
   patchTestCase: (id: string, patch: Partial<QATestCaseUI>) => void
   updateInputGroundtruthMutation: (args: {
-    projectId: string
+    orgId: string
     datasetId: string
     data: { inputs_groundtruths: any[] }
   }) => Promise<unknown>
@@ -26,6 +27,7 @@ interface EditingDeps {
 
 export function useQATestCaseEditing(deps: EditingDeps) {
   const {
+    orgId,
     projectId,
     currentDataset,
     testCases,
@@ -119,8 +121,9 @@ export function useQATestCaseEditing(deps: EditingDeps) {
   }
 
   const onUpdateTestCase = (testCase: QATestCaseUI, field: EditableField) => {
-    if (!projectId.value || !currentDataset.value) return
+    if (!orgId.value || !currentDataset.value) return
     const datasetId = currentDataset.value.id
+    const currentOrgId = orgId.value
     const projId = projectId.value
 
     if (field === 'input') return
@@ -146,7 +149,7 @@ export function useQATestCaseEditing(deps: EditingDeps) {
           const latestValue = latest.custom_columns?.[columnId] ?? null
           try {
             await updateInputGroundtruthMutation({
-              projectId: projId,
+              orgId: currentOrgId,
               datasetId,
               data: { inputs_groundtruths: [{ id: testCase.id, custom_columns: { [columnId]: latestValue } }] },
             })
@@ -184,7 +187,7 @@ export function useQATestCaseEditing(deps: EditingDeps) {
         patchTestCase(testCase.id, { evaluations: [] })
         try {
           await updateInputGroundtruthMutation({
-            projectId: projId,
+            orgId: currentOrgId,
             datasetId,
             data: { inputs_groundtruths: [{ id: testCase.id, groundtruth: latest.groundtruth || '' }] },
           })

--- a/frontend/src/composables/useSaveToQA.ts
+++ b/frontend/src/composables/useSaveToQA.ts
@@ -9,12 +9,13 @@ interface SaveToQAItem {
 }
 
 interface UseSaveToQAOptions {
+  orgId: Ref<string | undefined>
   projectId: Ref<string | undefined>
   getConversationData?: () => SaveToQAItem | null
 }
 
 export function useSaveToQA(options: UseSaveToQAOptions) {
-  const { projectId, getConversationData } = options
+  const { orgId, projectId, getConversationData } = options
   const { emitConversationSaved, emitDatasetCreated } = useQAEvents()
 
   // State
@@ -50,7 +51,7 @@ export function useSaveToQA(options: UseSaveToQAOptions) {
 
   // Load QA datasets
   const loadQADatasets = async () => {
-    if (!projectId.value) return
+    if (!orgId.value) return
 
     // If datasets already loaded, just ensure first one is selected
     if (qaDatasets.value.length > 0) {
@@ -61,7 +62,7 @@ export function useSaveToQA(options: UseSaveToQAOptions) {
 
     loadingQADatasets.value = true
     try {
-      const datasets = await scopeoApi.qa.getDatasets(projectId.value)
+      const datasets = await scopeoApi.qa.getDatasets(orgId.value)
 
       qaDatasets.value = datasets || []
 
@@ -77,7 +78,7 @@ export function useSaveToQA(options: UseSaveToQAOptions) {
 
   // Create new dataset
   const createDataset = async () => {
-    if (!projectId.value || !newDatasetName.value.trim()) return
+    if (!orgId.value || !newDatasetName.value.trim()) return
 
     const datasetNameToCreate = newDatasetName.value.trim()
 
@@ -85,7 +86,7 @@ export function useSaveToQA(options: UseSaveToQAOptions) {
     saveToQAError.value = null
 
     try {
-      await scopeoApi.qa.createDatasets(projectId.value, {
+      await scopeoApi.qa.createDatasets(orgId.value, {
         datasets_name: [datasetNameToCreate],
       })
 
@@ -93,10 +94,13 @@ export function useSaveToQA(options: UseSaveToQAOptions) {
       qaDatasets.value = [] // Clear cache to force reload
       loadingQADatasets.value = true
 
-      const datasets = await scopeoApi.qa.getDatasets(projectId.value)
+      try {
+        const datasets = await scopeoApi.qa.getDatasets(orgId.value)
 
-      qaDatasets.value = datasets || []
-      loadingQADatasets.value = false
+        qaDatasets.value = datasets || []
+      } finally {
+        loadingQADatasets.value = false
+      }
 
       // Auto-select the newly created dataset by name
       const newDataset = qaDatasets.value.find(d => d.dataset_name === datasetNameToCreate)
@@ -149,7 +153,7 @@ export function useSaveToQA(options: UseSaveToQAOptions) {
   // TanStack Query mutation for saving trace
   const saveTraceMutation = useMutation({
     mutationFn: ({ traceId, datasetId }: { traceId: string; datasetId: string }) =>
-      scopeoApi.qa.saveTraceToQA(projectId.value!, traceId, datasetId),
+      scopeoApi.qa.saveTraceToQA(orgId.value!, traceId, datasetId),
     gcTime: 0, // No cache
     onSuccess: (_, variables) => {
       saveToQASuccess.value = true
@@ -178,7 +182,7 @@ export function useSaveToQA(options: UseSaveToQAOptions) {
 
   // Save to QA
   const saveToQA = async () => {
-    if (!selectedQADataset.value || !projectId.value || !getConversationData) return
+    if (!selectedQADataset.value || !orgId.value || !getConversationData) return
 
     // Guard against concurrent saves
     if (savingToQA.value) {

--- a/frontend/src/types/qa.ts
+++ b/frontend/src/types/qa.ts
@@ -1,8 +1,9 @@
 // Dataset types
 export interface QADataset {
   id: string
-  project_id: string
+  organization_id: string
   dataset_name: string
+  project_ids: string[]
   created_at: string
   updated_at: string
 }
@@ -135,7 +136,8 @@ export type EvaluationType = 'boolean' | 'score' | 'free_text' | 'json_equality'
 
 export interface LLMJudge {
   id: string
-  project_id: string
+  organization_id: string
+  project_ids: string[]
   name: string
   description?: string | null
   evaluation_type: EvaluationType

--- a/mcp_server/tools/qa.py
+++ b/mcp_server/tools/qa.py
@@ -13,26 +13,29 @@ from mcp_server.client import api
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
 from mcp_server.tools.context_tools import _get_auth
 
+_P_ORG = Param("organization_id", UUID, description="The organization ID (from select_organization).")
 _P_PROJECT = Param("project_id", UUID, description="The project ID (from list_projects or get_project_overview).")
 _P_DATASET = Param("dataset_id", UUID, description="The dataset ID (from list_datasets or create_dataset).")
 _P_JUDGE = Param("judge_id", UUID, description="The judge ID (from list_judges or create_judge).")
 
-_QA = "/projects/{project_id}/qa"
-_DS = f"{_QA}/datasets"
+_ORG_QA = "/organizations/{organization_id}/qa"
+_DS = f"{_ORG_QA}/datasets"
 _DS_ITEM = f"{_DS}/{{dataset_id}}"
 _ENTRIES = f"{_DS_ITEM}/entries"
 _CUSTOM_COLS = f"{_DS_ITEM}/custom-columns"
-_JUDGES = f"{_QA}/llm-judges"
+_JUDGES = f"{_ORG_QA}/llm-judges"
 _JUDGE_ITEM = f"{_JUDGES}/{{judge_id}}"
 
+_PROJ_QA = "/projects/{project_id}/qa"
+
 SPECS: list[ToolSpec] = [
-    # --- Datasets ---
+    # --- Datasets (org-scoped) ---
     ToolSpec(
         name="list_datasets",
-        description="List QA datasets for a project.",
+        description="List QA datasets for an organization.",
         method="get",
         path=_DS,
-        path_params=(_P_PROJECT,),
+        path_params=(_P_ORG,),
         return_annotation=list,
     ),
     ToolSpec(
@@ -44,7 +47,7 @@ SPECS: list[ToolSpec] = [
         ),
         method="post",
         path=_DS,
-        path_params=(_P_PROJECT,),
+        path_params=(_P_ORG,),
         body_param=Param(
             "dataset_data", dict,
             description="Dataset configuration. Required fields: datasets_name (list[str]).",
@@ -55,7 +58,7 @@ SPECS: list[ToolSpec] = [
         description="Rename a QA dataset.",
         method="patch",
         path=_DS_ITEM,
-        path_params=(_P_PROJECT, _P_DATASET),
+        path_params=(_P_ORG, _P_DATASET),
         query_params=(Param("dataset_name", str, description="New name for the dataset."),),
     ),
     ToolSpec(
@@ -63,10 +66,18 @@ SPECS: list[ToolSpec] = [
         description="Destructive. Delete one or more QA datasets.",
         method="delete",
         path=_DS,
-        path_params=(_P_PROJECT,),
+        path_params=(_P_ORG,),
         body_fields=(Param("dataset_ids", list, description="List of dataset IDs to delete."),),
     ),
-    # --- Entries ---
+    ToolSpec(
+        name="set_dataset_projects",
+        description="Set which projects a dataset is associated with (replaces existing associations).",
+        method="put",
+        path=f"{_DS_ITEM}/projects",
+        path_params=(_P_ORG, _P_DATASET),
+        body_fields=(Param("project_ids", list, description="List of project IDs to associate."),),
+    ),
+    # --- Entries (org-scoped) ---
     ToolSpec(
         name="list_entries",
         description=(
@@ -81,7 +92,7 @@ SPECS: list[ToolSpec] = [
         ),
         method="get",
         path=_ENTRIES,
-        path_params=(_P_PROJECT, _P_DATASET),
+        path_params=(_P_ORG, _P_DATASET),
         query_params=(
             Param("page", int, default=1, description="Page number (1-based)."),
             Param("page_size", int, default=100, description="Items per page (max 1000)."),
@@ -100,7 +111,7 @@ SPECS: list[ToolSpec] = [
         ),
         method="post",
         path=_ENTRIES,
-        path_params=(_P_PROJECT, _P_DATASET),
+        path_params=(_P_ORG, _P_DATASET),
         body_fields=(Param(
             "inputs_groundtruths", list,
             description="List of input/groundtruth objects.",
@@ -119,7 +130,7 @@ SPECS: list[ToolSpec] = [
         ),
         method="patch",
         path=_ENTRIES,
-        path_params=(_P_PROJECT, _P_DATASET),
+        path_params=(_P_ORG, _P_DATASET),
         body_fields=(Param(
             "inputs_groundtruths", list,
             description="List of input/groundtruth objects with their IDs and updated fields.",
@@ -130,7 +141,7 @@ SPECS: list[ToolSpec] = [
         description="Destructive. Delete entries from a QA dataset.",
         method="delete",
         path=_ENTRIES,
-        path_params=(_P_PROJECT, _P_DATASET),
+        path_params=(_P_ORG, _P_DATASET),
         body_fields=(
             Param(
                 "input_groundtruth_ids", list,
@@ -143,10 +154,10 @@ SPECS: list[ToolSpec] = [
         description="Save a trace execution as a QA dataset entry.",
         method="post",
         path=f"{_ENTRIES}/from-history",
-        path_params=(_P_PROJECT, _P_DATASET),
+        path_params=(_P_ORG, _P_DATASET),
         query_params=(Param("trace_id", UUID, description="The trace ID to save as a QA entry (from list_traces)."),),
     ),
-    # --- Custom Columns ---
+    # --- Custom Columns (org-scoped) ---
     ToolSpec(
         name="list_custom_columns",
         description=(
@@ -159,9 +170,10 @@ SPECS: list[ToolSpec] = [
         ),
         method="get",
         path=_CUSTOM_COLS,
-        path_params=(_P_PROJECT, _P_DATASET),
+        path_params=(_P_ORG, _P_DATASET),
         return_annotation=list,
     ),
+    # --- QA Runs (project-scoped) ---
     ToolSpec(
         name="run_qa",
         description=(
@@ -170,7 +182,7 @@ SPECS: list[ToolSpec] = [
             "`output`, `evaluations`, and `version_output_id` as stale."
         ),
         method="post",
-        path=f"{_DS_ITEM}/run",
+        path=f"{_PROJ_QA}/datasets/{{dataset_id}}/run",
         path_params=(_P_PROJECT, _P_DATASET),
         body_param=Param(
             "run_config", dict,
@@ -180,13 +192,13 @@ SPECS: list[ToolSpec] = [
             ),
         ),
     ),
-    # --- Judges ---
+    # --- Judges (org-scoped) ---
     ToolSpec(
         name="list_judges",
-        description="List LLM judges for a project.",
+        description="List LLM judges for an organization.",
         method="get",
         path=_JUDGES,
-        path_params=(_P_PROJECT,),
+        path_params=(_P_ORG,),
         return_annotation=list,
     ),
     ToolSpec(
@@ -203,7 +215,7 @@ SPECS: list[ToolSpec] = [
         ),
         method="post",
         path=_JUDGES,
-        path_params=(_P_PROJECT,),
+        path_params=(_P_ORG,),
         body_param=Param(
             "judge_data", dict,
             description=(
@@ -219,7 +231,7 @@ SPECS: list[ToolSpec] = [
         description="Update an LLM judge.",
         method="patch",
         path=_JUDGE_ITEM,
-        path_params=(_P_PROJECT, _P_JUDGE),
+        path_params=(_P_ORG, _P_JUDGE),
         body_param=Param("judge_data", dict, description="Updated judge fields."),
     ),
     ToolSpec(
@@ -227,9 +239,18 @@ SPECS: list[ToolSpec] = [
         description="Destructive. Delete one or more LLM judges.",
         method="delete",
         path=_JUDGES,
-        path_params=(_P_PROJECT,),
+        path_params=(_P_ORG,),
         body_param=Param("judge_ids", list, description="List of judge IDs to delete."),
     ),
+    ToolSpec(
+        name="set_judge_projects",
+        description="Set which projects a judge is associated with (replaces existing associations).",
+        method="put",
+        path=f"{_JUDGE_ITEM}/projects",
+        path_params=(_P_ORG, _P_JUDGE),
+        body_fields=(Param("project_ids", list, description="List of project IDs to associate."),),
+    ),
+    # --- Evaluations (project-scoped) ---
     ToolSpec(
         name="run_evaluation",
         description=(
@@ -239,7 +260,7 @@ SPECS: list[ToolSpec] = [
             "written for each output afterward."
         ),
         method="post",
-        path=f"{_JUDGE_ITEM}/evaluations/run",
+        path=f"{_PROJ_QA}/llm-judges/{{judge_id}}/evaluations/run",
         path_params=(_P_PROJECT, _P_JUDGE),
         body_fields=(
             Param(
@@ -253,7 +274,7 @@ SPECS: list[ToolSpec] = [
         name="get_evaluations",
         description="Get evaluation results for a version output.",
         method="get",
-        path=f"{_QA}/version-outputs/{{version_output_id}}/evaluations",
+        path=f"{_PROJ_QA}/version-outputs/{{version_output_id}}/evaluations",
         path_params=(
             _P_PROJECT,
             Param("version_output_id", UUID, description="The version output ID (from run_qa results)."),
@@ -268,7 +289,7 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool()
     async def export_dataset_csv(
-        project_id: Annotated[UUID, Field(description="The project ID (from list_projects or get_project_overview).")],
+        organization_id: Annotated[UUID, Field(description="The organization ID (from select_organization).")],
         dataset_id: Annotated[UUID, Field(description="The dataset ID (from list_datasets or create_dataset).")],
     ) -> str:
         """Export all entries in a QA dataset as CSV text.
@@ -280,7 +301,7 @@ def register(mcp: FastMCP) -> None:
         jwt, _ = _get_auth()
 
         columns = await api.get(
-            f"/projects/{project_id}/qa/datasets/{dataset_id}/custom-columns",
+            f"/organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns",
             jwt, trim=False,
         )
         sorted_cols = sorted(columns, key=lambda c: c.get("column_display_position", 0))
@@ -289,7 +310,7 @@ def register(mcp: FastMCP) -> None:
         page = 1
         while True:
             resp = await api.get(
-                f"/projects/{project_id}/qa/datasets/{dataset_id}/entries",
+                f"/organizations/{organization_id}/qa/datasets/{dataset_id}/entries",
                 jwt, page=page, page_size=100, trim=False,
             )
             all_entries.extend(resp.get("inputs_groundtruths", []))
@@ -323,7 +344,7 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool()
     async def import_dataset_csv(
-        project_id: Annotated[UUID, Field(description="The project ID (from list_projects or get_project_overview).")],
+        organization_id: Annotated[UUID, Field(description="The organization ID (from select_organization).")],
         dataset_id: Annotated[UUID, Field(description="The dataset ID (from list_datasets or create_dataset).")],
         csv_content: Annotated[str, Field(description="The full CSV text to import.")],
     ) -> dict:
@@ -342,7 +363,7 @@ def register(mcp: FastMCP) -> None:
         jwt, _ = _get_auth()
 
         return await api.post_file(
-            f"/projects/{project_id}/qa/datasets/{dataset_id}/import",
+            f"/organizations/{organization_id}/qa/datasets/{dataset_id}/import",
             jwt,
             file_content=csv_content.encode("utf-8"),
             filename="import.csv",

--- a/tests/ada_backend/test_qa_evaluation_services.py
+++ b/tests/ada_backend/test_qa_evaluation_services.py
@@ -17,7 +17,7 @@ from ada_backend.services.project_service import delete_project_service
 from ada_backend.services.qa.llm_judges_service import (
     create_llm_judge_service,
     delete_llm_judges_service,
-    get_llm_judges_by_project_service,
+    get_llm_judges_by_organization_service,
     update_llm_judge_service,
 )
 from ada_backend.services.qa.qa_evaluation_service import (
@@ -25,7 +25,7 @@ from ada_backend.services.qa.qa_evaluation_service import (
     get_evaluations_by_version_output_service,
     run_judge_evaluation_service,
 )
-from tests.ada_backend.test_utils import create_project_and_graph_runner
+from tests.ada_backend.test_utils import ORGANIZATION_ID, create_project_and_graph_runner
 
 MOCK_LLM_SERVICE_PATH = (
     "ada_backend.services.qa.qa_evaluation_service.CompletionService.constrained_complete_with_pydantic_async"
@@ -35,7 +35,7 @@ MOCK_LLM_SERVICE_PATH = (
 def _create_evaluation_scenario(session, project_id: UUID, graph_runner_id: UUID) -> dict:
     datasets = create_datasets(
         session=session,
-        project_id=project_id,
+        organization_id=ORGANIZATION_ID,
         dataset_names=["test_dataset"],
     )
 
@@ -59,7 +59,7 @@ def _create_evaluation_scenario(session, project_id: UUID, graph_runner_id: UUID
 
     judge = create_llm_judge_service(
         session=session,
-        project_id=project_id,
+        organization_id=ORGANIZATION_ID,
         judge_data=LLMJudgeCreate(
             name="Test Judge",
             evaluation_type=EvaluationType.BOOLEAN,
@@ -81,8 +81,8 @@ def test_llm_judge_management():
             session, project_name_prefix="llm_judge_management_test", description="Test project"
         )
 
-        judges = get_llm_judges_by_project_service(session=session, project_id=project_id)
-        assert judges == []
+        judges = get_llm_judges_by_organization_service(session=session, organization_id=ORGANIZATION_ID)
+        initial_count = len(judges)
 
         create_data = LLMJudgeCreate(
             name="Test Judge",
@@ -92,22 +92,22 @@ def test_llm_judge_management():
         )
         judge = create_llm_judge_service(
             session=session,
-            project_id=project_id,
+            organization_id=ORGANIZATION_ID,
             judge_data=create_data,
         )
         assert judge.name == "Test Judge"
         judge_id = judge.id
 
-        judges = get_llm_judges_by_project_service(session=session, project_id=project_id)
-        assert len(judges) == 1
-        assert judges[0].id == judge_id
-        assert judges[0].name == "Test Judge"
-        assert judges[0].project_id == project_id
+        judges = get_llm_judges_by_organization_service(session=session, organization_id=ORGANIZATION_ID)
+        assert len(judges) == initial_count + 1
+        created_judge = next(j for j in judges if j.id == judge_id)
+        assert created_judge.name == "Test Judge"
+        assert created_judge.organization_id == ORGANIZATION_ID
 
         update_data = LLMJudgeUpdate(name="Updated Judge Name", description="Updated description", temperature=0.9)
         updated_judge = update_llm_judge_service(
             session=session,
-            project_id=project_id,
+            organization_id=ORGANIZATION_ID,
             judge_id=judge_id,
             judge_data=update_data,
         )
@@ -118,7 +118,7 @@ def test_llm_judge_management():
 
         delete_llm_judges_service(
             session=session,
-            project_id=project_id,
+            organization_id=ORGANIZATION_ID,
             judge_ids=[judge_id],
         )
 
@@ -126,7 +126,7 @@ def test_llm_judge_management():
         with pytest.raises(LLMJudgeNotFound):
             update_llm_judge_service(
                 session=session,
-                project_id=project_id,
+                organization_id=ORGANIZATION_ID,
                 judge_id=judge_id,
                 judge_data=update_data,
             )

--- a/tests/ada_backend/test_quality_assurance_service.py
+++ b/tests/ada_backend/test_quality_assurance_service.py
@@ -8,7 +8,10 @@ import pytest
 
 from ada_backend.database.models import EnvType
 from ada_backend.database.setup_db import get_db_session
-from ada_backend.repositories.quality_assurance_repository import get_qa_columns_by_dataset
+from ada_backend.repositories.quality_assurance_repository import (
+    get_qa_columns_by_dataset,
+    set_dataset_project_associations,
+)
 from ada_backend.schemas.dataset_schema import DatasetCreateList, DatasetDeleteList
 from ada_backend.schemas.input_groundtruth_schema import (
     InputGroundtruthCreateList,
@@ -29,7 +32,7 @@ from ada_backend.services.qa.qa_error import (
     CSVMissingDatasetColumnError,
     CSVNonUniquePositionError,
     QAColumnNotFoundError,
-    QADatasetNotInProjectError,
+    QADatasetNotInOrganizationError,
     QADuplicatePositionError,
     QAPartialPositionError,
 )
@@ -45,7 +48,7 @@ from ada_backend.services.qa.quality_assurance_service import (
     delete_datasets_service,
     delete_inputs_groundtruths_service,
     export_qa_data_to_csv_service,
-    get_datasets_by_project_service,
+    get_datasets_by_organization_service,
     get_inputs_groundtruths_with_version_outputs_service,
     import_qa_data_from_csv_service,
     run_qa_service,
@@ -53,7 +56,7 @@ from ada_backend.services.qa.quality_assurance_service import (
     update_inputs_groundtruths_service,
 )
 from engine.trace.trace_context import set_trace_manager
-from tests.ada_backend.test_utils import create_project_and_graph_runner
+from tests.ada_backend.test_utils import ORGANIZATION_ID, create_project_and_graph_runner
 
 # JSON constants for test workflow configuration
 DEFAULT_PAYLOAD_SCHEMA = {"messages": [{"role": "user", "content": "Hello"}], "additional_info": "info"}
@@ -116,7 +119,7 @@ def test_pagination():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"pagination_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"pagination_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -170,36 +173,39 @@ def test_dataset_management():
             session, project_name_prefix="dataset_test", description="Test project for dataset management"
         )
 
+        initial_datasets = get_datasets_by_organization_service(session, ORGANIZATION_ID)
+        initial_count = len(initial_datasets)
+
         # Test dataset creation
         create_payload = DatasetCreateList(datasets_name=["dataset1", "dataset2", "dataset3"])
-        created_response = create_datasets_service(session, project_id, create_payload)
+        created_response = create_datasets_service(session, ORGANIZATION_ID, create_payload)
         created_datasets = created_response.datasets
         assert len(created_datasets) == 3
 
         # Test dataset retrieval
-        retrieved_datasets = get_datasets_by_project_service(session, project_id)
-        assert len(retrieved_datasets) == 3
+        retrieved_datasets = get_datasets_by_organization_service(session, ORGANIZATION_ID)
+        assert len(retrieved_datasets) == initial_count + 3
 
         # Test dataset update
         dataset_to_update = created_datasets[0].id
-        updated_dataset = update_dataset_service(session, project_id, dataset_to_update, "updated_dataset1")
+        updated_dataset = update_dataset_service(session, ORGANIZATION_ID, dataset_to_update, "updated_dataset1")
         assert updated_dataset.dataset_name == "updated_dataset1"
 
         # Test dataset deletion
         dataset_to_delete = created_datasets[1].id
         delete_payload = DatasetDeleteList(dataset_ids=[dataset_to_delete])
-        deleted_count = delete_datasets_service(session, project_id, delete_payload)
-        assert deleted_count == 1  # Should have deleted 1 dataset
+        deleted_count = delete_datasets_service(session, ORGANIZATION_ID, delete_payload)
+        assert deleted_count == 1
 
         # Verify the dataset was deleted
-        remaining_datasets = get_datasets_by_project_service(session, project_id)
-        assert len(remaining_datasets) == 2  # Should now have 2 datasets instead of 3
+        remaining_datasets = get_datasets_by_organization_service(session, ORGANIZATION_ID)
+        assert len(remaining_datasets) == initial_count + 2
 
         # Test that deleting a dataset cascades to QA metadata (custom columns)
         dataset_with_columns = created_datasets[0].id
         # Create custom columns for this dataset
-        create_qa_column_service(session, project_id, dataset_with_columns, "Priority")
-        create_qa_column_service(session, project_id, dataset_with_columns, "Category")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_with_columns, "Priority")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_with_columns, "Category")
 
         # Verify columns exist
         columns_before = get_qa_columns_by_dataset(session, dataset_with_columns)
@@ -207,7 +213,7 @@ def test_dataset_management():
 
         # Delete the dataset
         delete_payload2 = DatasetDeleteList(dataset_ids=[dataset_with_columns])
-        deleted_count2 = delete_datasets_service(session, project_id, delete_payload2)
+        deleted_count2 = delete_datasets_service(session, ORGANIZATION_ID, delete_payload2)
         assert deleted_count2 == 1
 
         # Verify QA metadata was cascaded (deleted)
@@ -229,7 +235,7 @@ def test_input_groundtruth_basic_operations():
         # Create a dataset
         dataset_uuid = str(uuid4())
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"input_groundtruth_dataset_{dataset_uuid}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"input_groundtruth_dataset_{dataset_uuid}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -431,9 +437,11 @@ async def test_run_qa_service():
         # Create a dataset
         dataset_uuid = str(uuid4())
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"qa_run_dataset_{dataset_uuid}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"qa_run_dataset_{dataset_uuid}"])
         )
         dataset_id = dataset_data.datasets[0].id
+
+        set_dataset_project_associations(session, dataset_id, [project_id])
 
         # Create input-groundtruth entries
         input_payload = InputGroundtruthCreateList(
@@ -529,7 +537,7 @@ def test_position_field_in_responses():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"index_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"index_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -584,7 +592,7 @@ def test_duplicate_positions_validation():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"duplicate_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"duplicate_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -610,7 +618,7 @@ def test_partial_position_validation():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"partial_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"partial_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -636,7 +644,7 @@ def test_position_auto_generation():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"auto_index_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"auto_index_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -663,7 +671,7 @@ def test_csv_import_duplicate_positions_inside_csv():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_duplicate_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_duplicate_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -679,7 +687,7 @@ def test_csv_import_duplicate_positions_inside_csv():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         with pytest.raises(CSVNonUniquePositionError) as exc_info:
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         error_detail = str(exc_info.value)
         assert "Duplicate positions found in CSV import: [1]" in error_detail
         assert "CSV import" in error_detail
@@ -697,7 +705,7 @@ def test_csv_import_invalid_positions_values():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_invalid_index_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_invalid_index_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -711,7 +719,7 @@ def test_csv_import_invalid_positions_values():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         with pytest.raises(CSVInvalidPositionError) as exc_info:
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         error_detail = str(exc_info.value)
         assert "Invalid integer in 'position' column" in error_detail
         assert "row" in error_detail
@@ -727,7 +735,7 @@ def test_csv_import_position_less_than_one():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_position_lt_one_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_position_lt_one_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -740,7 +748,7 @@ def test_csv_import_position_less_than_one():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         with pytest.raises(CSVInvalidPositionError) as exc_info:
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         error_detail = str(exc_info.value)
         assert "Invalid integer in 'position' column" in error_detail
         assert "greater than or equal to 1" in error_detail
@@ -758,7 +766,7 @@ def test_csv_import_creates_new_custom_columns_and_values():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_custom_cols_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_custom_cols_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -778,7 +786,7 @@ def test_csv_import_creates_new_custom_columns_and_values():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         # Import CSV
-        import_response = import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+        import_response = import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         imported_entries = import_response.inputs_groundtruths
         assert len(imported_entries) == 2
 
@@ -821,13 +829,13 @@ def test_csv_import_requires_all_existing_custom_columns_in_header():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_missing_cols_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_missing_cols_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create two existing custom columns
-        create_qa_column_service(session, project_id, dataset_id, "col_a")
-        create_qa_column_service(session, project_id, dataset_id, "col_b")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "col_a")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "col_b")
 
         # Verify columns exist
         existing_columns = get_qa_columns_by_dataset(session, dataset_id)
@@ -846,7 +854,7 @@ def test_csv_import_requires_all_existing_custom_columns_in_header():
 
         # Should raise CSVMissingDatasetColumnError
         with pytest.raises(CSVMissingDatasetColumnError) as exc_info:
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         error_detail = str(exc_info.value)
         assert "col_b" in error_detail or "col_b" in error_detail.lower()
 
@@ -863,12 +871,12 @@ def test_csv_import_adds_new_columns_while_preserving_existing():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_mixed_cols_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_mixed_cols_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create one existing custom column
-        existing_col_response = create_qa_column_service(session, project_id, dataset_id, "existing_col")
+        existing_col_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "existing_col")
         existing_column_id = existing_col_response.column_id
 
         # CSV with both existing and new column
@@ -881,7 +889,7 @@ def test_csv_import_adds_new_columns_while_preserving_existing():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         # Import CSV
-        import_response = import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+        import_response = import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         assert len(import_response.inputs_groundtruths) == 1
 
         # Verify both columns exist
@@ -918,7 +926,7 @@ def test_csv_import_handles_missing_cell_values_for_custom_columns():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_empty_cells_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_empty_cells_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -934,7 +942,7 @@ def test_csv_import_handles_missing_cell_values_for_custom_columns():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         # Import CSV
-        import_response = import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+        import_response = import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         assert len(import_response.inputs_groundtruths) == 2
 
         # Verify column was created
@@ -968,7 +976,7 @@ def test_csv_import_uses_get_headers_from_csv_and_processes_all_rows():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_all_rows_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_all_rows_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -986,7 +994,7 @@ def test_csv_import_uses_get_headers_from_csv_and_processes_all_rows():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         # Import CSV
-        import_response = import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+        import_response = import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         imported_entries = import_response.inputs_groundtruths
         assert len(imported_entries) == 3
 
@@ -1023,20 +1031,20 @@ def test_get_qa_columns_by_dataset_service():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"get_columns_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"get_columns_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Initially no columns
-        columns_response = get_qa_columns_by_dataset_service(session, project_id, dataset_id)
+        columns_response = get_qa_columns_by_dataset_service(session, ORGANIZATION_ID, dataset_id)
         assert len(columns_response) == 0
 
         # Create two columns
-        create_qa_column_service(session, project_id, dataset_id, "Priority")
-        create_qa_column_service(session, project_id, dataset_id, "Category")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
+        create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Category")
 
         # Get columns again
-        columns_response = get_qa_columns_by_dataset_service(session, project_id, dataset_id)
+        columns_response = get_qa_columns_by_dataset_service(session, ORGANIZATION_ID, dataset_id)
         assert len(columns_response) == 2
 
         # Verify columns are sorted by column_display_position
@@ -1044,20 +1052,15 @@ def test_get_qa_columns_by_dataset_service():
         column_names = {col.column_name for col in columns_response}
         assert column_names == {"Priority", "Category"}
 
-        # Test error case: dataset not in project
-        project_id2, _ = create_project_and_graph_runner(
-            session,
-            project_name_prefix="get_columns_project2",
-            description="Test project 2",
-        )
+        # Test error case: dataset not in organization
+        other_org_id = uuid4()
 
-        with pytest.raises(QADatasetNotInProjectError) as exc_info:
-            get_qa_columns_by_dataset_service(session, project_id2, dataset_id)
-        assert str(project_id2) in str(exc_info.value)
+        with pytest.raises(QADatasetNotInOrganizationError) as exc_info:
+            get_qa_columns_by_dataset_service(session, other_org_id, dataset_id)
+        assert str(other_org_id) in str(exc_info.value)
         assert str(dataset_id) in str(exc_info.value)
 
         delete_project_service(session=session, project_id=project_id)
-        delete_project_service(session=session, project_id=project_id2)
 
 
 def test_create_qa_column_service():
@@ -1070,25 +1073,25 @@ def test_create_qa_column_service():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"create_column_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"create_column_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create first column
-        col_response = create_qa_column_service(session, project_id, dataset_id, "Priority")
+        col_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
         assert col_response.column_name == "Priority"
         assert col_response.column_display_position == 0
         assert col_response.column_id is not None
         assert col_response.dataset_id == dataset_id
 
         # Create second column
-        col2_response = create_qa_column_service(session, project_id, dataset_id, "Category")
+        col2_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Category")
         assert col2_response.column_name == "Category"
         assert col2_response.column_display_position == 1
         assert col2_response.column_id != col_response.column_id
 
         # Create third column to verify sequential column positions
-        col3_response = create_qa_column_service(session, project_id, dataset_id, "Third")
+        col3_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Third")
         assert col3_response.column_display_position == 2
 
         # Verify all columns exist and positions are sequential
@@ -1097,20 +1100,15 @@ def test_create_qa_column_service():
         positions = [col.column_display_position for col in columns]
         assert positions == [0, 1, 2]
 
-        # Test error case: dataset not in project
-        project_id2, _ = create_project_and_graph_runner(
-            session,
-            project_name_prefix="create_col_project2",
-            description="Test project 2",
-        )
+        # Test error case: dataset not in organization
+        other_org_id = uuid4()
 
-        with pytest.raises(QADatasetNotInProjectError) as exc_info:
-            create_qa_column_service(session, project_id2, dataset_id, "Priority")
-        assert str(project_id2) in str(exc_info.value)
+        with pytest.raises(QADatasetNotInOrganizationError) as exc_info:
+            create_qa_column_service(session, other_org_id, dataset_id, "Priority")
+        assert str(other_org_id) in str(exc_info.value)
         assert str(dataset_id) in str(exc_info.value)
 
         delete_project_service(session=session, project_id=project_id)
-        delete_project_service(session=session, project_id=project_id2)
 
 
 def test_rename_qa_column_service():
@@ -1123,17 +1121,17 @@ def test_rename_qa_column_service():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"rename_column_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"rename_column_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create a column
-        original_col = create_qa_column_service(session, project_id, dataset_id, "OldName")
+        original_col = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "OldName")
         original_column_id = original_col.column_id
         original_column_display_position = original_col.column_display_position
 
         # Rename the column
-        renamed_col = rename_qa_column_service(session, project_id, dataset_id, original_column_id, "NewName")
+        renamed_col = rename_qa_column_service(session, ORGANIZATION_ID, dataset_id, original_column_id, "NewName")
         assert renamed_col.column_name == "NewName"
         assert renamed_col.column_id == original_column_id  # column_id should not change
         assert (
@@ -1149,23 +1147,18 @@ def test_rename_qa_column_service():
         # Test error case: column not found
         fake_column_id = uuid4()
         with pytest.raises(QAColumnNotFoundError) as exc_info:
-            rename_qa_column_service(session, project_id, dataset_id, fake_column_id, "NewName")
+            rename_qa_column_service(session, ORGANIZATION_ID, dataset_id, fake_column_id, "NewName")
         assert str(dataset_id) in str(exc_info.value)
         assert str(fake_column_id) in str(exc_info.value)
 
-        # Test error case: dataset not in project
-        project_id2, _ = create_project_and_graph_runner(
-            session,
-            project_name_prefix="rename_project2",
-            description="Test project 2",
-        )
+        # Test error case: dataset not in organization
+        other_org_id = uuid4()
 
-        with pytest.raises(QADatasetNotInProjectError) as exc_info:
-            rename_qa_column_service(session, project_id2, dataset_id, original_column_id, "NewName")
-        assert str(project_id2) in str(exc_info.value)
+        with pytest.raises(QADatasetNotInOrganizationError) as exc_info:
+            rename_qa_column_service(session, other_org_id, dataset_id, original_column_id, "NewName")
+        assert str(other_org_id) in str(exc_info.value)
 
         delete_project_service(session=session, project_id=project_id)
-        delete_project_service(session=session, project_id=project_id2)
 
 
 def test_delete_qa_column_service():
@@ -1178,20 +1171,20 @@ def test_delete_qa_column_service():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"delete_column_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"delete_column_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create two columns
-        col1 = create_qa_column_service(session, project_id, dataset_id, "Priority")
-        col2 = create_qa_column_service(session, project_id, dataset_id, "Category")
+        col1 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
+        col2 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Category")
 
         # Verify both exist
         columns = get_qa_columns_by_dataset(session, dataset_id)
         assert len(columns) == 2
 
         # Delete one column
-        delete_response = delete_qa_column_service(session, project_id, dataset_id, col1.column_id)
+        delete_response = delete_qa_column_service(session, ORGANIZATION_ID, dataset_id, col1.column_id)
         assert "message" in delete_response
         assert "successfully" in delete_response["message"].lower()
 
@@ -1229,7 +1222,7 @@ def test_delete_qa_column_service():
             assert column_id_str in entry.custom_columns
 
         # Delete the column
-        delete_qa_column_service(session, project_id, dataset_id, col2.column_id)
+        delete_qa_column_service(session, ORGANIZATION_ID, dataset_id, col2.column_id)
 
         # Verify column is gone
         columns = get_qa_columns_by_dataset(session, dataset_id)
@@ -1245,26 +1238,21 @@ def test_delete_qa_column_service():
         # Test error case: column not found
         fake_column_id = uuid4()
         with pytest.raises(QAColumnNotFoundError) as exc_info:
-            delete_qa_column_service(session, project_id, dataset_id, fake_column_id)
+            delete_qa_column_service(session, ORGANIZATION_ID, dataset_id, fake_column_id)
         assert str(dataset_id) in str(exc_info.value)
         assert str(fake_column_id) in str(exc_info.value)
 
-        # Test error case: dataset not in project
-        project_id2, _ = create_project_and_graph_runner(
-            session,
-            project_name_prefix="delete_project2",
-            description="Test project 2",
-        )
+        # Test error case: dataset not in organization
+        other_org_id = uuid4()
 
         # Recreate a column for this test
-        col3 = create_qa_column_service(session, project_id, dataset_id, "TestCol")
+        col3 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "TestCol")
 
-        with pytest.raises(QADatasetNotInProjectError) as exc_info:
-            delete_qa_column_service(session, project_id2, dataset_id, col3.column_id)
-        assert str(project_id2) in str(exc_info.value)
+        with pytest.raises(QADatasetNotInOrganizationError) as exc_info:
+            delete_qa_column_service(session, other_org_id, dataset_id, col3.column_id)
+        assert str(other_org_id) in str(exc_info.value)
 
         delete_project_service(session=session, project_id=project_id)
-        delete_project_service(session=session, project_id=project_id2)
 
 
 def test_export_qa_data_to_csv_service_with_custom_columns():
@@ -1277,13 +1265,13 @@ def test_export_qa_data_to_csv_service_with_custom_columns():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"export_csv_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"export_csv_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create custom columns
-        col1 = create_qa_column_service(session, project_id, dataset_id, "Priority")
-        col2 = create_qa_column_service(session, project_id, dataset_id, "Score")
+        col1 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
+        col2 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Score")
         column_id1_str = str(col1.column_id)
         column_id2_str = str(col2.column_id)
 
@@ -1338,12 +1326,12 @@ def test_update_inputs_groundtruths_service_with_custom_columns():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"update_custom_cols_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"update_custom_cols_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
         # Create custom column
-        col = create_qa_column_service(session, project_id, dataset_id, "Priority")
+        col = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
         column_id_str = str(col.column_id)
 
         # Create entry with custom column
@@ -1398,7 +1386,7 @@ def test_csv_import_export_without_custom_columns():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_basic_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_basic_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -1413,7 +1401,7 @@ def test_csv_import_export_without_custom_columns():
         csv_content = csv_buffer.getvalue()
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
-        import_response = import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+        import_response = import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         assert len(import_response.inputs_groundtruths) == 2
 
         # Verify entries were created correctly
@@ -1447,7 +1435,7 @@ def test_csv_import_invalid_json_error():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_invalid_json_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_invalid_json_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -1460,7 +1448,7 @@ def test_csv_import_invalid_json_error():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         with pytest.raises(CSVInvalidJSONError) as exc_info:
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
         assert "Invalid JSON" in str(exc_info.value)
         assert "row" in str(exc_info.value)
 
@@ -1477,7 +1465,7 @@ def test_csv_import_empty_file_error():
         )
 
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_empty_file_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_empty_file_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 
@@ -1489,7 +1477,7 @@ def test_csv_import_empty_file_error():
         csv_file = io.BytesIO(csv_content.encode("utf-8"))
 
         with pytest.raises(CSVEmptyFileError):
-            import_qa_data_from_csv_service(session, project_id, dataset_id, csv_file)
+            import_qa_data_from_csv_service(session, ORGANIZATION_ID, dataset_id, csv_file)
 
         delete_project_service(session=session, project_id=project_id)
 
@@ -1505,7 +1493,7 @@ def test_csv_export_error_cases():
 
         # Test empty dataset
         dataset_data = create_datasets_service(
-            session, project_id, DatasetCreateList(datasets_name=[f"csv_export_empty_dataset_{project_id}"])
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"csv_export_empty_dataset_{project_id}"])
         )
         dataset_id = dataset_data.datasets[0].id
 

--- a/tests/mcp_server/test_qa.py
+++ b/tests/mcp_server/test_qa.py
@@ -6,6 +6,7 @@ from mcp_server.tools import _factory, qa
 from tests.mcp_server.conftest import (
     FAKE_DATASET_ID,
     FAKE_JUDGE_ID,
+    FAKE_ORG_ID,
     FAKE_PROJECT_ID,
     FAKE_VERSION_OUTPUT_ID,
 )
@@ -23,10 +24,10 @@ async def test_update_dataset_sends_name_as_query_param(mcp, monkeypatch):
     patch_mock = AsyncMock(return_value={"ok": True})
     monkeypatch.setattr(_factory.api, "patch", patch_mock)
 
-    await mcp.tools["update_dataset"](FAKE_PROJECT_ID, FAKE_DATASET_ID, "New Name")
+    await mcp.tools["update_dataset"](FAKE_ORG_ID, FAKE_DATASET_ID, "New Name")
 
     patch_mock.assert_awaited_once_with(
-        f"/projects/{FAKE_PROJECT_ID}/qa/datasets/{FAKE_DATASET_ID}",
+        f"/organizations/{FAKE_ORG_ID}/qa/datasets/{FAKE_DATASET_ID}",
         "jwt-token",
         trim=True,
         dataset_name="New Name",


### PR DESCRIPTION
# feat(qa): move datasets and LLM judges to org-level scope DRA-952

## Summary
- Datasets and LLM judges are now scoped to the organization instead of a single project. This allows users to share and reuse QA datasets and evaluation judges across multiple projects within the same organization.
- New many-to-many association tables (dataset_project_associations, llm_judge_project_associations) replace the former 1:1 project ownership, enabling a dataset or judge to be linked to multiple projects.
- New organization-scoped API endpoints for full CRUD on datasets, test cases, QA columns, LLM judges, and QA sessions (e.g. GET /organizations/{organization_id}/qa/datasets). Existing project-scoped endpoints are preserved for backward compatibility and now resolve the organization from the project.
- Frontend updated to call org-level endpoints: the QA API layer, Vue composables (useQAQuery, useQADatasetTable, useQAEvaluation, useQATestCaseCrud, etc.), and components (QADatasetTableHeader, QALLMJudgesManager) now operate at the org level with a project-association UX for linking/unlinking.
- New useProjectAssociation composable provides reusable linked/unlinked filtering and project-id list builders for any entity with project_ids.
- Alembic migration (i8j9k0l1m2n3) adds organization_id to dataset_project and llm_judges, creates the association tables, backfills existing data, and makes project_id nullable (to be dropped in a follow-up).
- MCP server QA tools updated to pass organization_id instead of project_id.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * QA Datasets and LLM Judges are now organization-scoped and can be shared across multiple projects within your organization.
  * Added ability to associate datasets and judges with specific projects while maintaining organization-level ownership.
  * Introduced new endpoints to manage project associations for datasets and judges.

* **Documentation**
  * Updated QA system documentation to reflect the new organization-scoped data model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->