### PR TITLE
feat(redis): Fix stale-client dedup key cleanup in push_git_sync_task dra-1243

### DIFF
--- a/ada_backend/utils/redis_client.py
+++ b/ada_backend/utils/redis_client.py
@@ -462,7 +462,12 @@ def push_git_sync_task(config_id: UUID, commit_sha: str) -> bool:
             client, settings.REDIS_GIT_SYNC_QUEUE_NAME, payload, f"git sync task (config {config_id})"
         )
         if not pushed:
-            client.delete(dedup_key)
+            try:
+                fresh = get_redis_client()
+                if fresh:
+                    fresh.delete(dedup_key)
+            except Exception as exc:
+                LOGGER.warning("Best-effort dedup key cleanup failed for %s: %s", dedup_key, exc)
         return pushed
     except _RECONNECT_ERRORS as e:
         LOGGER.error("Redis connection error pushing git sync task %s to queue: %s", config_id, e)


### PR DESCRIPTION
# fix(redis): use fresh client for dedup key cleanup in push_git_sync_task DRA-1243

## Summary
- When `_push_to_redis_queue` fails in `push_git_sync_task`, the dedup key cleanup now uses a fresh Redis connection (`get_redis_client()`) instead of reusing the original client, which may be stale or broken after the failed push.
- The delete is wrapped in its own `try/except` so a cleanup failure is logged as a warning but never propagates or affects the return value.

## Problem
If the original Redis client enters a bad state (e.g. connection reset mid-push), the subsequent `client.delete(dedup_key)` would fail with the same stale connection. This left the dedup key in Redis, causing the git sync task to be permanently skipped for that (`config_id`, `commit_sha`) pair until the TTL expired (up to 1 hour).