### PR TITLE
feat(ingestion): create EAV source attributes table and dual-write DRA-1272

### DIFF
--- a/ada_backend/database/alembic/versions/67df5c87b638_create_source_attribute_entries_table.py
+++ b/ada_backend/database/alembic/versions/67df5c87b638_create_source_attribute_entries_table.py
@@ -1,0 +1,88 @@
+"""create source attribute entries table
+
+Revision ID: 67df5c87b638
+Revises: j1k2l3m4n5o6
+Create Date: 2026-04-23 12:59:35.649247
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "67df5c87b638"
+down_revision: Union[str, None] = "j1k2l3m4n5o6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy: Union[str, None] = "migrate-first"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "source_attribute_entries",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("source_id", sa.UUID(), nullable=False),
+        sa.Column("attribute_name", sa.String(), nullable=False),
+        sa.Column("value", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.ForeignKeyConstraint(["source_id"], ["data_sources.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "source_id",
+            "attribute_name",
+            name="uq_source_attribute_entries_source_id_attribute_name",
+        ),
+    )
+    op.create_index(
+        "ix_source_attribute_entries_source_id",
+        "source_attribute_entries",
+        ["source_id"],
+        unique=False,
+    )
+
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO source_attribute_entries (id, source_id, attribute_name, value, created_at, updated_at)
+            SELECT
+                gen_random_uuid(),
+                source_id,
+                attr_name,
+                attr_value,
+                created_at,
+                updated_at
+            FROM source_attributes,
+            LATERAL (
+                VALUES
+                    ('access_token', to_jsonb(access_token)),
+                    ('path', to_jsonb(path)),
+                    ('folder_id', to_jsonb(folder_id)),
+                    ('source_db_url', to_jsonb(source_db_url::text)),
+                    ('source_table_name', to_jsonb(source_table_name)),
+                    ('id_column_name', to_jsonb(id_column_name)),
+                    ('source_schema_name', to_jsonb(source_schema_name)),
+                    ('chunk_size', to_jsonb(chunk_size)),
+                    ('chunk_overlap', to_jsonb(chunk_overlap)),
+                    ('timestamp_column_name', to_jsonb(timestamp_column_name)),
+                    ('url_pattern', to_jsonb(url_pattern)),
+                    ('update_existing', to_jsonb(update_existing)),
+                    ('query_filter', to_jsonb(query_filter)),
+                    ('timestamp_filter', to_jsonb(timestamp_filter)),
+                    ('list_of_files_from_local_folder', NULLIF(list_of_files_from_local_folder::jsonb, 'null'::jsonb)),
+                    ('text_column_names', NULLIF(text_column_names::jsonb, 'null'::jsonb)),
+                    ('metadata_column_names', NULLIF(metadata_column_names::jsonb, 'null'::jsonb))
+            ) AS attribute_values(attr_name, attr_value)
+            WHERE attr_value IS NOT NULL
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_source_attribute_entries_source_id", table_name="source_attribute_entries")
+    op.drop_table("source_attribute_entries")

--- a/ada_backend/database/alembic/versions/67df5c87b638_create_source_attribute_entries_table.py
+++ b/ada_backend/database/alembic/versions/67df5c87b638_create_source_attribute_entries_table.py
@@ -1,7 +1,7 @@
 """create source attribute entries table
 
 Revision ID: 67df5c87b638
-Revises: j1k2l3m4n5o6
+Revises: i8j9k0l1m2n3
 Create Date: 2026-04-23 12:59:35.649247
 
 """
@@ -14,7 +14,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "67df5c87b638"
-down_revision: Union[str, None] = "j1k2l3m4n5o6"
+down_revision: Union[str, None] = "i8j9k0l1m2n3"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/ada_backend/database/alembic/versions/67df5c87b638_create_source_attribute_entries_table.py
+++ b/ada_backend/database/alembic/versions/67df5c87b638_create_source_attribute_entries_table.py
@@ -22,6 +22,27 @@ deploy_strategy: Union[str, None] = "migrate-first"
 
 
 def upgrade() -> None:
+    backfill_values_sql = """
+        VALUES
+            ('access_token', to_jsonb(access_token)),
+            ('path', to_jsonb(path)),
+            ('folder_id', to_jsonb(folder_id)),
+            ('source_db_url', to_jsonb(source_db_url::text)),
+            ('source_table_name', to_jsonb(source_table_name)),
+            ('id_column_name', to_jsonb(id_column_name)),
+            ('source_schema_name', to_jsonb(source_schema_name)),
+            ('chunk_size', to_jsonb(chunk_size)),
+            ('chunk_overlap', to_jsonb(chunk_overlap)),
+            ('timestamp_column_name', to_jsonb(timestamp_column_name)),
+            ('url_pattern', to_jsonb(url_pattern)),
+            ('update_existing', to_jsonb(update_existing)),
+            ('query_filter', to_jsonb(query_filter)),
+            ('timestamp_filter', to_jsonb(timestamp_filter)),
+            ('list_of_files_from_local_folder', NULLIF(list_of_files_from_local_folder::jsonb, 'null'::jsonb)),
+            ('text_column_names', NULLIF(text_column_names::jsonb, 'null'::jsonb)),
+            ('metadata_column_names', NULLIF(metadata_column_names::jsonb, 'null'::jsonb))
+    """
+
     op.create_table(
         "source_attribute_entries",
         sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
@@ -47,7 +68,7 @@ def upgrade() -> None:
 
     op.execute(
         sa.text(
-            """
+            f"""
             INSERT INTO source_attribute_entries (id, source_id, attribute_name, value, created_at, updated_at)
             SELECT
                 gen_random_uuid(),
@@ -57,30 +78,38 @@ def upgrade() -> None:
                 created_at,
                 updated_at
             FROM source_attributes,
-            LATERAL (
-                VALUES
-                    ('access_token', to_jsonb(access_token)),
-                    ('path', to_jsonb(path)),
-                    ('folder_id', to_jsonb(folder_id)),
-                    ('source_db_url', to_jsonb(source_db_url::text)),
-                    ('source_table_name', to_jsonb(source_table_name)),
-                    ('id_column_name', to_jsonb(id_column_name)),
-                    ('source_schema_name', to_jsonb(source_schema_name)),
-                    ('chunk_size', to_jsonb(chunk_size)),
-                    ('chunk_overlap', to_jsonb(chunk_overlap)),
-                    ('timestamp_column_name', to_jsonb(timestamp_column_name)),
-                    ('url_pattern', to_jsonb(url_pattern)),
-                    ('update_existing', to_jsonb(update_existing)),
-                    ('query_filter', to_jsonb(query_filter)),
-                    ('timestamp_filter', to_jsonb(timestamp_filter)),
-                    ('list_of_files_from_local_folder', NULLIF(list_of_files_from_local_folder::jsonb, 'null'::jsonb)),
-                    ('text_column_names', NULLIF(text_column_names::jsonb, 'null'::jsonb)),
-                    ('metadata_column_names', NULLIF(metadata_column_names::jsonb, 'null'::jsonb))
-            ) AS attribute_values(attr_name, attr_value)
+            LATERAL ({backfill_values_sql}) AS attribute_values(attr_name, attr_value)
             WHERE attr_value IS NOT NULL
             """
         )
     )
+
+    connection = op.get_bind()
+    expected_backfill_count = connection.execute(
+        sa.text(
+            f"""
+            SELECT COUNT(*)
+            FROM source_attributes,
+            LATERAL ({backfill_values_sql}) AS attribute_values(attr_name, attr_value)
+            WHERE attr_value IS NOT NULL
+            """
+        )
+    ).scalar_one()
+    actual_backfill_count = connection.execute(sa.text("SELECT COUNT(*) FROM source_attribute_entries")).scalar_one()
+    jsonb_null_row_count = connection.execute(
+        sa.text("SELECT COUNT(*) FROM source_attribute_entries WHERE value = 'null'::jsonb")
+    ).scalar_one()
+
+    if actual_backfill_count != expected_backfill_count:
+        raise RuntimeError(
+            "source_attribute_entries backfill row count mismatch: "
+            f"expected {expected_backfill_count}, got {actual_backfill_count}"
+        )
+
+    if jsonb_null_row_count != 0:
+        raise RuntimeError(
+            "source_attribute_entries backfill produced unexpected jsonb null rows: " f"{jsonb_null_row_count}"
+        )
 
 
 def downgrade() -> None:

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -1681,6 +1681,11 @@ class DataSource(Base):
         back_populates="source",
         cascade="all, delete-orphan",
     )
+    attribute_entries = relationship(
+        "SourceAttributeEntry",
+        back_populates="source",
+        cascade="all, delete-orphan",
+    )
 
     def __str__(self):
         return f"DataSource({self.name})"
@@ -1726,6 +1731,36 @@ class SourceAttributes(Base):
 
     def __str__(self):
         return f"SourceAttributes(source_id={self.source_id})"
+
+
+class SourceAttributeEntry(Base):
+    """Represents a single persisted source attribute in the EAV transition table."""
+
+    __tablename__ = "source_attribute_entries"
+    __table_args__ = (
+        UniqueConstraint(
+            "source_id",
+            "attribute_name",
+            name="uq_source_attribute_entries_source_id_attribute_name",
+        ),
+    )
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4)
+    source_id = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("data_sources.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    attribute_name = mapped_column(String, nullable=False)
+    value = mapped_column(JSONB, nullable=True)
+    created_at = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    source = relationship("DataSource", back_populates="attribute_entries")
+
+    def __str__(self):
+        return f"SourceAttributeEntry(source_id={self.source_id}, attribute_name={self.attribute_name})"
 
 
 class CronJob(Base):

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -1771,7 +1771,7 @@ class SourceAttributeEntry(Base):
         ),
     )
 
-    id = mapped_column(UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4)
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     source_id = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("data_sources.id", ondelete="CASCADE"),

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -26,7 +26,7 @@ from sqlalchemy import (
 )
 from sqlalchemy import Enum as SQLAlchemyEnum
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import declarative_base, mapped_column, relationship
+from sqlalchemy.orm import declarative_base, mapped_column, relationship, validates
 
 from ada_backend.database.utils import camel_to_snake
 from ada_backend.schemas.llm_models_schema import ModelCapabilityEnum
@@ -184,6 +184,30 @@ class SourceType(StrEnum):
     LOCAL = "local"
     DATABASE = "database"
     WEBSITE = "website"
+
+
+class SourceAttributeKey(StrEnum):
+    ACCESS_TOKEN = "access_token"
+    PATH = "path"
+    LIST_OF_FILES_FROM_LOCAL_FOLDER = "list_of_files_from_local_folder"
+    FOLDER_ID = "folder_id"
+    SOURCE_DB_URL = "source_db_url"
+    SOURCE_TABLE_NAME = "source_table_name"
+    ID_COLUMN_NAME = "id_column_name"
+    TEXT_COLUMN_NAMES = "text_column_names"
+    SOURCE_SCHEMA_NAME = "source_schema_name"
+    CHUNK_SIZE = "chunk_size"
+    CHUNK_OVERLAP = "chunk_overlap"
+    METADATA_COLUMN_NAMES = "metadata_column_names"
+    TIMESTAMP_COLUMN_NAME = "timestamp_column_name"
+    URL_PATTERN = "url_pattern"
+    UPDATE_EXISTING = "update_existing"
+    QUERY_FILTER = "query_filter"
+    TIMESTAMP_FILTER = "timestamp_filter"
+
+    @classmethod
+    def values(cls) -> set[str]:
+        return {item.value for item in cls}
 
 
 class TaskStatus(StrEnum):
@@ -1676,6 +1700,7 @@ class DataSource(Base):
     last_ingestion_time = mapped_column(DateTime(timezone=True), nullable=True)
 
     ingestion_tasks = relationship("IngestionTask", back_populates="source")
+    # TODO(DRA-1273): Remove once reads no longer depend on the legacy wide table.
     attributes = relationship(
         "SourceAttributes",
         back_populates="source",
@@ -1695,6 +1720,7 @@ class SourceAttributes(Base):
     """
     Represents attributes for a data source.
     """
+    # TODO(DRA-1273): Delete after switching reads to EAV and dropping the legacy table.
 
     __tablename__ = "source_attributes"
 
@@ -1758,6 +1784,12 @@ class SourceAttributeEntry(Base):
     updated_at = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     source = relationship("DataSource", back_populates="attribute_entries")
+
+    @validates("attribute_name")
+    def validate_attribute_name(self, _, attribute_name: str) -> str:
+        if attribute_name not in SourceAttributeKey.values():
+            raise ValueError(f"Invalid source attribute key: {attribute_name}")
+        return attribute_name
 
     def __str__(self):
         return f"SourceAttributeEntry(source_id={self.source_id}, attribute_name={self.attribute_name})"

--- a/ada_backend/repositories/source_repository.py
+++ b/ada_backend/repositories/source_repository.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 
 from sqlalchemy import and_, exists, func, select
@@ -13,6 +13,17 @@ from ada_backend.repositories.organization_repository import (
 from ada_backend.schemas.ingestion_task_schema import SourceAttributes
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _build_source_attribute_entries(source_id: UUID, attributes: dict[str, Any]) -> list[db.SourceAttributeEntry]:
+    return [
+        db.SourceAttributeEntry(
+            source_id=source_id,
+            attribute_name=attribute_name,
+            value=value,
+        )
+        for attribute_name, value in attributes.items()
+    ]
 
 
 def get_data_source_by_id(
@@ -103,6 +114,7 @@ def create_source(
             secret_type=db.OrgSecretType.PASSWORD,
         )
 
+        # TODO(DRA-1273): Remove this legacy wide-table write after the read path switches to EAV.
         source_attributes = db.SourceAttributes(
             source_id=source_data_create.id,
             access_token=attributes.access_token,
@@ -124,7 +136,17 @@ def create_source(
             timestamp_filter=attributes.timestamp_filter,
         )
 
+        eav_attributes = {
+            key: value
+            for key, value in attributes.model_dump(mode="json", exclude_none=True).items()
+            if key in db.SourceAttributeKey.values()
+        }
+        eav_attributes["source_db_url"] = str(org_secret.id)
+
+        source_attribute_entries = _build_source_attribute_entries(source_data_create.id, eav_attributes)
+
         session.add(source_attributes)
+        session.add_all(source_attribute_entries)
         session.commit()
     return source_data_create.id
 


### PR DESCRIPTION
## What changed

PR1 of the `source_attributes` normalization to EAV (DRA-1168).

- Creates the new `source_attribute_entries` EAV table.
- Backfills existing legacy `source_attributes` rows into EAV rows, preserving JSONB types and explicitly casting `jsonb null` to SQL `NULL`.
- Adds the coexistence SQLAlchemy model `SourceAttributeEntry`.
- Adds dual-write in `create_source()` to both the legacy table and the new EAV table, restricted to a strict `SourceAttributeKey` allowlist.

## Why

The current `source_attributes` table is a wide table where most columns are `NULL` depending on the source type. Normalizing to EAV prevents schema migrations for every new source integration.

This PR is step 1 of a 2-step rollout:
1. **PR1 (this)**: Add table, backfill, dual-write. Reads stay on the legacy table.
2. **PR2 (next)**: Switch reads to EAV, drop legacy table and wide model.

## Out of scope

- Switching reads to the new table.
- Removing the legacy ORM model.
- Expanding persistence beyond the current database-source behavior (Google Drive, Local, and Website sources still do not persist attributes).

## Testing

- Migration explicitly annotated as `migrate-first`.
- Backfill includes embedded sanity checks at the end of the `upgrade()` step to verify row counts and prevent `jsonb null` regressions. Rollback is automatic if checks fail.
- Tested locally with full `db-upgrade` and `db-downgrade` round-trips.