### PR TITLE
feat(runs): Fix missing trace link on failed runs dra-1270

### DIFF
--- a/ada_backend/services/agent_runner_service.py
+++ b/ada_backend/services/agent_runner_service.py
@@ -321,7 +321,9 @@ async def run_agent(
             is_root_execution=True,
         )
         params = get_tracing_span()
-    except EngineError:
+    except EngineError as e:
+        params = get_tracing_span()
+        e.trace_id = params.trace_id if params else None
         raise
     except Exception as e:
         tb = traceback.format_exc()

--- a/ada_backend/services/run_service.py
+++ b/ada_backend/services/run_service.py
@@ -189,6 +189,7 @@ def get_run_final_state_event(session: Session, run_id: UUID) -> Optional[Dict[s
         return {
             "type": "run.failed",
             "error": getattr(run, "error", None) or {"message": "Run failed", "type": "UnknownError"},
+            "trace_id": getattr(run, "trace_id", None),
         }
     return None
 

--- a/ada_backend/workers/run_queue_worker.py
+++ b/ada_backend/workers/run_queue_worker.py
@@ -205,7 +205,11 @@ class RunQueueWorker(BaseQueueWorker):
                 try:
                     publish_run_event(
                         run_id,
-                        {"type": "run.failed", "error": {"message": str(e), "type": type(e).__name__}},
+                        {
+                            "type": "run.failed",
+                            "error": {"message": str(e), "type": type(e).__name__},
+                            "trace_id": trace_id,
+                        },
                     )
                 except Exception as event_exc:
                     LOGGER.exception("Failed to publish run.failed event for %s: %s", run_id, event_exc)

--- a/frontend/src/composables/usePlaygroundChatRun.ts
+++ b/frontend/src/composables/usePlaygroundChatRun.ts
@@ -92,7 +92,7 @@ export function usePlaygroundChatRun() {
 
     const { onSyncSuccess, isAsyncRunStream, runStreamCleanup } = options
 
-    const failStream = (error?: string) => {
+    const failStream = (error?: string, trace_id?: string) => {
       const errorMessage = error ?? 'Unknown error'
 
       runStreamCleanup.value?.()
@@ -101,7 +101,7 @@ export function usePlaygroundChatRun() {
         content: errorMessage,
         isLoading: false,
         isError: true,
-        metadata: { status: 'error' },
+        metadata: { status: 'error', trace_id },
       })
       setError(errorMessage)
       ensureScrollToBottom()
@@ -161,7 +161,7 @@ export function usePlaygroundChatRun() {
           isAsyncRunStream.value = false
           setTyping(false)
         },
-        onRunFailed: ({ message, type }) => failStream(type ? `${type}: ${message}` : message),
+        onRunFailed: ({ message, type, trace_id }) => failStream(type ? `${type}: ${message}` : message, trace_id),
         onError: message => failStream(message),
         onClose: (code, reason) => {
           if (code >= 4400 && code <= 4510) failStream(reason || `Connection closed (${code})`)

--- a/frontend/src/composables/useRunStream.ts
+++ b/frontend/src/composables/useRunStream.ts
@@ -22,7 +22,7 @@ export interface RunStreamCallbacks {
     message?: string
     response?: string
   }) => void
-  onRunFailed?: (payload: { message: string; type?: string }) => void
+  onRunFailed?: (payload: { message: string; type?: string; trace_id?: string }) => void
   onError?: (message: string) => void
   onClose?: (code: number, reason: string) => void
   /** Called when autoReconnect exhausts all retries without a terminal run event. */
@@ -116,6 +116,7 @@ export function useRunStream() {
                 callbacks.onRunFailed?.({
                   message: payload.error.message,
                   type: payload.error.type,
+                  trace_id: payload.trace_id,
                 })
                 close()
                 break

--- a/frontend/src/types/runStream.ts
+++ b/frontend/src/types/runStream.ts
@@ -24,6 +24,7 @@ export interface RunCompletedPayload {
 
 export interface RunFailedPayload {
   type: 'run.failed'
+  trace_id?: string
   error: {
     message: string
     type?: string


### PR DESCRIPTION
# Summary
- Failed runs caused by `EngineError` (LLM failures, routing errors, MCP errors, etc.) lost their `trace_id` because the exception was re-raised without capturing it from the tracing span — unlike the generic `Exception` handler which already did this correctly.
- The `run.failed` WebSocket event and the late-connect `get_run_final_state_event` response both omitted `trace_id`, so even when the DB had the trace link, real-time clients never received it. The `run.completed` path already included it.
- The frontend `RunFailedPayload` type, stream callback, and playground error handler had no `trace_id` plumbing, so the UI could never display a trace link for failed runs.