### PR TITLE
feat(graph): fix V2 compt update ignoring input port dra-1271

### DIFF
--- a/ada_backend/services/graph/component_instance_v2_service.py
+++ b/ada_backend/services/graph/component_instance_v2_service.py
@@ -8,10 +8,20 @@ from ada_backend.repositories.component_repository import (
     get_component_instance_by_id,
 )
 from ada_backend.repositories.edge_repository import delete_edge, get_edges
+from ada_backend.repositories.field_expression_repository import (
+    create_field_expression,
+    delete_field_expression_by_id,
+    update_field_expression,
+)
 from ada_backend.repositories.graph_runner_repository import (
     delete_node,
     get_component_nodes,
     upsert_component_node,
+)
+from ada_backend.repositories.input_port_instance_repository import (
+    create_input_port_instance,
+    get_input_port_instances_for_component_instance,
+    update_input_port_instance,
 )
 from ada_backend.schemas.pipeline.base import ComponentInstanceSchema
 from ada_backend.schemas.pipeline.graph_schema import (
@@ -19,7 +29,10 @@ from ada_backend.schemas.pipeline.graph_schema import (
     ComponentUpdateV2Schema,
 )
 from ada_backend.services.graph.delete_graph_service import delete_component_instances_from_nodes
-from ada_backend.services.pipeline.update_pipeline_service import create_or_update_component_instance
+from ada_backend.services.pipeline.update_pipeline_service import (
+    _normalize_expression_json,
+    create_or_update_component_instance,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -78,6 +91,60 @@ def create_component_in_graph(
     return instance_id
 
 
+def _sync_input_port_field_expressions(
+    session: Session,
+    instance_id: UUID,
+    incoming_port_instances: list[dict],
+) -> None:
+    """Sync field expressions on input port instances for a single component.
+
+    Creates, updates, or removes field expressions so the DB matches the
+    incoming payload.  Mirrors the logic in ``update_graph_service`` but
+    scoped to a single component instance (used by the V2 component PUT).
+    """
+    db_ports = get_input_port_instances_for_component_instance(
+        session,
+        instance_id,
+        eager_load_field_expression=True,
+    )
+    db_port_by_name: dict[str, object] = {p.name: p for p in db_ports}
+
+    incoming_names: set[str] = set()
+
+    for port_data in incoming_port_instances:
+        field_expr_data = port_data.get("field_expression")
+        if not field_expr_data or not field_expr_data.get("expression_json"):
+            continue
+
+        field_name = port_data["name"]
+        incoming_names.add(field_name)
+
+        expression_json = _normalize_expression_json(field_expr_data["expression_json"])
+        if expression_json is None:
+            continue
+
+        existing_port = db_port_by_name.get(field_name)
+        if existing_port:
+            if existing_port.field_expression_id:
+                update_field_expression(session, existing_port.field_expression_id, expression_json)
+            else:
+                expr = create_field_expression(session, expression_json)
+                update_input_port_instance(session, existing_port.id, field_expression_id=expr.id)
+        else:
+            expr = create_field_expression(session, expression_json)
+            create_input_port_instance(
+                session=session,
+                component_instance_id=instance_id,
+                name=field_name,
+                field_expression_id=expr.id,
+            )
+
+    for port in db_ports:
+        if port.name not in incoming_names and port.field_expression_id:
+            delete_field_expression_by_id(session, port.field_expression_id)
+            update_input_port_instance(session, port.id, field_expression_id=None)
+
+
 def update_single_component(
     session: Session,
     graph_runner_id: UUID,
@@ -110,6 +177,9 @@ def update_single_component(
         tool_description_override=payload.tool_description_override,
     )
     create_or_update_component_instance(session, instance_schema, project_id)
+
+    if payload.input_port_instances:
+        _sync_input_port_field_expressions(session, instance_id, payload.input_port_instances)
 
     upsert_component_node(
         session,


### PR DESCRIPTION
# Fix: V2 component update endpoint ignoring input port field expressions

## Summary
- The `PUT /v2/.../components/{instance_id}` endpoint silently dropped input_port_instances — field expressions (e.g. injections in the messages parameter of an AI agent) were never persisted, so the previous value always reappeared after save.
- Added `_sync_input_port_field_expressions` to `component_instance_v2_service.py` which creates, updates, or removes field expressions on input port instances to match the incoming payload.

## Root cause
create_or_update_component_instance processes parameters, integration, and port_configurations, but completely ignores the input_port_instances field on ComponentInstanceSchema. The full graph save path (update_graph_service.py) handles them correctly, but the individual V2 component update path never did.

