### PR TITLE
fix(frontend): move VMenu outside VSelect item slot to fix page freez…

### DIFF
--- a/frontend/src/components/shared/VersionSelector.vue
+++ b/frontend/src/components/shared/VersionSelector.vue
@@ -42,10 +42,9 @@ const contextMenu = useContextMenu()
 // VSelect menu state
 const isSelectMenuOpen = ref(false)
 
-// Close context menu when VSelect opens
-watch(isSelectMenuOpen, isOpen => {
-  if (isOpen) contextMenu.closeMenu()
-})
+// Close context menu whenever the VSelect open state changes; otherwise the
+// context menu can be left open against an item element that has just unmounted.
+watch(isSelectMenuOpen, () => contextMenu.closeMenu())
 
 // Watch for deployment completion (watcher only stops spinner, doesn't emit)
 deployment.watchDeploymentCompletion(
@@ -65,11 +64,6 @@ const handleContextMenu = (event: MouseEvent, graphRunnerId: string) => {
   if (runner?.env === 'draft') return // Don't show menu for draft
 
   contextMenu.openMenu(event, graphRunnerId)
-}
-
-const handleMenuItemRef = (el: HTMLElement | null, graphRunnerId: string) => {
-  if (!props.projectId) return
-  contextMenu.handleItemRef(el, graphRunnerId)
 }
 
 const handleDeploy = () => {
@@ -125,7 +119,6 @@ const isCurrentMenuTargetProduction = computed(() => {
       <template #item="{ props: itemProps, item }">
         <VListItem
           v-bind="itemProps"
-          :ref="(el: any) => handleMenuItemRef(el, item.raw.graph_runner_id)"
           :title="item.raw.versionLabel"
           @contextmenu.prevent="handleContextMenu($event, item.raw.graph_runner_id)"
         >
@@ -140,61 +133,52 @@ const isCurrentMenuTargetProduction = computed(() => {
             </VChip>
           </template>
         </VListItem>
-
-        <!-- Context menu for deployment actions -->
-        <VMenu
-          v-if="projectId && item.raw.env !== 'draft' && contextMenu.menuTargetId.value === item.raw.graph_runner_id"
-          v-model="contextMenu.menuVisible.value"
-          :activator="contextMenu.menuActivatorElement.value as any"
-          location="bottom end"
-          :close-on-content-click="false"
-        >
-          <VList density="compact">
-            <VListItem
-              :disabled="
-                deployment.isDeploying.value || draftLoading.isLoadingDraft.value || isCurrentMenuTargetProduction
-              "
-              @click="handleDeploy"
-              @contextmenu.prevent.stop="
-                () => {
-                  contextMenu.closeMenu()
-                  isSelectMenuOpen = true
-                }
-              "
-            >
-              <template #prepend>
-                <VProgressCircular v-if="deployment.isDeploying.value" indeterminate size="20" width="2" class="me-2" />
-                <VIcon v-else icon="tabler-cloud-upload" />
-              </template>
-              <VListItemTitle>Deploy to Production</VListItemTitle>
-            </VListItem>
-
-            <VListItem
-              :disabled="deployment.isDeploying.value || draftLoading.isLoadingDraft.value"
-              @click="handleLoadDraft"
-              @contextmenu.prevent.stop="
-                () => {
-                  contextMenu.closeMenu()
-                  isSelectMenuOpen = true
-                }
-              "
-            >
-              <template #prepend>
-                <VProgressCircular
-                  v-if="draftLoading.isLoadingDraft.value"
-                  indeterminate
-                  size="20"
-                  width="2"
-                  class="me-2"
-                />
-                <VIcon v-else icon="tabler-edit" />
-              </template>
-              <VListItemTitle>Start draft from this version</VListItemTitle>
-            </VListItem>
-          </VList>
-        </VMenu>
       </template>
     </VSelect>
+
+    <!-- Context menu for deployment actions (single shared instance, outside item loop) -->
+    <VMenu
+      v-if="projectId"
+      v-model="contextMenu.menuVisible.value"
+      :activator="contextMenu.menuActivatorElement.value as any"
+      location="bottom end"
+      :close-on-content-click="false"
+      @click:outside="contextMenu.closeMenu"
+    >
+      <VList density="compact">
+        <VListItem
+          :disabled="
+            deployment.isDeploying.value || draftLoading.isLoadingDraft.value || isCurrentMenuTargetProduction
+          "
+          @click="handleDeploy"
+          @contextmenu.prevent
+        >
+          <template #prepend>
+            <VProgressCircular v-if="deployment.isDeploying.value" indeterminate size="20" width="2" class="me-2" />
+            <VIcon v-else icon="tabler-cloud-upload" />
+          </template>
+          <VListItemTitle>Deploy to Production</VListItemTitle>
+        </VListItem>
+
+        <VListItem
+          :disabled="deployment.isDeploying.value || draftLoading.isLoadingDraft.value"
+          @click="handleLoadDraft"
+          @contextmenu.prevent
+        >
+          <template #prepend>
+            <VProgressCircular
+              v-if="draftLoading.isLoadingDraft.value"
+              indeterminate
+              size="20"
+              width="2"
+              class="me-2"
+            />
+            <VIcon v-else icon="tabler-edit" />
+          </template>
+          <VListItemTitle>Start draft from this version</VListItemTitle>
+        </VListItem>
+      </VList>
+    </VMenu>
 
     <!-- Loading spinner overlay -->
     <VProgressCircular

--- a/frontend/src/composables/useVersionContextMenu.ts
+++ b/frontend/src/composables/useVersionContextMenu.ts
@@ -22,18 +22,11 @@ export function useContextMenu() {
     menuTargetId.value = null
   }
 
-  const handleItemRef = (el: HTMLElement | null, targetId: string) => {
-    if (el && menuTargetId.value === targetId) {
-      menuActivatorElement.value = el
-    }
-  }
-
   return {
     menuVisible,
     menuTargetId,
     menuActivatorElement,
     openMenu,
     closeMenu,
-    handleItemRef,
   }
 }


### PR DESCRIPTION
…e DRA-1268

The version dropdown's context menu (VMenu) was rendered once per item inside the VSelect #item slot. On right-click, changing menuTargetId forced all items' v-if conditions to re-evaluate simultaneously, triggering cascading VMenu positioning calculations that blocked the UI thread. The per-item :ref callback was also mutating reactive state during render, creating a secondary render loop.

Fix: single shared VMenu outside the item slot, driven by openMenu's menuActivatorElement ref. Removes the :ref mutation-during-render pattern and adds @click:outside so the menu always closes cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified the version selector context menu into a single shared menu for improved performance and consistent behavior across items.
  * Removed per-item ref wiring and simplified the context-menu API to expose only menu state and open/close controls.
  * Ensured the shared menu closes when the select menu changes or on outside clicks; deploy/draft actions remain available but are conditionally disabled based on state and production targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Scopeo/draftnrun/pull/687)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->