### PR TITLE
fix(workers): fix race condition in orphan queue recovery dra-1267

### DIFF
--- a/ada_backend/workers/base_queue_worker.py
+++ b/ada_backend/workers/base_queue_worker.py
@@ -109,21 +109,18 @@ class BaseQueueWorker(ABC):
                         orphan_worker_id,
                     )
                     while True:
-                        item = client.rpoplpush(key_str, self.queue_name)
+                        item = client.rpop(key_str)
                         if item is None:
                             break
                         try:
                             item_payload = json.loads(item)
                             self.parse_item_id(item_payload)
                         except Exception:
-                            try:
-                                client.lrem(self.queue_name, 1, item)
-                            except Exception as rm_exc:
-                                LOGGER.exception(
-                                    "[%s] Failed to remove malformed item from main queue during orphan recovery: %s",
-                                    self.worker_label,
-                                    rm_exc,
-                                )
+                            LOGGER.warning(
+                                "[%s] Discarding malformed item from orphaned queue of worker %s",
+                                self.worker_label,
+                                orphan_worker_id,
+                            )
                             continue
 
                         try:
@@ -131,6 +128,16 @@ class BaseQueueWorker(ABC):
                         except Exception as e:
                             LOGGER.exception(
                                 "[%s] Error resetting stuck item to PENDING: %s", self.worker_label, e,
+                            )
+
+                        try:
+                            client.lpush(self.queue_name, item)
+                        except Exception as push_exc:
+                            LOGGER.exception(
+                                "[%s] Failed to re-enqueue recovered item %s (stranded in PENDING): %s",
+                                self.worker_label,
+                                self.parse_item_id(item_payload),
+                                push_exc,
                             )
 
                     self._cleanup_worker_keys(client, self.queue_name, orphan_worker_id)

--- a/tests/ada_backend/workers/test_run_queue_worker.py
+++ b/tests/ada_backend/workers/test_run_queue_worker.py
@@ -572,7 +572,7 @@ class TestPeriodicOrphanRecovery:
 
         client.exists.side_effect = fake_exists
         client.scan.return_value = (0, [processing_key])
-        client.rpoplpush.side_effect = [orphan_payload.encode(), None]
+        client.rpop.side_effect = [orphan_payload.encode(), None]
 
         with patch.object(RunQueueWorker, "__init__", lambda self: None):
             w = RunQueueWorker.__new__(RunQueueWorker)
@@ -582,14 +582,15 @@ class TestPeriodicOrphanRecovery:
         own_processing = BaseQueueWorker._processing_queue_key(queue_name, "live-worker")
 
         w._recover_orphaned_processing_queues(client, own_processing)
-        client.rpoplpush.assert_not_called()
+        client.rpop.assert_not_called()
 
         heartbeat_alive = False
         client.scan.return_value = (0, [processing_key])
-        client.rpoplpush.side_effect = [orphan_payload.encode(), None]
+        client.rpop.side_effect = [orphan_payload.encode(), None]
 
         w._recover_orphaned_processing_queues(client, own_processing)
-        client.rpoplpush.assert_called()
+        client.rpop.assert_called()
+        client.lpush.assert_called_once_with(queue_name, orphan_payload.encode())
 
     def test_worker_loop_triggers_periodic_scan(self):
         queue_name = "test_queue"
@@ -687,3 +688,48 @@ class TestPeriodicOrphanRecovery:
 
     def test_follow_up_delay_covers_heartbeat_ttl(self):
         assert _ORPHAN_FOLLOW_UP_DELAY >= _HEARTBEAT_TTL
+
+    def test_recover_resets_db_before_enqueueing(self):
+        """The DB status must be reset to PENDING before the item is pushed to the
+        main queue, otherwise a concurrent worker can grab it, see RUNNING, and
+        silently discard it."""
+        queue_name = "test_queue"
+        dead_worker_id = "dead-worker-race"
+        processing_key = BaseQueueWorker._processing_queue_key(queue_name, dead_worker_id)
+        run_id = uuid4()
+        orphan_payload = json.dumps({
+            "run_id": str(run_id),
+            "project_id": str(uuid4()),
+            "env": "production",
+            "input_data": {},
+        })
+
+        client = MagicMock()
+        client.exists.return_value = False
+        client.scan.return_value = (0, [processing_key])
+        client.rpop.side_effect = [orphan_payload.encode(), None]
+
+        call_order = []
+        original_lpush = client.lpush
+
+        def tracking_lpush(*args, **kwargs):
+            call_order.append("lpush")
+            return original_lpush(*args, **kwargs)
+
+        client.lpush = MagicMock(side_effect=tracking_lpush)
+
+        with patch.object(RunQueueWorker, "__init__", lambda self: None):
+            w = RunQueueWorker.__new__(RunQueueWorker)
+            w.queue_name = queue_name
+            w.worker_label = "test"
+
+        def tracking_recover(item_payload):
+            call_order.append("recover")
+
+        with patch.object(w, "recover_orphaned_item", side_effect=tracking_recover):
+            own_processing = BaseQueueWorker._processing_queue_key(queue_name, "live-worker")
+            w._recover_orphaned_processing_queues(client, own_processing)
+
+        assert call_order == ["recover", "lpush"], (
+            f"recover_orphaned_item must be called before lpush, got: {call_order}"
+        )


### PR DESCRIPTION
# fix(workers): fix race condition in orphan queue recovery

## Summary
- Replace atomic rpoplpush with separate rpop + lpush to ensure the DB status is reset to PENDING before the item is re-enqueued on the main queue. The previous rpoplpush atomically moved the item to the main queue first, meaning a concurrent worker could grab it while the DB still showed RUNNING, causing it to be silently discarded.
- Simplify malformed-item handling during orphan recovery: malformed items popped from a dead worker's processing queue are now simply discarded with a warning log, instead of attempting a fragile lrem on the main queue (which was only necessary because rpoplpush had already moved them there).

## Problem
When a worker died and another worker recovered its orphaned processing queue, rpoplpush atomically moved items to the main queue before the DB status was reset to PENDING. A fast concurrent worker could dequeue the item, see its status was still RUNNING, and drop it — effectively losing the run.

## Solution
1. rpop the item from the dead worker's processing queue (removing it from the orphan queue only).
2. Call recover_orphaned_item to reset the DB status to PENDING.
3. lpush the item onto the main queue so it can be picked up by any worker.
This ordering guarantees the DB state is consistent before any worker can see the re-enqueued item.