### PR TITLE
feat(qa): add flexible dataset columns dra-1275

### DIFF
--- a/ada_backend/database/alembic/versions/k1l2m3n4o5p6_flexible_qa_datasets.py
+++ b/ada_backend/database/alembic/versions/k1l2m3n4o5p6_flexible_qa_datasets.py
@@ -1,0 +1,283 @@
+"""Add flexible QA dataset columns: DatasetCellValue table, column_role, association_column_mappings.
+
+Migrates existing data into the new normalized cell value table.
+
+Revision ID: k1l2m3n4o5p6
+Revises: b4c5d6e7f8b0
+Create Date: 2026-04-24
+"""
+
+import json
+import uuid
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from ada_backend.database.utils import create_enum_if_not_exists
+
+revision: str = "k1l2m3n4o5p6"
+down_revision: Union[str, None] = "b4c5d6e7f8b0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy = "migrate-first"
+
+QA_SCHEMA = "quality_assurance"
+
+
+def upgrade() -> None:
+    create_enum_if_not_exists(op.get_bind(), ["input", "expected_output"], "column_role", schema=QA_SCHEMA)
+    column_role_enum = postgresql.ENUM(
+        "input", "expected_output", name="column_role", schema=QA_SCHEMA, create_type=False
+    )
+
+    op.add_column(
+        "qa_dataset_metadata",
+        sa.Column("default_role", column_role_enum, nullable=True),
+        schema=QA_SCHEMA,
+    )
+    op.create_unique_constraint("uq_qa_metadata_column_id", "qa_dataset_metadata", ["column_id"], schema=QA_SCHEMA)
+
+    op.create_table(
+        "association_column_mappings",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column(
+            "association_id",
+            sa.UUID(),
+            sa.ForeignKey(f"{QA_SCHEMA}.dataset_project_associations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "column_id",
+            sa.UUID(),
+            sa.ForeignKey(f"{QA_SCHEMA}.qa_dataset_metadata.column_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("role", column_role_enum, nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("association_id", "column_id", name="uq_association_column_mapping"),
+        schema=QA_SCHEMA,
+    )
+    op.create_index(
+        op.f("ix_quality_assurance_association_column_mappings_association_id"),
+        "association_column_mappings",
+        ["association_id"],
+        schema=QA_SCHEMA,
+    )
+    op.create_index(
+        op.f("ix_quality_assurance_association_column_mappings_column_id"),
+        "association_column_mappings",
+        ["column_id"],
+        schema=QA_SCHEMA,
+    )
+
+    op.create_table(
+        "dataset_cell_values",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("row_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "column_id",
+            sa.UUID(),
+            sa.ForeignKey(f"{QA_SCHEMA}.qa_dataset_metadata.column_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("value", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["row_id"], [f"{QA_SCHEMA}.input_groundtruth.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("row_id", "column_id", name="uq_cell_row_column"),
+        schema=QA_SCHEMA,
+    )
+    op.create_index(
+        op.f("ix_quality_assurance_dataset_cell_values_row_id"),
+        "dataset_cell_values",
+        ["row_id"],
+        schema=QA_SCHEMA,
+    )
+    op.create_index(
+        op.f("ix_quality_assurance_dataset_cell_values_column_id"),
+        "dataset_cell_values",
+        ["column_id"],
+        schema=QA_SCHEMA,
+    )
+
+    _migrate_existing_data()
+
+
+def _migrate_existing_data() -> None:
+    conn = op.get_bind()
+
+    datasets = conn.execute(sa.text(f"SELECT id FROM {QA_SCHEMA}.dataset_project")).fetchall()
+
+    for (dataset_id,) in datasets:
+        existing_max = conn.execute(
+            sa.text(
+                f"SELECT COALESCE(MAX(column_display_position), -1) "
+                f"FROM {QA_SCHEMA}.qa_dataset_metadata WHERE dataset_id = :did"
+            ),
+            {"did": dataset_id},
+        ).scalar()
+
+        input_col_id = uuid.uuid4()
+        expected_output_col_id = uuid.uuid4()
+
+        input_pos = existing_max + 1
+        expected_output_pos = existing_max + 2
+
+        conn.execute(
+            sa.text(
+                f"INSERT INTO {QA_SCHEMA}.qa_dataset_metadata "
+                f"(id, dataset_id, column_id, column_name, column_display_position, default_role) "
+                f"VALUES (gen_random_uuid(), :did, :cid, :cname, :cpos, :crole)"
+            ),
+            {"did": dataset_id, "cid": str(input_col_id), "cname": "Input", "cpos": input_pos, "crole": "input"},
+        )
+        conn.execute(
+            sa.text(
+                f"INSERT INTO {QA_SCHEMA}.qa_dataset_metadata "
+                f"(id, dataset_id, column_id, column_name, column_display_position, default_role) "
+                f"VALUES (gen_random_uuid(), :did, :cid, :cname, :cpos, :crole)"
+            ),
+            {
+                "did": dataset_id,
+                "cid": str(expected_output_col_id),
+                "cname": "Expected Output",
+                "cpos": expected_output_pos,
+                "crole": "expected_output",
+            },
+        )
+
+        col_name_to_id = {}
+        metadata_rows = conn.execute(
+            sa.text(
+                f"SELECT column_id, column_name "
+                f"FROM {QA_SCHEMA}.qa_dataset_metadata "
+                f"WHERE dataset_id = :did AND default_role IS NULL"
+            ),
+            {"did": dataset_id},
+        ).fetchall()
+        for col_uuid, col_name in metadata_rows:
+            col_name_to_id[col_name] = str(col_uuid)
+
+        rows = conn.execute(
+            sa.text(
+                f"SELECT id, input, groundtruth, custom_columns "
+                f"FROM {QA_SCHEMA}.input_groundtruth WHERE dataset_id = :did"
+            ),
+            {"did": dataset_id},
+        ).fetchall()
+
+        for row_id, input_val, groundtruth_val, custom_columns_val in rows:
+            input_text = json.dumps(input_val) if input_val is not None else None
+            conn.execute(
+                sa.text(
+                    f"INSERT INTO {QA_SCHEMA}.dataset_cell_values (id, row_id, column_id, value) "
+                    f"VALUES (gen_random_uuid(), :rid, :cid, :val)"
+                ),
+                {"rid": row_id, "cid": str(input_col_id), "val": input_text},
+            )
+            conn.execute(
+                sa.text(
+                    f"INSERT INTO {QA_SCHEMA}.dataset_cell_values (id, row_id, column_id, value) "
+                    f"VALUES (gen_random_uuid(), :rid, :cid, :val)"
+                ),
+                {"rid": row_id, "cid": str(expected_output_col_id), "val": groundtruth_val},
+            )
+
+            if custom_columns_val:
+                for col_key, col_value in custom_columns_val.items():
+                    try:
+                        uuid.UUID(col_key)
+                        resolved_col_id = col_key
+                    except ValueError:
+                        resolved_col_id = col_name_to_id.get(col_key)
+                        if resolved_col_id is None:
+                            continue
+                    conn.execute(
+                        sa.text(
+                            f"INSERT INTO {QA_SCHEMA}.dataset_cell_values (id, row_id, column_id, value) "
+                            f"VALUES (gen_random_uuid(), :rid, :cid, :val) "
+                            f"ON CONFLICT (row_id, column_id) DO UPDATE SET value = :val"
+                        ),
+                        {"rid": row_id, "cid": resolved_col_id, "val": col_value},
+                    )
+
+        assoc_rows = conn.execute(
+            sa.text(f"SELECT id FROM {QA_SCHEMA}.dataset_project_associations WHERE dataset_id = :did"),
+            {"did": dataset_id},
+        ).fetchall()
+        for (assoc_id,) in assoc_rows:
+            conn.execute(
+                sa.text(
+                    f"INSERT INTO {QA_SCHEMA}.association_column_mappings "
+                    f"(id, association_id, column_id, role) "
+                    f"VALUES (gen_random_uuid(), :aid, :cid, :role)"
+                ),
+                {"aid": assoc_id, "cid": str(input_col_id), "role": "input"},
+            )
+            conn.execute(
+                sa.text(
+                    f"INSERT INTO {QA_SCHEMA}.association_column_mappings "
+                    f"(id, association_id, column_id, role) "
+                    f"VALUES (gen_random_uuid(), :aid, :cid, :role)"
+                ),
+                {"aid": assoc_id, "cid": str(expected_output_col_id), "role": "expected_output"},
+            )
+
+    orphan_count = conn.execute(
+        sa.text(
+            f"SELECT COUNT(*) FROM {QA_SCHEMA}.input_groundtruth ig "
+            f"WHERE NOT EXISTS ("
+            f"  SELECT 1 FROM {QA_SCHEMA}.dataset_cell_values dcv "
+            f"  JOIN {QA_SCHEMA}.qa_dataset_metadata m ON dcv.column_id = m.column_id "
+            f"  WHERE dcv.row_id = ig.id AND m.dataset_id = ig.dataset_id AND m.default_role = 'input'"
+            f") OR NOT EXISTS ("
+            f"  SELECT 1 FROM {QA_SCHEMA}.dataset_cell_values dcv "
+            f"  JOIN {QA_SCHEMA}.qa_dataset_metadata m ON dcv.column_id = m.column_id "
+            f"  WHERE dcv.row_id = ig.id AND m.dataset_id = ig.dataset_id AND m.default_role = 'expected_output'"
+            f")"
+        )
+    ).scalar()
+    if orphan_count:
+        raise RuntimeError(
+            f"Migration validation failed: {orphan_count} input_groundtruth rows without cell values "
+            f"for system columns (input/expected_output)"
+        )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_quality_assurance_dataset_cell_values_column_id"),
+        table_name="dataset_cell_values",
+        schema=QA_SCHEMA,
+        if_exists=True,
+    )
+    op.drop_index(
+        op.f("ix_quality_assurance_dataset_cell_values_row_id"),
+        table_name="dataset_cell_values",
+        schema=QA_SCHEMA,
+        if_exists=True,
+    )
+    op.drop_table("dataset_cell_values", schema=QA_SCHEMA, if_exists=True)
+
+    op.drop_index(
+        op.f("ix_quality_assurance_association_column_mappings_column_id"),
+        table_name="association_column_mappings",
+        schema=QA_SCHEMA,
+        if_exists=True,
+    )
+    op.drop_index(
+        op.f("ix_quality_assurance_association_column_mappings_association_id"),
+        table_name="association_column_mappings",
+        schema=QA_SCHEMA,
+        if_exists=True,
+    )
+    op.drop_table("association_column_mappings", schema=QA_SCHEMA, if_exists=True)
+
+    op.drop_constraint("uq_qa_metadata_column_id", "qa_dataset_metadata", schema=QA_SCHEMA, if_exists=True)
+    op.execute(f"DELETE FROM {QA_SCHEMA}.qa_dataset_metadata WHERE default_role IS NOT NULL")
+    op.drop_column("qa_dataset_metadata", "default_role", schema=QA_SCHEMA, if_exists=True)
+
+    column_role_enum = postgresql.ENUM("input", "expected_output", name="column_role", schema=QA_SCHEMA)
+    column_role_enum.drop(op.get_bind(), checkfirst=True)

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -1878,6 +1878,7 @@ class InputGroundtruth(Base):
     # Relationships
     dataset = relationship("DatasetProject", back_populates="input_groundtruths")
     version_outputs = relationship("VersionOutput", back_populates="input_groundtruth", cascade="all, delete-orphan")
+    cell_values = relationship("DatasetCellValue", back_populates="row", cascade="all, delete-orphan")
 
     def __str__(self):
         return f"InputGroundtruth(id={self.id}, input={self.input})"
@@ -1926,18 +1927,50 @@ class DatasetProjectAssociation(Base):
         nullable=False,
         index=True,
     )
+    column_mappings = relationship("AssociationColumnMapping", cascade="all, delete-orphan", lazy="selectin")
+
+
+class ColumnRole(StrEnum):
+    INPUT = "input"
+    EXPECTED_OUTPUT = "expected_output"
+
+
+class AssociationColumnMapping(Base):
+    __tablename__ = "association_column_mappings"
+    __table_args__ = (
+        sa.UniqueConstraint("association_id", "column_id", name="uq_association_column_mapping"),
+        {"schema": "quality_assurance"},
+    )
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    association_id = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("quality_assurance.dataset_project_associations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    column_id = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("quality_assurance.qa_dataset_metadata.column_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    role = mapped_column(make_pg_enum(ColumnRole, schema="quality_assurance"), nullable=False)
+
+    column = relationship("QADatasetMetadata")
 
 
 class QADatasetMetadata(Base):
     """
-    Represents custom column definitions for QA datasets.
-    Each row defines a custom column with its name, ID, and display position.
+    Represents column definitions for QA datasets.
+    Each row defines a column with its name, ID, display position, and optional role.
     """
 
     __tablename__ = "qa_dataset_metadata"
     __table_args__ = (
         sa.UniqueConstraint("dataset_id", "column_id", name="uq_qa_metadata_dataset_column_id"),
         sa.UniqueConstraint("dataset_id", "column_display_position", name="uq_qa_metadata_dataset_column_position"),
+        sa.UniqueConstraint("column_id", name="uq_qa_metadata_column_id"),
         sa.CheckConstraint("column_display_position >= 0", name="ck_qa_metadata_column_position_non_negative"),
         {"schema": "quality_assurance"},
     )
@@ -1957,13 +1990,43 @@ class QADatasetMetadata(Base):
 
     column_display_position = mapped_column(Integer, nullable=False)
 
+    default_role = mapped_column(make_pg_enum(ColumnRole, schema="quality_assurance"), nullable=True)
+
     dataset = relationship("DatasetProject", back_populates="qa_metadata")
 
     def __str__(self):
         return (
             f"QADatasetMetadata(id={self.id}, dataset_id={self.dataset_id}, "
-            f"column_name={self.column_name}, column_display_position={self.column_display_position})"
+            f"column_name={self.column_name}, default_role={self.default_role})"
         )
+
+
+class DatasetCellValue(Base):
+    """Each row stores one cell value: the intersection of a dataset row and a column."""
+
+    __tablename__ = "dataset_cell_values"
+    __table_args__ = (
+        sa.UniqueConstraint("row_id", "column_id", name="uq_cell_row_column"),
+        {"schema": "quality_assurance"},
+    )
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    row_id = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("quality_assurance.input_groundtruth.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    column_id = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("quality_assurance.qa_dataset_metadata.column_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    value = mapped_column(Text, nullable=True)
+
+    row = relationship("InputGroundtruth", back_populates="cell_values")
+    column = relationship("QADatasetMetadata")
 
 
 class VersionOutput(Base):

--- a/ada_backend/docs/qa-system.md
+++ b/ada_backend/docs/qa-system.md
@@ -14,8 +14,10 @@ Datasets belong to an organization and contain input/groundtruth entries. Each d
 
 - **`DatasetProject`** (`quality_assurance.dataset_project`): `organization_id`, `name`
 - **`DatasetProjectAssociation`** (`quality_assurance.dataset_project_associations`): `dataset_id`, `project_id` (many-to-many)
-- **`InputGroundtruth`** (`quality_assurance.input_groundtruth`): `dataset_id`, `input_data`, `groundtruth`, `position`, custom column values
-- **`QADatasetMetadata`** (`quality_assurance.qa_dataset_metadata`): custom column definitions per dataset
+- **`AssociationColumnMapping`** (`quality_assurance.association_column_mappings`): `association_id` FK → `dataset_project_associations.id`, `column_id` FK → `qa_dataset_metadata.column_id`, `role` (`ColumnRole` enum: `input` | `expected_output`). Unique on `(association_id, column_id)`. Tracks which dataset columns serve as inputs vs. expected outputs for each project association. Auto-populated from system columns when an association is created.
+- **`QADatasetMetadata`** (`quality_assurance.qa_dataset_metadata`): column definitions per dataset. `dataset_id` FK → `dataset_project.id`, `column_id` (UUID, unique), `column_name`, `column_display_position`, `default_role` (`ColumnRole` enum, nullable — `input` | `expected_output` for system columns, `NULL` for user-created columns).
+- **`InputGroundtruth`** (`quality_assurance.input_groundtruth`): dataset rows. `dataset_id` FK → `dataset_project.id`, `input` (JSONB), `groundtruth` (String, nullable), `position`. Also carries a legacy `custom_columns` (JSONB, nullable) field, but the canonical per-cell store is `DatasetCellValue`.
+- **`DatasetCellValue`** (`quality_assurance.dataset_cell_values`): normalized per-cell storage — one row per (dataset-row, column) intersection. `row_id` FK → `input_groundtruth.id`, `column_id` FK → `qa_dataset_metadata.column_id`, `value` (Text, nullable). Unique on `(row_id, column_id)`.
 
 ### CRUD Endpoints (Organization-scoped)
 
@@ -112,10 +114,11 @@ Evaluates a judge against version outputs, storing results as `JudgeEvaluation` 
 
 ## Key Files
 
-- `routers/quality_assurance_router.py` — dataset + entry CRUD, run (sync + async), import/export
+- `routers/quality_assurance_router.py` — dataset + entry CRUD, run (sync + async), import/export. Thin transport layer: delegates all business logic and DB writes to the QA service.
 - `routers/qa_stream_router.py` — WebSocket endpoint for async QA session streaming (auth only; delegates to service)
 - `routers/llm_judges_router.py` — judge CRUD, defaults
 - `routers/qa_evaluation_router.py` — evaluation run, results
+- `services/qa/quality_assurance_service.py` — dataset CRUD, project association with column mappings, QA session lifecycle, dataset validation, run orchestration
 - `services/qa/qa_stream_service.py` — session replay, Redis subscription, and event streaming logic for the QA WebSocket
 - `services/qa/qa_evaluation_service.py` — LLM evaluation logic
 - `workers/qa_queue_worker.py` — `QAQueueWorker` subclass of `BaseQueueWorker` for async QA jobs

--- a/ada_backend/repositories/quality_assurance_repository.py
+++ b/ada_backend/repositories/quality_assurance_repository.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Dict, List, Optional, Tuple
 from uuid import UUID
@@ -7,13 +8,20 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session
 
 from ada_backend.database.models import (
+    AssociationColumnMapping,
+    ColumnRole,
+    DatasetCellValue,
     DatasetProject,
     DatasetProjectAssociation,
     InputGroundtruth,
     QADatasetMetadata,
     VersionOutput,
 )
-from ada_backend.schemas.input_groundtruth_schema import InputGroundtruthCreate, InputGroundtruthUpdateList
+from ada_backend.schemas.input_groundtruth_schema import (
+    InputGroundtruthCreate,
+    InputGroundtruthUpdateList,
+    InputGroundtruthUpdateWithId,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -83,7 +91,7 @@ def create_inputs_groundtruths(
     dataset_id: UUID,
     inputs_groundtruths_data: List[InputGroundtruthCreate],
 ) -> List[InputGroundtruth]:
-    """Create multiple input-groundtruth entries."""
+    """Create multiple input-groundtruth entries with dual-write to DatasetCellValue."""
     max_position = get_max_position_of_dataset(session, dataset_id)
     starting_position = (max_position + 1) if max_position is not None else 1
 
@@ -92,22 +100,32 @@ def create_inputs_groundtruths(
         for i, data in enumerate(inputs_groundtruths_data)
     ]
 
-    inputs_groundtruths = [
-        InputGroundtruth(
+    column_map = _get_typed_column_map(session, dataset_id)
+
+    inputs_groundtruths = []
+    for data, position in zip(inputs_groundtruths_data, positions, strict=False):
+        input_val, groundtruth_val = _resolve_legacy_from_cell_values(data, column_map)
+        ig = InputGroundtruth(
             dataset_id=dataset_id,
-            input=data.input,
-            groundtruth=data.groundtruth,
+            input=input_val,
+            groundtruth=groundtruth_val,
             position=position,
             custom_columns=data.custom_columns,
         )
-        for data, position in zip(inputs_groundtruths_data, positions, strict=False)
-    ]
+        inputs_groundtruths.append(ig)
 
     session.add_all(inputs_groundtruths)
+    session.flush()
+
+    for ig, data in zip(inputs_groundtruths, inputs_groundtruths_data, strict=False):
+        cell_vals = _build_cell_values_for_write(data, column_map)
+        if cell_vals:
+            _upsert_cell_values(session, ig.id, cell_vals)
+
     session.commit()
 
-    for input_groundtruth in inputs_groundtruths:
-        session.refresh(input_groundtruth)
+    for ig in inputs_groundtruths:
+        session.refresh(ig)
 
     LOGGER.info(f"Created {len(inputs_groundtruths)} input-groundtruth entries for dataset {dataset_id}")
     return inputs_groundtruths
@@ -118,8 +136,9 @@ def update_inputs_groundtruths(
     inputs_groundtruths_data: InputGroundtruthUpdateList,
     dataset_id: UUID,
 ) -> List[InputGroundtruth]:
-    """Update multiple input-groundtruth entries."""
+    """Update multiple input-groundtruth entries with dual-write to DatasetCellValue."""
     updated_inputs_groundtruths = []
+    column_map = _get_typed_column_map(session, dataset_id)
 
     for update_item in inputs_groundtruths_data.inputs_groundtruths:
         input_id = update_item.id
@@ -145,6 +164,10 @@ def update_inputs_groundtruths(
                     else:
                         current_custom_columns[key] = value
                 input_groundtruth.custom_columns = current_custom_columns if current_custom_columns else None
+
+            cell_updates = _build_cell_values_for_update(update_item, column_map)
+            if cell_updates:
+                _upsert_cell_values(session, input_id, cell_updates)
 
             updated_inputs_groundtruths.append(input_groundtruth)
 
@@ -356,12 +379,26 @@ def get_datasets_by_organization(
     )
 
 
+# TODO: remove when system columns are no longer hardcoded (users will define their own roles)
+def _create_system_columns(session: Session, dataset_id: UUID) -> None:
+    session.add(QADatasetMetadata(
+        dataset_id=dataset_id, column_name="Input", column_display_position=0, default_role=ColumnRole.INPUT,
+    ))
+    session.add(QADatasetMetadata(
+        dataset_id=dataset_id,
+        column_name="Expected Output",
+        column_display_position=1,
+        default_role=ColumnRole.EXPECTED_OUTPUT,
+    ))
+
+
 def create_datasets(
     session: Session,
     organization_id: UUID,
     dataset_names: List[str],
+    *,
+    commit: bool = True,
 ) -> List[DatasetProject]:
-    """Create multiple datasets."""
     datasets = []
 
     for dataset_name in dataset_names:
@@ -372,10 +409,15 @@ def create_datasets(
         datasets.append(dataset)
 
     session.add_all(datasets)
-    session.commit()
+    session.flush()
 
     for dataset in datasets:
-        session.refresh(dataset)
+        _create_system_columns(session, dataset.id)
+
+    if commit:
+        session.commit()
+        for dataset in datasets:
+            session.refresh(dataset)
 
     LOGGER.debug(f"Created {len(datasets)} datasets for organization {organization_id}")
     return datasets
@@ -455,24 +497,73 @@ def set_dataset_project_associations(
     dataset_id: UUID,
     project_ids: List[UUID],
 ) -> None:
-    """Replace all project associations for a dataset."""
+    """Replace all project associations for a dataset, auto-populating column mappings from system columns."""
     session.query(DatasetProjectAssociation).filter(DatasetProjectAssociation.dataset_id == dataset_id).delete(
         synchronize_session=False
     )
 
-    for project_id in project_ids:
-        session.add(DatasetProjectAssociation(dataset_id=dataset_id, project_id=project_id))
+    system_columns = (
+        session.query(QADatasetMetadata)
+        .filter(QADatasetMetadata.dataset_id == dataset_id, QADatasetMetadata.default_role.isnot(None))
+        .all()
+    )
+
+    associations = [DatasetProjectAssociation(dataset_id=dataset_id, project_id=pid) for pid in project_ids]
+    session.add_all(associations)
+    session.flush()
+
+    mappings = [
+        AssociationColumnMapping(association_id=assoc.id, column_id=col.column_id, role=col.default_role)
+        for assoc in associations
+        for col in system_columns
+    ]
+    session.add_all(mappings)
 
     session.commit()
 
 
-def get_qa_columns_by_dataset(session: Session, dataset_id: UUID) -> List[QADatasetMetadata]:
-    return (
+def create_column_mappings_for_association(
+    session: Session, association_id: UUID, dataset_id: UUID,
+) -> List[AssociationColumnMapping]:
+    system_columns = (
         session.query(QADatasetMetadata)
-        .filter(QADatasetMetadata.dataset_id == dataset_id)
-        .order_by(QADatasetMetadata.column_display_position.asc())
+        .filter(QADatasetMetadata.dataset_id == dataset_id, QADatasetMetadata.default_role.isnot(None))
         .all()
     )
+    mappings = []
+    for col in system_columns:
+        mapping = AssociationColumnMapping(
+            association_id=association_id, column_id=col.column_id, role=col.default_role,
+        )
+        session.add(mapping)
+        mappings.append(mapping)
+    return mappings
+
+
+def get_column_mappings_for_association(
+    session: Session, association_id: UUID,
+) -> List[AssociationColumnMapping]:
+    return (
+        session.query(AssociationColumnMapping)
+        .filter(AssociationColumnMapping.association_id == association_id)
+        .all()
+    )
+
+
+def remove_column_mapping(session: Session, association_id: UUID, column_id: UUID) -> None:
+    session.query(AssociationColumnMapping).filter(
+        AssociationColumnMapping.association_id == association_id,
+        AssociationColumnMapping.column_id == column_id,
+    ).delete(synchronize_session=False)
+
+
+def get_qa_columns_by_dataset(
+    session: Session, dataset_id: UUID, *, user_only: bool = False,
+) -> List[QADatasetMetadata]:
+    query = session.query(QADatasetMetadata).filter(QADatasetMetadata.dataset_id == dataset_id)
+    if user_only:
+        query = query.filter(QADatasetMetadata.default_role.is_(None))
+    return query.order_by(QADatasetMetadata.column_display_position.asc()).all()
 
 
 def get_dataset_custom_columns_display_max_position(
@@ -493,12 +584,14 @@ def create_custom_column(
     column_id: UUID,
     column_name: str,
     column_display_position: int,
+    default_role: Optional["ColumnRole"] = None,
 ) -> QADatasetMetadata:
     qa_metadata = QADatasetMetadata(
         dataset_id=dataset_id,
         column_id=column_id,
         column_name=column_name,
         column_display_position=column_display_position,
+        default_role=default_role,
     )
 
     session.add(qa_metadata)
@@ -506,7 +599,7 @@ def create_custom_column(
     session.refresh(qa_metadata)
 
     LOGGER.info(
-        f"Created QA column '{column_name}' (column_id: {column_id}) "
+        f"Created QA column '{column_name}' (column_id: {column_id}, default_role: {default_role}) "
         f"at position {column_display_position} for dataset {dataset_id}"
     )
     return qa_metadata
@@ -519,6 +612,14 @@ def check_column_exist(session: Session, dataset_id: UUID, column_id: UUID) -> b
         .exists()
     ).scalar()
     return exists
+
+
+def get_column_metadata(session: Session, dataset_id: UUID, column_id: UUID) -> Optional[QADatasetMetadata]:
+    return (
+        session.query(QADatasetMetadata)
+        .filter(QADatasetMetadata.dataset_id == dataset_id, QADatasetMetadata.column_id == column_id)
+        .first()
+    )
 
 
 def rename_custom_column(
@@ -540,13 +641,13 @@ def rename_custom_column(
     return qa_metadata
 
 
-def remove_column_value_from_custom_column(session: Session, dataset_id: UUID, column_id: UUID) -> None:
+def delete_custom_column(session: Session, dataset_id: UUID, column_id: UUID) -> None:
     column_id_str = str(column_id)
 
     remove_key_from_jsonb = InputGroundtruth.custom_columns.op("-")(column_id_str)
     jsonb_empty_dict = func.cast("{}", JSONB)
 
-    stmt = (
+    session.execute(
         update(InputGroundtruth)
         .where(
             InputGroundtruth.dataset_id == dataset_id,
@@ -561,15 +662,145 @@ def remove_column_value_from_custom_column(session: Session, dataset_id: UUID, c
         )
     )
 
-    session.execute(stmt)
+    session.query(DatasetCellValue).filter(DatasetCellValue.column_id == column_id).delete(
+        synchronize_session=False
+    )
+    session.query(AssociationColumnMapping).filter(
+        AssociationColumnMapping.column_id == column_id
+    ).delete(synchronize_session=False)
+    session.query(QADatasetMetadata).filter(
+        QADatasetMetadata.dataset_id == dataset_id, QADatasetMetadata.column_id == column_id
+    ).delete(synchronize_session=False)
+
     session.commit()
 
 
-def delete_custom_column(session: Session, dataset_id: UUID, column_id: UUID) -> None:
-    (
-        session.query(QADatasetMetadata)
-        .filter(QADatasetMetadata.dataset_id == dataset_id, QADatasetMetadata.column_id == column_id)
+# ── DatasetCellValue helpers ──────────────────────────────────────────
+
+def get_cell_values_for_rows(session: Session, row_ids: List[UUID]) -> Dict[UUID, Dict[str, Optional[str]]]:
+    """Fetch cell values grouped by row_id."""
+    if not row_ids:
+        return {}
+    rows = (
+        session.query(DatasetCellValue.row_id, DatasetCellValue.column_id, DatasetCellValue.value)
+        .filter(DatasetCellValue.row_id.in_(row_ids))
+        .all()
+    )
+    result: Dict[UUID, Dict[str, Optional[str]]] = {}
+    for row_id, col_id, value in rows:
+        result.setdefault(row_id, {})[str(col_id)] = value
+    return result
+
+
+def _upsert_cell_values(session: Session, row_id: UUID, cell_values: Dict[str, Optional[str]]) -> None:
+    """Insert or update cell values for a given row."""
+    for col_id_str, value in cell_values.items():
+        col_id = UUID(col_id_str)
+        existing = (
+            session.query(DatasetCellValue)
+            .filter(DatasetCellValue.row_id == row_id, DatasetCellValue.column_id == col_id)
+            .first()
+        )
+        if existing:
+            existing.value = value
+        else:
+            session.add(DatasetCellValue(row_id=row_id, column_id=col_id, value=value))
+
+
+def delete_cell_values_for_row(session: Session, row_id: UUID) -> int:
+    return (
+        session.query(DatasetCellValue)
+        .filter(DatasetCellValue.row_id == row_id)
         .delete(synchronize_session=False)
     )
 
-    session.commit()
+
+def _get_typed_column_map(session: Session, dataset_id: UUID) -> Dict[str, List["QADatasetMetadata"]]:
+    """Return a dict mapping default_role -> list of columns for typed columns."""
+    columns = get_qa_columns_by_dataset(session, dataset_id)
+    result = {}
+    for col in columns:
+        if col.default_role is not None:
+            role_key = col.default_role.value if hasattr(col.default_role, "value") else col.default_role
+            result.setdefault(role_key, []).append(col)
+    return result
+
+
+def _resolve_legacy_from_cell_values(
+    data: InputGroundtruthCreate,
+    column_map: Dict,
+) -> tuple[dict, Optional[str]]:
+    """Derive legacy input/groundtruth from cell_values when not explicitly provided."""
+    input_val = data.input
+    groundtruth_val = data.groundtruth
+
+    if data.cell_values:
+        if input_val is None:
+            for col in column_map.get("input", []):
+                cv = data.cell_values.get(str(col.column_id))
+                if cv is not None:
+                    try:
+                        input_val = json.loads(cv)
+                    except (json.JSONDecodeError, TypeError):
+                        input_val = {"value": cv}
+                    break
+        if groundtruth_val is None:
+            for col in column_map.get("expected_output", []):
+                cv = data.cell_values.get(str(col.column_id))
+                if cv is not None:
+                    groundtruth_val = cv
+                    break
+
+    if input_val is None:
+        input_val = {}
+
+    return input_val, groundtruth_val
+
+
+def _build_cell_values_for_write(
+    data: InputGroundtruthCreate,
+    column_map: Dict,
+) -> Dict[str, Optional[str]]:
+    """Build cell_values dict from a create request, for dual-write."""
+    cell_vals: Dict[str, Optional[str]] = {}
+
+    for col in column_map.get("input", []):
+        if data.input is not None:
+            cell_vals[str(col.column_id)] = json.dumps(data.input)
+
+    for col in column_map.get("expected_output", []):
+        cell_vals[str(col.column_id)] = data.groundtruth
+
+    if data.custom_columns:
+        for col_id_str, value in data.custom_columns.items():
+            cell_vals[col_id_str] = value
+
+    if data.cell_values:
+        cell_vals.update(data.cell_values)
+
+    return cell_vals
+
+
+def _build_cell_values_for_update(
+    data: InputGroundtruthUpdateWithId,
+    column_map: Dict,
+) -> Dict[str, Optional[str]]:
+    """Build cell_values dict from an update request, for dual-write."""
+    cell_vals: Dict[str, Optional[str]] = {}
+
+    if data.input is not None:
+        for col in column_map.get("input", []):
+            cell_vals[str(col.column_id)] = json.dumps(data.input)
+
+    if data.groundtruth is not None:
+        for col in column_map.get("expected_output", []):
+            cell_vals[str(col.column_id)] = data.groundtruth
+
+    if data.custom_columns:
+        for col_id_str, value in data.custom_columns.items():
+            cell_vals[col_id_str] = value
+
+    if data.cell_values:
+        cell_vals.update(data.cell_values)
+
+    return cell_vals

--- a/ada_backend/routers/quality_assurance_router.py
+++ b/ada_backend/routers/quality_assurance_router.py
@@ -7,13 +7,7 @@ from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, Upload
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import DatasetProject, DatasetProjectAssociation, RunStatus
 from ada_backend.database.setup_db import get_db
-from ada_backend.repositories.qa_session_repository import update_qa_session_status
-from ada_backend.repositories.quality_assurance_repository import (
-    check_dataset_belongs_to_organization,
-    check_dataset_belongs_to_project,
-)
 from ada_backend.routers.auth_router import (
     UserRights,
     user_has_access_to_organization_dependency,
@@ -41,20 +35,6 @@ from ada_backend.schemas.input_groundtruth_schema import (
     QASessionResponseSchema,
 )
 from ada_backend.schemas.qa_metadata_schema import QAColumnResponse
-from ada_backend.services.errors import GraphNotBoundToProjectError, ProjectNotFound
-from ada_backend.services.qa.qa_error import (
-    CSVEmptyFileError,
-    CSVExportError,
-    CSVInvalidJSONError,
-    CSVInvalidPositionError,
-    CSVMissingDatasetColumnError,
-    CSVNonUniquePositionError,
-    QAColumnNotFoundError,
-    QADatasetNotInOrganizationError,
-    QADatasetNotInProjectError,
-    QADuplicatePositionError,
-    QAPartialPositionError,
-)
 from ada_backend.services.qa.qa_metadata_service import (
     create_qa_column_project_service,
     create_qa_column_service,
@@ -66,12 +46,14 @@ from ada_backend.services.qa.qa_metadata_service import (
     rename_qa_column_service,
 )
 from ada_backend.services.qa.quality_assurance_service import (
+    create_datasets_for_project_service,
     create_datasets_service,
     create_inputs_groundtruths_service,
     create_qa_session_service,
     delete_datasets_service,
     delete_inputs_groundtruths_service,
     export_qa_data_to_csv_service,
+    fail_qa_session_service,
     get_datasets_by_organization_service,
     get_datasets_by_project_service,
     get_inputs_groundtruths_with_version_outputs_service,
@@ -85,17 +67,14 @@ from ada_backend.services.qa.quality_assurance_service import (
     set_dataset_projects_service,
     update_dataset_service,
     update_inputs_groundtruths_service,
+    validate_dataset_in_organization,
+    validate_dataset_in_project,
     validate_qa_run_request,
 )
 from ada_backend.utils.redis_client import push_qa_task
 
 router = APIRouter(tags=["Quality Assurance"])
 LOGGER = logging.getLogger(__name__)
-
-
-def _validate_dataset_in_organization(session: Session, organization_id: UUID, dataset_id: UUID) -> None:
-    if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
-        raise QADatasetNotInOrganizationError(organization_id, dataset_id)
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -123,9 +102,6 @@ def get_datasets_by_organization_endpoint(
     except ValueError as e:
         LOGGER.error(f"Failed to get datasets for organization {organization_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to get datasets for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
@@ -148,9 +124,6 @@ def create_dataset_by_organization_endpoint(
     except ValueError as e:
         LOGGER.error(f"Failed to create datasets for organization {organization_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to create datasets for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.patch(
@@ -174,9 +147,6 @@ def update_dataset_by_organization_endpoint(
     except ValueError as e:
         LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.delete(
@@ -199,9 +169,6 @@ def delete_dataset_by_organization_endpoint(
     except ValueError as e:
         LOGGER.error(f"Failed to delete datasets for organization {organization_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to delete datasets for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.put(
@@ -224,9 +191,6 @@ def set_dataset_projects_endpoint(
         return set_dataset_projects_service(session, organization_id, dataset_id, body.project_ids)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to set dataset projects: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 # ── Organization-scoped QA Metadata (Custom Columns) ────────────────
@@ -246,15 +210,7 @@ def get_columns_by_dataset_org_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> List[QAColumnResponse]:
-    try:
-        return get_qa_columns_by_dataset_service(session, organization_id, dataset_id)
-    except QADatasetNotInOrganizationError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(
-            f"Failed to get columns for dataset {dataset_id} in org {organization_id}: {str(e)}", exc_info=True
-        )
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return get_qa_columns_by_dataset_service(session, organization_id, dataset_id)
 
 
 @router.post(
@@ -275,11 +231,8 @@ def add_column_to_dataset_org_endpoint(
 ) -> QAColumnResponse:
     try:
         return create_qa_column_service(session, organization_id, dataset_id, column_name)
-    except QADatasetNotInOrganizationError as e:
+    except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to add column to dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.patch(
@@ -299,15 +252,7 @@ def rename_column_org_endpoint(
     session: Session = Depends(get_db),
     column_name: str = Body(..., embed=True),
 ) -> QAColumnResponse:
-    try:
-        return rename_qa_column_service(session, organization_id, dataset_id, column_id, column_name)
-    except QADatasetNotInOrganizationError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except QAColumnNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to rename column {column_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return rename_qa_column_service(session, organization_id, dataset_id, column_id, column_name)
 
 
 @router.delete(
@@ -325,15 +270,7 @@ def delete_column_org_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> dict:
-    try:
-        return delete_qa_column_service(session, organization_id, dataset_id, column_id)
-    except QADatasetNotInOrganizationError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except QAColumnNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to delete column {column_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return delete_qa_column_service(session, organization_id, dataset_id, column_id)
 
 
 # ── Organization-scoped entries, CSV import/export ───────────────────
@@ -356,18 +293,10 @@ def get_inputs_groundtruths_by_dataset_org_endpoint(
     page_size: int = Query(100, ge=1, le=1000, description="Number of items per page"),
 ) -> PaginatedInputGroundtruthResponse:
     try:
-        _validate_dataset_in_organization(session, organization_id, dataset_id)
+        validate_dataset_in_organization(session, organization_id, dataset_id)
         return get_inputs_groundtruths_with_version_outputs_service(session, dataset_id, page, page_size)
-    except QADatasetNotInOrganizationError:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
-        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to get entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.get(
@@ -387,18 +316,10 @@ def get_outputs_org_endpoint(
     graph_runner_id: UUID = Query(..., description="Graph runner ID to get outputs for"),
 ) -> Dict[UUID, str]:
     try:
-        _validate_dataset_in_organization(session, organization_id, dataset_id)
+        validate_dataset_in_organization(session, organization_id, dataset_id)
         return get_outputs_by_graph_runner_service(session, dataset_id, graph_runner_id)
-    except QADatasetNotInOrganizationError:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
-        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to get outputs for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
@@ -418,20 +339,10 @@ def create_input_groundtruth_org_endpoint(
     session: Session = Depends(get_db),
 ) -> InputGroundtruthResponseList:
     try:
-        _validate_dataset_in_organization(session, organization_id, dataset_id)
+        validate_dataset_in_organization(session, organization_id, dataset_id)
         return create_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
-    except QADatasetNotInOrganizationError:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
-        )
-    except (QADuplicatePositionError, QAPartialPositionError) as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to create entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.patch(
@@ -451,18 +362,10 @@ def update_input_groundtruth_org_endpoint(
     session: Session = Depends(get_db),
 ) -> InputGroundtruthResponseList:
     try:
-        _validate_dataset_in_organization(session, organization_id, dataset_id)
+        validate_dataset_in_organization(session, organization_id, dataset_id)
         return update_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
-    except QADatasetNotInOrganizationError:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
-        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to update entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.delete(
@@ -481,19 +384,11 @@ def delete_input_groundtruth_org_endpoint(
     session: Session = Depends(get_db),
 ) -> dict:
     try:
-        _validate_dataset_in_organization(session, organization_id, dataset_id)
+        validate_dataset_in_organization(session, organization_id, dataset_id)
         deleted_count = delete_inputs_groundtruths_service(session, dataset_id, delete_data)
         return {"message": f"Deleted {deleted_count} input-groundtruth entries successfully"}
-    except QADatasetNotInOrganizationError:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
-        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to delete entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
@@ -513,24 +408,14 @@ async def create_entry_from_history_org(
     session: Session = Depends(get_db),
 ) -> List[InputGroundtruthResponse]:
     try:
-        _validate_dataset_in_organization(session, organization_id, dataset_id)
+        validate_dataset_in_organization(session, organization_id, dataset_id)
         return save_conversation_to_groundtruth_service(
             session=session,
             trace_id=trace_id,
             dataset_id=dataset_id,
         )
-    except QADatasetNotInOrganizationError:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
-        )
-    except (QADuplicatePositionError, QAPartialPositionError) as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to save trace {trace_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
@@ -548,25 +433,15 @@ def export_qa_data_to_csv_org_endpoint(
     session: Session = Depends(get_db),
     graph_runner_id: UUID = Query(..., description="Graph runner ID to filter outputs"),
 ) -> Response:
-    try:
-        _validate_dataset_in_organization(session, organization_id, dataset_id)
-        csv_content = export_qa_data_to_csv_service(session, dataset_id, graph_runner_id)
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-        filename = f"qa_export_{dataset_id}_{timestamp}.csv"
-        return Response(
-            content=csv_content,
-            media_type="text/csv",
-            headers={"Content-Disposition": f"attachment; filename={filename}"},
-        )
-    except QADatasetNotInOrganizationError:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
-        )
-    except CSVExportError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except Exception as e:
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    validate_dataset_in_organization(session, organization_id, dataset_id)
+    csv_content = export_qa_data_to_csv_service(session, dataset_id, graph_runner_id)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    filename = f"qa_export_{dataset_id}_{timestamp}.csv"
+    return Response(
+        content=csv_content,
+        media_type="text/csv",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
 
 
 @router.post(
@@ -585,31 +460,14 @@ async def import_qa_data_from_csv_org_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> InputGroundtruthResponseList:
-    try:
-        _validate_dataset_in_organization(session, organization_id, dataset_id)
-        await file.seek(0)
-        return import_qa_data_from_csv_service(
-            session=session,
-            organization_id=organization_id,
-            dataset_id=dataset_id,
-            csv_file=file.file,
-        )
-    except QADatasetNotInOrganizationError:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Dataset {dataset_id} not found in organization {organization_id}",
-        )
-    except (
-        CSVEmptyFileError,
-        CSVInvalidJSONError,
-        CSVMissingDatasetColumnError,
-        CSVNonUniquePositionError,
-        CSVInvalidPositionError,
-    ) as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to import QA data for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    validate_dataset_in_organization(session, organization_id, dataset_id)
+    await file.seek(0)
+    return import_qa_data_from_csv_service(
+        session=session,
+        organization_id=organization_id,
+        dataset_id=dataset_id,
+        csv_file=file.file,
+    )
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -654,15 +512,8 @@ async def run_qa_endpoint(
 ) -> QARunResponse:
     try:
         return await run_qa_service(session, project_id, dataset_id, run_request)
-    except QADatasetNotInProjectError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except GraphNotBoundToProjectError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to run QA on dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
@@ -684,8 +535,6 @@ async def run_qa_async_endpoint(
 ) -> QASessionAcceptedSchema:
     try:
         validate_qa_run_request(session, project_id, dataset_id, run_request)
-    except QADatasetNotInProjectError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -701,9 +550,8 @@ async def run_qa_async_endpoint(
         dataset_id=dataset_id,
         run_request_data=run_request.model_dump(mode="json"),
     ):
-        update_qa_session_status(
+        fail_qa_session_service(
             session, qa_session.id,
-            status=RunStatus.FAILED,
             error={"message": "Failed to enqueue QA run; Redis unavailable.", "type": "EnqueueError"},
         )
         raise HTTPException(
@@ -787,9 +635,6 @@ def get_datasets_by_project_endpoint(
     except ValueError as e:
         LOGGER.error(f"Failed to get datasets for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to get datasets for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
@@ -819,26 +664,10 @@ def create_dataset_endpoint(
 
     try:
         organization_id = resolve_organization_id(session, project_id)
-        response = create_datasets_service(session, organization_id, dataset_data)
-        dataset_ids = [dataset_resp.id for dataset_resp in response.datasets]
-        session.query(DatasetProject).filter(
-            DatasetProject.id.in_(dataset_ids)
-        ).update({"project_id": project_id}, synchronize_session=False)
-        session.add_all(
-            [DatasetProjectAssociation(dataset_id=did, project_id=project_id) for did in dataset_ids]
-        )
-        session.commit()
-        for dataset_resp in response.datasets:
-            dataset_resp.project_ids = [project_id]
-        return response
-    except ProjectNotFound as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+        return create_datasets_for_project_service(session, organization_id, project_id, dataset_data)
     except ValueError as e:
         LOGGER.error(f"Failed to create datasets for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to create datasets for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.patch(
@@ -869,22 +698,11 @@ def update_dataset_endpoint(
 
     try:
         organization_id = resolve_organization_id(session, project_id)
-        if not check_dataset_belongs_to_project(session, project_id, dataset_id):
-            raise QADatasetNotInProjectError(project_id, dataset_id)
+        validate_dataset_in_project(session, project_id, dataset_id)
         return update_dataset_service(session, organization_id, dataset_id, dataset_name)
-    except ProjectNotFound as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except QADatasetNotInProjectError:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Dataset {dataset_id} is not associated with project {project_id}",
-        )
     except ValueError as e:
         LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.delete(
@@ -914,23 +732,12 @@ def delete_dataset_endpoint(
     try:
         organization_id = resolve_organization_id(session, project_id)
         for dataset_id in delete_data.dataset_ids:
-            if not check_dataset_belongs_to_project(session, project_id, dataset_id):
-                raise QADatasetNotInProjectError(project_id, dataset_id)
+            validate_dataset_in_project(session, project_id, dataset_id)
         deleted_count = delete_datasets_service(session, organization_id, delete_data)
         return {"message": f"Deleted {deleted_count} datasets successfully"}
-    except ProjectNotFound as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except QADatasetNotInProjectError as e:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Dataset {e.dataset_id} is not associated with project {project_id}",
-        ) from e
     except ValueError as e:
         LOGGER.error(f"Failed to delete datasets for project {project_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to delete datasets for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 # ── Deprecated custom columns ────────────────────────────────────────
@@ -954,18 +761,7 @@ def get_columns_by_dataset_endpoint(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
-    try:
-        return get_qa_columns_by_dataset_project_service(session, project_id, dataset_id)
-    except QADatasetNotInProjectError as e:
-        LOGGER.error(
-            f"Failed to get columns for dataset {dataset_id} in project {project_id}: {str(e)}", exc_info=True
-        )
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(
-            f"Failed to get columns for dataset {dataset_id} in project {project_id}: {str(e)}", exc_info=True
-        )
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return get_qa_columns_by_dataset_project_service(session, project_id, dataset_id)
 
 
 @router.post(
@@ -989,13 +785,11 @@ def add_column_to_dataset_endpoint(
         raise HTTPException(status_code=400, detail="User ID not found")
 
     try:
-        return create_qa_column_project_service(session, project_id, dataset_id, column_name)
-    except QADatasetNotInProjectError as e:
-        LOGGER.error(f"Failed to add column to dataset {dataset_id} for project {project_id}: {str(e)}", exc_info=True)
+        return create_qa_column_project_service(
+            session, project_id, dataset_id, column_name,
+        )
+    except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to add column to dataset {dataset_id} for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.patch(
@@ -1019,26 +813,7 @@ def rename_column_endpoint(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
-    try:
-        return rename_qa_column_project_service(session, project_id, dataset_id, column_id, column_name)
-    except QADatasetNotInProjectError as e:
-        LOGGER.error(
-            f"Failed to rename column {column_id} in dataset {dataset_id} for project {project_id}: {str(e)}",
-            exc_info=True,
-        )
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except QAColumnNotFoundError as e:
-        LOGGER.error(
-            f"Failed to rename column {column_id} in dataset {dataset_id} for project {project_id}: {str(e)}",
-            exc_info=True,
-        )
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(
-            f"Failed to rename column {column_id} in dataset {dataset_id} for project {project_id}: {str(e)}",
-            exc_info=True,
-        )
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return rename_qa_column_project_service(session, project_id, dataset_id, column_id, column_name)
 
 
 @router.delete(
@@ -1060,26 +835,7 @@ def delete_column_endpoint(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
-    try:
-        return delete_qa_column_project_service(session, project_id, dataset_id, column_id)
-    except QADatasetNotInProjectError as e:
-        LOGGER.error(
-            f"Failed to delete column {column_id} from dataset {dataset_id} for project {project_id}: {str(e)}",
-            exc_info=True,
-        )
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except QAColumnNotFoundError as e:
-        LOGGER.error(
-            f"Failed to delete column {column_id} from dataset {dataset_id} for project {project_id}: {str(e)}",
-            exc_info=True,
-        )
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(
-            f"Failed to delete column {column_id} from dataset {dataset_id} for project {project_id}: {str(e)}",
-            exc_info=True,
-        )
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return delete_qa_column_project_service(session, project_id, dataset_id, column_id)
 
 
 # ── Deprecated entries, CSV import/export ────────────────────────────
@@ -1116,9 +872,6 @@ def get_inputs_groundtruths_by_dataset_endpoint(
     except ValueError as e:
         LOGGER.error(f"Failed to get input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to get input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.get(
@@ -1154,12 +907,6 @@ def get_outputs_endpoint(
             exc_info=True,
         )
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(
-            f"Failed to get outputs for graph runner {graph_runner_id} and dataset {dataset_id}: {str(e)}",
-            exc_info=True,
-        )
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
@@ -1190,15 +937,9 @@ def create_input_groundtruth_endpoint(
 
     try:
         return create_inputs_groundtruths_service(session, dataset_id, input_groundtruth_data)
-    except (QADuplicatePositionError, QAPartialPositionError) as e:
-        LOGGER.error(f"Failed to create input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e)) from e
     except ValueError as e:
         LOGGER.error(f"Failed to create input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to create input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.patch(
@@ -1232,9 +973,6 @@ def update_input_groundtruth_endpoint(
     except ValueError as e:
         LOGGER.error(f"Failed to update input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to update input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.delete(
@@ -1268,9 +1006,6 @@ def delete_input_groundtruth_endpoint(
     except ValueError as e:
         LOGGER.error(f"Failed to delete input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to delete input-groundtruth entries for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
@@ -1352,30 +1087,11 @@ async def import_qa_data_from_csv_endpoint(
 
     await file.seek(0)
 
-    try:
-        organization_id = resolve_organization_id(session, project_id)
-        result = import_qa_data_from_csv_service(
-            session=session,
-            organization_id=organization_id,
-            dataset_id=dataset_id,
-            csv_file=file.file,
-        )
-        return result
-    except ProjectNotFound as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except (
-        CSVEmptyFileError,
-        CSVInvalidJSONError,
-        CSVMissingDatasetColumnError,
-        CSVNonUniquePositionError,
-        CSVInvalidPositionError,
-    ) as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except QADatasetNotInProjectError as e:
-        LOGGER.error(
-            f"Failed to import QA data for dataset {dataset_id} in project {project_id}: {str(e)}", exc_info=True
-        )
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to import QA data for dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    organization_id = resolve_organization_id(session, project_id)
+    validate_dataset_in_project(session, project_id, dataset_id)
+    return import_qa_data_from_csv_service(
+        session=session,
+        organization_id=organization_id,
+        dataset_id=dataset_id,
+        csv_file=file.file,
+    )

--- a/ada_backend/schemas/input_groundtruth_schema.py
+++ b/ada_backend/schemas/input_groundtruth_schema.py
@@ -17,10 +17,11 @@ class Pagination(BaseModel):
 class InputGroundtruthCreate(BaseModel):
     """Schema for creating a new input-groundtruth entry."""
 
-    input: dict
+    input: Optional[dict] = None
     groundtruth: Optional[str] = None
     position: Optional[int] = None
     custom_columns: Optional[Dict[str, Optional[str]]] = None
+    cell_values: Optional[Dict[str, Optional[str]]] = None
 
     @field_validator("position")
     @classmethod
@@ -29,6 +30,12 @@ class InputGroundtruthCreate(BaseModel):
         if v is not None and v < 1:
             raise ValueError("position for a QA example must be a positive integer greater or equal to 1 if provided")
         return v
+
+    @model_validator(mode="after")
+    def validate_input_or_cell_values(self):
+        if not self.input and not self.cell_values:
+            raise ValueError("Either 'input' or 'cell_values' must be provided.")
+        return self
 
 
 class InputGroundtruthWithVersionResponse(BaseModel):
@@ -116,6 +123,7 @@ class InputGroundtruthUpdateWithId(BaseModel):
     input: Optional[dict] = None
     groundtruth: Optional[str] = None
     custom_columns: Optional[Dict[str, Optional[str]]] = None
+    cell_values: Optional[Dict[str, Optional[str]]] = None
 
 
 class InputGroundtruthUpdateList(BaseModel):
@@ -136,9 +144,10 @@ class InputGroundtruthResponse(BaseModel):
     id: UUID
     dataset_id: UUID
     position: int
-    input: dict
+    input: Optional[dict] = None
     groundtruth: Optional[str] = None
     custom_columns: Optional[Dict[str, Optional[str]]] = None
+    cell_values: Optional[Dict[str, Optional[str]]] = None
     created_at: datetime
     updated_at: datetime
 

--- a/ada_backend/schemas/qa_metadata_schema.py
+++ b/ada_backend/schemas/qa_metadata_schema.py
@@ -1,6 +1,11 @@
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
+
+
+class QAColumnCreate(BaseModel):
+    column_name: str
 
 
 class QAColumnResponse(BaseModel):
@@ -9,6 +14,7 @@ class QAColumnResponse(BaseModel):
     column_id: UUID
     column_name: str
     column_display_position: int
+    default_role: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/ada_backend/services/qa/qa_error.py
+++ b/ada_backend/services/qa/qa_error.py
@@ -131,3 +131,12 @@ class QAColumnNotFoundError(QAServiceError):
         self.dataset_id = dataset_id
         self.column_id = column_id
         super().__init__(f"Column {column_id} not found in dataset {dataset_id}")
+
+
+class QASystemColumnModificationError(QAServiceError):
+    status_code = 400
+
+    def __init__(self, dataset_id: UUID, column_id: UUID):
+        self.dataset_id = dataset_id
+        self.column_id = column_id
+        super().__init__(f"System column {column_id} in dataset {dataset_id} cannot be modified or deleted")

--- a/ada_backend/services/qa/qa_metadata_service.py
+++ b/ada_backend/services/qa/qa_metadata_service.py
@@ -1,19 +1,20 @@
 import logging
 import uuid
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from ada_backend.database.models import ColumnRole
 from ada_backend.repositories.quality_assurance_repository import (
     check_column_exist,
     check_dataset_belongs_to_organization,
     check_dataset_belongs_to_project,
     create_custom_column,
     delete_custom_column,
+    get_column_metadata,
     get_dataset_custom_columns_display_max_position,
     get_qa_columns_by_dataset,
-    remove_column_value_from_custom_column,
     rename_custom_column,
 )
 from ada_backend.schemas.qa_metadata_schema import QAColumnResponse
@@ -21,6 +22,7 @@ from ada_backend.services.qa.qa_error import (
     QAColumnNotFoundError,
     QADatasetNotInOrganizationError,
     QADatasetNotInProjectError,
+    QASystemColumnModificationError,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -43,29 +45,49 @@ def _validate_column_exists(session: Session, dataset_id: UUID, column_id: UUID)
         raise QAColumnNotFoundError(dataset_id, column_id)
 
 
+def _validate_column_is_user_column(session: Session, dataset_id: UUID, column_id: UUID) -> None:
+    col = get_column_metadata(session, dataset_id, column_id)
+    if col and col.default_role is not None:
+        raise QASystemColumnModificationError(dataset_id, column_id)
+
+
 # ── Core operations (ownership-agnostic) ──────────────────────────────
 
 def _get_columns(session: Session, dataset_id: UUID) -> List[QAColumnResponse]:
-    columns = get_qa_columns_by_dataset(session, dataset_id)
+    columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
     return [QAColumnResponse.model_validate(col) for col in columns]
 
 
-def _create_column(session: Session, dataset_id: UUID, column_name: str) -> QAColumnResponse:
+def _parse_default_role(default_role: Optional[str]) -> Optional[ColumnRole]:
+    if default_role is None:
+        return None
+    try:
+        return ColumnRole(default_role)
+    except ValueError:
+        raise ValueError(f"Invalid default_role: '{default_role}'. Must be 'input' or 'expected_output'.")
+
+
+def _create_column(
+    session: Session, dataset_id: UUID, column_name: str, default_role: Optional[str] = None,
+) -> QAColumnResponse:
     max_position = get_dataset_custom_columns_display_max_position(session, dataset_id)
     new_position = (max_position + 1) if max_position is not None else 0
     column_id = uuid.uuid4()
+    parsed_role = _parse_default_role(default_role)
     qa_metadata = create_custom_column(
         session=session,
         dataset_id=dataset_id,
         column_id=column_id,
         column_name=column_name,
         column_display_position=new_position,
+        default_role=parsed_role,
     )
     return QAColumnResponse.model_validate(qa_metadata)
 
 
 def _rename_column(session: Session, dataset_id: UUID, column_id: UUID, column_name: str) -> QAColumnResponse:
     _validate_column_exists(session, dataset_id, column_id)
+    _validate_column_is_user_column(session, dataset_id, column_id)
     qa_metadata = rename_custom_column(
         session=session,
         dataset_id=dataset_id,
@@ -77,7 +99,7 @@ def _rename_column(session: Session, dataset_id: UUID, column_id: UUID, column_n
 
 def _delete_column(session: Session, dataset_id: UUID, column_id: UUID) -> dict:
     _validate_column_exists(session, dataset_id, column_id)
-    remove_column_value_from_custom_column(session, dataset_id, column_id)
+    _validate_column_is_user_column(session, dataset_id, column_id)
     delete_custom_column(session, dataset_id, column_id)
     return {"message": f"Deleted column {column_id} successfully"}
 

--- a/ada_backend/services/qa/quality_assurance_service.py
+++ b/ada_backend/services/qa/quality_assurance_service.py
@@ -10,7 +10,14 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import CallType, DatasetProject, Project, QASession, RunStatus
+from ada_backend.database.models import (
+    CallType,
+    DatasetProject,
+    DatasetProjectAssociation,
+    Project,
+    QASession,
+    RunStatus,
+)
 from ada_backend.database.setup_db import get_db_session
 from ada_backend.repositories.env_repository import get_env_relationship_by_graph_runner_id
 from ada_backend.repositories.qa_evaluation_repository import delete_evaluations_for_input_ids
@@ -24,10 +31,12 @@ from ada_backend.repositories.quality_assurance_repository import (
     check_dataset_belongs_to_organization,
     check_dataset_belongs_to_project,
     clear_version_outputs_for_input_ids,
+    create_column_mappings_for_association,
     create_datasets,
     create_inputs_groundtruths,
     delete_datasets,
     delete_inputs_groundtruths,
+    get_cell_values_for_rows,
     get_dataset_project_associations,
     get_datasets_by_organization,
     get_datasets_by_project,
@@ -74,6 +83,7 @@ from ada_backend.services.qa.qa_error import (
     CSVInvalidPositionError,
     CSVMissingDatasetColumnError,
     CSVNonUniquePositionError,
+    QADatasetNotInOrganizationError,
     QADatasetNotInProjectError,
     QADuplicatePositionError,
     QAPartialPositionError,
@@ -82,6 +92,24 @@ from ada_backend.services.qa.qa_metadata_service import create_qa_column_service
 from ada_backend.utils.redis_client import publish_qa_event
 
 LOGGER = logging.getLogger(__name__)
+
+_IG_COLUMN_KEYS = (
+    "id",
+    "dataset_id",
+    "position",
+    "input",
+    "groundtruth",
+    "custom_columns",
+    "created_at",
+    "updated_at",
+)
+
+
+def _ig_to_response(ig, cell_values: Optional[Dict[str, Optional[str]]] = None) -> InputGroundtruthResponse:
+    data = {k: getattr(ig, k) for k in _IG_COLUMN_KEYS}
+    data["cell_values"] = cell_values
+    return InputGroundtruthResponse.model_validate(data)
+
 
 MAX_CSV_EXPORT_SIZE_MB = 10
 MAX_CSV_EXPORT_SIZE_BYTES = MAX_CSV_EXPORT_SIZE_MB * 1024 * 1024
@@ -113,7 +141,10 @@ def get_inputs_groundtruths_with_version_outputs_service(
         )
         inputs = get_inputs_groundtruths_by_dataset(session, dataset_id, skip, page_size)
 
-        response_list = [InputGroundtruthResponse.model_validate(input_groundtruth) for input_groundtruth in inputs]
+        row_ids = [ig.id for ig in inputs]
+        cell_values_map = get_cell_values_for_rows(session, row_ids) if row_ids else {}
+
+        response_list = [_ig_to_response(ig, cell_values_map.get(ig.id)) for ig in inputs]
 
         return PaginatedInputGroundtruthResponse(
             pagination=Pagination(
@@ -176,9 +207,7 @@ def _validate_env_binding(
     project_id: UUID,
     graph_runner_id: UUID,
 ):
-    env_relationship = get_env_relationship_by_graph_runner_id(
-        session=session, graph_runner_id=graph_runner_id
-    )
+    env_relationship = get_env_relationship_by_graph_runner_id(session=session, graph_runner_id=graph_runner_id)
     if not env_relationship:
         raise GraphNotBoundToProjectError(graph_runner_id)
     if env_relationship.project_id != project_id:
@@ -225,9 +254,7 @@ def resolve_qa_entries_and_environment(
 
     if run_request.run_all:
         number_of_dataset_inputs = get_inputs_groundtruths_count_by_dataset(session, dataset_id)
-        input_entries = get_inputs_groundtruths_by_dataset(
-            session, dataset_id, skip=0, limit=number_of_dataset_inputs
-        )
+        input_entries = get_inputs_groundtruths_by_dataset(session, dataset_id, skip=0, limit=number_of_dataset_inputs)
         if not input_entries:
             raise ValueError(f"No input entries found in dataset {dataset_id}")
     else:
@@ -246,10 +273,7 @@ def resolve_qa_entries_and_environment(
 
     env_relationship = _validate_env_binding(session, project_id, run_request.graph_runner_id)
 
-    qa_entries = [
-        QAEntry(id=entry.id, input=entry.input, groundtruth=entry.groundtruth)
-        for entry in input_entries
-    ]
+    qa_entries = [QAEntry(id=entry.id, input=entry.input, groundtruth=entry.groundtruth) for entry in input_entries]
     return qa_entries, env_relationship.environment
 
 
@@ -268,12 +292,15 @@ async def _execute_qa_entries(
     with get_db_session() as db_session:
         for index, input_entry in enumerate(input_entries):
             if session_id:
-                publish_qa_event(session_id, {
-                    "type": "qa.entry.started",
-                    "input_id": str(input_entry.id),
-                    "index": index,
-                    "total": total,
-                })
+                publish_qa_event(
+                    session_id,
+                    {
+                        "type": "qa.entry.started",
+                        "input_id": str(input_entry.id),
+                        "index": index,
+                        "total": total,
+                    },
+                )
 
             try:
                 chat_response = await run_agent(
@@ -336,13 +363,16 @@ async def _execute_qa_entries(
             results.append(result)
 
             if session_id:
-                publish_qa_event(session_id, {
-                    "type": "qa.entry.completed",
-                    "input_id": str(input_entry.id),
-                    "output": result.output,
-                    "success": result.success,
-                    "error": result.error,
-                })
+                publish_qa_event(
+                    session_id,
+                    {
+                        "type": "qa.entry.completed",
+                        "input_id": str(input_entry.id),
+                        "output": result.output,
+                        "success": result.success,
+                        "error": result.error,
+                    },
+                )
 
     total_processed = len(results)
     success_rate = (successful_runs / total_processed * 100) if total_processed > 0 else 0.0
@@ -355,10 +385,7 @@ async def _execute_qa_entries(
     )
 
     run_mode = "all entries" if run_request.run_all else f"{len(run_request.input_ids)} selected entries"
-    LOGGER.info(
-        f"QA run completed for project {project_id}, "
-        f"dataset {run_request.graph_runner_id}, mode: {run_mode}"
-    )
+    LOGGER.info(f"QA run completed for project {project_id}, dataset {run_request.graph_runner_id}, mode: {run_mode}")
 
     return QARunResponse(results=results, summary=summary)
 
@@ -388,20 +415,29 @@ async def run_qa_background(
     try:
         with get_db_session() as session:
             input_entries, environment = resolve_qa_entries_and_environment(
-                session, project_id, dataset_id, run_request,
+                session,
+                project_id,
+                dataset_id,
+                run_request,
             )
             update_qa_session_status(
-                session, session_id,
+                session,
+                session_id,
                 status=RunStatus.RUNNING,
                 started_at=datetime.now(timezone.utc),
             )
         response = await _execute_qa_entries(
-            project_id, run_request, input_entries, environment, session_id=session_id,
+            project_id,
+            run_request,
+            input_entries,
+            environment,
+            session_id=session_id,
         )
 
         with get_db_session() as session:
             update_qa_session_status(
-                session, session_id,
+                session,
+                session_id,
                 status=RunStatus.COMPLETED,
                 finished_at=datetime.now(timezone.utc),
                 total=response.summary.total,
@@ -409,27 +445,34 @@ async def run_qa_background(
                 failed=response.summary.failed,
             )
 
-        publish_qa_event(session_id, {
-            "type": "qa.completed",
-            "summary": response.summary.model_dump(),
-        })
+        publish_qa_event(
+            session_id,
+            {
+                "type": "qa.completed",
+                "summary": response.summary.model_dump(),
+            },
+        )
 
     except Exception as e:
         LOGGER.error(f"Background QA run failed for session {session_id}: {str(e)}", exc_info=True)
         try:
             with get_db_session() as session:
                 update_qa_session_status(
-                    session, session_id,
+                    session,
+                    session_id,
                     status=RunStatus.FAILED,
                     finished_at=datetime.now(timezone.utc),
                     error={"message": str(e), "type": type(e).__name__},
                 )
         except Exception as status_err:
             LOGGER.error(f"Failed to update QA session status to FAILED for {session_id}: {status_err}")
-        publish_qa_event(session_id, {
-            "type": "qa.failed",
-            "error": {"message": str(e), "type": type(e).__name__},
-        })
+        publish_qa_event(
+            session_id,
+            {
+                "type": "qa.failed",
+                "error": {"message": str(e), "type": type(e).__name__},
+            },
+        )
 
 
 def create_qa_session_service(
@@ -440,7 +483,10 @@ def create_qa_session_service(
     graph_runner_id: UUID,
 ) -> QASession:
     return create_qa_session(
-        session, project_id=project_id, dataset_id=dataset_id, graph_runner_id=graph_runner_id,
+        session,
+        project_id=project_id,
+        dataset_id=dataset_id,
+        graph_runner_id=graph_runner_id,
     )
 
 
@@ -499,9 +545,12 @@ def create_inputs_groundtruths_service(
 
         LOGGER.info(f"Created {len(created_inputs_groundtruths)} input-groundtruth entries for dataset {dataset_id}")
 
-        return InputGroundtruthResponseList(
-            inputs_groundtruths=[InputGroundtruthResponse.model_validate(ig) for ig in created_inputs_groundtruths]
-        )
+        row_ids = [ig.id for ig in created_inputs_groundtruths]
+        cell_values_map = get_cell_values_for_rows(session, row_ids) if row_ids else {}
+
+        responses = [_ig_to_response(ig, cell_values_map.get(ig.id)) for ig in created_inputs_groundtruths]
+
+        return InputGroundtruthResponseList(inputs_groundtruths=responses)
     except (QADuplicatePositionError, QAPartialPositionError):
         raise
     except Exception as e:
@@ -545,9 +594,12 @@ def update_inputs_groundtruths_service(
 
         LOGGER.info(f"Updated {len(updated_inputs_groundtruths)} input-groundtruth entries for dataset {dataset_id}")
 
-        return InputGroundtruthResponseList(
-            inputs_groundtruths=[InputGroundtruthResponse.model_validate(ig) for ig in updated_inputs_groundtruths]
-        )
+        row_ids = [ig.id for ig in updated_inputs_groundtruths]
+        cell_values_map = get_cell_values_for_rows(session, row_ids) if row_ids else {}
+
+        responses = [_ig_to_response(ig, cell_values_map.get(ig.id)) for ig in updated_inputs_groundtruths]
+
+        return InputGroundtruthResponseList(inputs_groundtruths=responses)
     except Exception as e:
         session.rollback()
         LOGGER.error(f"Error in update_inputs_groundtruths_service: {str(e)}")
@@ -621,25 +673,66 @@ def get_datasets_by_organization_service(
         raise ValueError(f"Failed to get datasets: {str(e)}") from e
 
 
+def validate_dataset_in_organization(session: Session, organization_id: UUID, dataset_id: UUID) -> None:
+    if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
+        raise QADatasetNotInOrganizationError(organization_id, dataset_id)
+
+
+def validate_dataset_in_project(session: Session, project_id: UUID, dataset_id: UUID) -> None:
+    if not check_dataset_belongs_to_project(session, project_id, dataset_id):
+        raise QADatasetNotInProjectError(project_id, dataset_id)
+
+
+def fail_qa_session_service(session: Session, session_id: UUID, error: dict) -> None:
+    update_qa_session_status(session, session_id, status=RunStatus.FAILED, error=error)
+
+
 def create_datasets_service(
     session: Session,
     organization_id: UUID,
     datasets_data: DatasetCreateList,
+    *,
+    commit: bool = True,
 ) -> DatasetListResponse:
     try:
         created_datasets = create_datasets(
             session,
             organization_id,
             datasets_data.datasets_name,
+            commit=commit,
         )
 
         LOGGER.info(f"Created {len(created_datasets)} datasets for organization {organization_id}")
-        return DatasetListResponse(
-            datasets=[_dataset_to_response(session, dataset) for dataset in created_datasets]
-        )
+        return DatasetListResponse(datasets=[_dataset_to_response(session, dataset) for dataset in created_datasets])
     except Exception as e:
         LOGGER.error(f"Error in create_datasets_service: {str(e)}")
         raise ValueError(f"Failed to create datasets: {str(e)}") from e
+
+
+def create_datasets_for_project_service(
+    session: Session,
+    organization_id: UUID,
+    project_id: UUID,
+    datasets_data: DatasetCreateList,
+) -> DatasetListResponse:
+    try:
+        response = create_datasets_service(session, organization_id, datasets_data, commit=False)
+        dataset_ids = [dataset_resp.id for dataset_resp in response.datasets]
+        session.query(DatasetProject).filter(DatasetProject.id.in_(dataset_ids)).update(
+            {"project_id": project_id}, synchronize_session=False
+        )
+        assocs = [DatasetProjectAssociation(dataset_id=did, project_id=project_id) for did in dataset_ids]
+        session.add_all(assocs)
+        session.flush()
+        for assoc in assocs:
+            create_column_mappings_for_association(session, assoc.id, assoc.dataset_id)
+        session.commit()
+        for dataset_resp in response.datasets:
+            dataset_resp.project_ids = [project_id]
+        return response
+    except Exception:
+        session.rollback()
+        raise
 
 
 def update_dataset_service(
@@ -649,9 +742,7 @@ def update_dataset_service(
     dataset_name: str,
 ) -> DatasetResponse:
     if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
-        LOGGER.error(
-            f"Failed to update dataset {dataset_id}: not found in organization {organization_id}"
-        )
+        LOGGER.error(f"Failed to update dataset {dataset_id}: not found in organization {organization_id}")
         raise ValueError(f"Dataset {dataset_id} not found in organization {organization_id}")
 
     try:
@@ -754,7 +845,7 @@ def export_qa_data_to_csv_service(
         input_entries = get_inputs_groundtruths_by_dataset(session, dataset_id, skip=0, limit=total_count)
         outputs_dict = dict(get_outputs_by_graph_runner(session, dataset_id, graph_runner_id))
 
-        custom_columns = get_qa_columns_by_dataset(session, dataset_id)
+        custom_columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
 
         header_row = DEFAULT_HEADERS.copy()
         custom_column_names = [col.column_name for col in custom_columns]
@@ -811,7 +902,7 @@ def import_qa_data_from_csv_service(
         headers_from_csv = get_headers_from_csv(csv_file)
         expected_columns = set(DEFAULT_HEADERS.copy())
         custom_columns_from_csv = set(headers_from_csv) - expected_columns
-        dataset_custom_columns = get_qa_columns_by_dataset(session, dataset_id)
+        dataset_custom_columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         dataset_column_names = {col.column_name for col in dataset_custom_columns}
 
         missing_custom_columns_from_csv = dataset_column_names - custom_columns_from_csv
@@ -833,7 +924,7 @@ def import_qa_data_from_csv_service(
                 column_name=column_name,
             )
 
-        updated_dataset_custom_columns_list = get_qa_columns_by_dataset(session, dataset_id)
+        updated_dataset_custom_columns_list = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         updated_dataset_custom_columns = {
             str(col.column_id): col.column_name for col in updated_dataset_custom_columns_list
         }

--- a/tests/ada_backend/test_quality_assurance_service.py
+++ b/tests/ada_backend/test_quality_assurance_service.py
@@ -1,15 +1,19 @@
 import csv
 import io
 import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
 
-from ada_backend.database.models import EnvType
+from ada_backend.database.models import ColumnRole, DatasetProjectAssociation, EnvType
 from ada_backend.database.setup_db import get_db_session
 from ada_backend.repositories.quality_assurance_repository import (
+    get_column_mappings_for_association,
     get_qa_columns_by_dataset,
+    remove_column_mapping,
     set_dataset_project_associations,
 )
 from ada_backend.schemas.dataset_schema import DatasetCreateList, DatasetDeleteList
@@ -43,6 +47,7 @@ from ada_backend.services.qa.qa_metadata_service import (
     rename_qa_column_service,
 )
 from ada_backend.services.qa.quality_assurance_service import (
+    _ig_to_response,
     create_datasets_service,
     create_inputs_groundtruths_service,
     delete_datasets_service,
@@ -207,8 +212,8 @@ def test_dataset_management():
         create_qa_column_service(session, ORGANIZATION_ID, dataset_with_columns, "Priority")
         create_qa_column_service(session, ORGANIZATION_ID, dataset_with_columns, "Category")
 
-        # Verify columns exist
-        columns_before = get_qa_columns_by_dataset(session, dataset_with_columns)
+        # Verify custom columns exist (system columns are created automatically)
+        columns_before = get_qa_columns_by_dataset(session, dataset_with_columns, user_only=True)
         assert len(columns_before) == 2
 
         # Delete the dataset
@@ -771,7 +776,7 @@ def test_csv_import_creates_new_custom_columns_and_values():
         dataset_id = dataset_data.datasets[0].id
 
         # Verify no custom columns exist initially
-        initial_columns = get_qa_columns_by_dataset(session, dataset_id)
+        initial_columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(initial_columns) == 0
 
         # CSV with custom columns that don't exist yet
@@ -791,7 +796,7 @@ def test_csv_import_creates_new_custom_columns_and_values():
         assert len(imported_entries) == 2
 
         # Verify custom columns were created
-        columns_after_import = get_qa_columns_by_dataset(session, dataset_id)
+        columns_after_import = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(columns_after_import) == 2
         column_names = {col.column_name for col in columns_after_import}
         assert column_names == {"my_flag", "score"}
@@ -838,7 +843,7 @@ def test_csv_import_requires_all_existing_custom_columns_in_header():
         create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "col_b")
 
         # Verify columns exist
-        existing_columns = get_qa_columns_by_dataset(session, dataset_id)
+        existing_columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(existing_columns) == 2
         column_names = {col.column_name for col in existing_columns}
         assert column_names == {"col_a", "col_b"}
@@ -893,7 +898,7 @@ def test_csv_import_adds_new_columns_while_preserving_existing():
         assert len(import_response.inputs_groundtruths) == 1
 
         # Verify both columns exist
-        columns_after_import = get_qa_columns_by_dataset(session, dataset_id)
+        columns_after_import = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(columns_after_import) == 2
         column_names = {col.column_name for col in columns_after_import}
         assert column_names == {"existing_col", "new_col"}
@@ -946,7 +951,7 @@ def test_csv_import_handles_missing_cell_values_for_custom_columns():
         assert len(import_response.inputs_groundtruths) == 2
 
         # Verify column was created
-        columns = get_qa_columns_by_dataset(session, dataset_id)
+        columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(columns) == 1
         assert columns[0].column_name == "optional_col"
         column_id_str = str(columns[0].column_id)
@@ -1007,7 +1012,7 @@ def test_csv_import_uses_get_headers_from_csv_and_processes_all_rows():
         assert positions == [1, 2, 3]
 
         # Verify all entries have custom column values
-        columns = get_qa_columns_by_dataset(session, dataset_id)
+        columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(columns) == 1
         column_id_str = str(columns[0].column_id)
 
@@ -1077,28 +1082,26 @@ def test_create_qa_column_service():
         )
         dataset_id = dataset_data.datasets[0].id
 
-        # Create first column
+        # System columns "Input" (pos 0) and "Expected Output" (pos 1) are created
+        # automatically, so custom columns start at position 2.
         col_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Priority")
         assert col_response.column_name == "Priority"
-        assert col_response.column_display_position == 0
+        assert col_response.column_display_position == 2
         assert col_response.column_id is not None
         assert col_response.dataset_id == dataset_id
 
-        # Create second column
         col2_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Category")
         assert col2_response.column_name == "Category"
-        assert col2_response.column_display_position == 1
+        assert col2_response.column_display_position == 3
         assert col2_response.column_id != col_response.column_id
 
-        # Create third column to verify sequential column positions
         col3_response = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Third")
-        assert col3_response.column_display_position == 2
+        assert col3_response.column_display_position == 4
 
-        # Verify all columns exist and positions are sequential
-        columns = get_qa_columns_by_dataset(session, dataset_id)
+        columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(columns) == 3
         positions = [col.column_display_position for col in columns]
-        assert positions == [0, 1, 2]
+        assert positions == [2, 3, 4]
 
         # Test error case: dataset not in organization
         other_org_id = uuid4()
@@ -1139,7 +1142,7 @@ def test_rename_qa_column_service():
         )  # column_display_position should not change
 
         # Verify the rename persisted
-        columns = get_qa_columns_by_dataset(session, dataset_id)
+        columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(columns) == 1
         assert columns[0].column_name == "NewName"
         assert columns[0].column_id == original_column_id
@@ -1180,7 +1183,7 @@ def test_delete_qa_column_service():
         col2 = create_qa_column_service(session, ORGANIZATION_ID, dataset_id, "Category")
 
         # Verify both exist
-        columns = get_qa_columns_by_dataset(session, dataset_id)
+        columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(columns) == 2
 
         # Delete one column
@@ -1189,7 +1192,7 @@ def test_delete_qa_column_service():
         assert "successfully" in delete_response["message"].lower()
 
         # Verify only one column remains
-        columns_after = get_qa_columns_by_dataset(session, dataset_id)
+        columns_after = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(columns_after) == 1
         assert columns_after[0].column_id == col2.column_id
         assert columns_after[0].column_name == "Category"
@@ -1225,7 +1228,7 @@ def test_delete_qa_column_service():
         delete_qa_column_service(session, ORGANIZATION_ID, dataset_id, col2.column_id)
 
         # Verify column is gone
-        columns = get_qa_columns_by_dataset(session, dataset_id)
+        columns = get_qa_columns_by_dataset(session, dataset_id, user_only=True)
         assert len(columns) == 0
 
         # Verify values were removed from entries
@@ -1502,3 +1505,124 @@ def test_csv_export_error_cases():
         assert "No data to export" in str(exc_info.value)
 
         delete_project_service(session=session, project_id=project_id)
+
+
+def test_association_column_mappings_auto_populated():
+    """Verify set_dataset_project_associations auto-populates column mappings from system columns."""
+    with get_db_session() as session:
+        project_id, _ = create_project_and_graph_runner(
+            session, project_name_prefix="col_mapping_test", description="Column mapping test"
+        )
+        dataset_data = create_datasets_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"col_mapping_ds_{project_id}"])
+        )
+        dataset_id = dataset_data.datasets[0].id
+
+        set_dataset_project_associations(session, dataset_id, [project_id])
+
+        assoc = (
+            session.query(DatasetProjectAssociation)
+            .filter(
+                DatasetProjectAssociation.dataset_id == dataset_id,
+                DatasetProjectAssociation.project_id == project_id,
+            )
+            .one()
+        )
+        mappings = get_column_mappings_for_association(session, assoc.id)
+        roles = {m.role for m in mappings}
+        assert ColumnRole.INPUT in roles
+        assert ColumnRole.EXPECTED_OUTPUT in roles
+        assert len(mappings) == 2
+
+        delete_project_service(session=session, project_id=project_id)
+
+
+def test_association_column_mapping_remove():
+    """Verify removing a column mapping works and does not affect others."""
+    with get_db_session() as session:
+        project_id, _ = create_project_and_graph_runner(
+            session, project_name_prefix="col_mapping_rm_test", description="Column mapping remove test"
+        )
+        dataset_data = create_datasets_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"col_mapping_rm_ds_{project_id}"])
+        )
+        dataset_id = dataset_data.datasets[0].id
+
+        set_dataset_project_associations(session, dataset_id, [project_id])
+
+        assoc = (
+            session.query(DatasetProjectAssociation)
+            .filter(
+                DatasetProjectAssociation.dataset_id == dataset_id,
+                DatasetProjectAssociation.project_id == project_id,
+            )
+            .one()
+        )
+        mappings = get_column_mappings_for_association(session, assoc.id)
+        input_mapping = next(m for m in mappings if m.role == ColumnRole.INPUT)
+
+        remove_column_mapping(session, assoc.id, input_mapping.column_id)
+        session.commit()
+
+        remaining = get_column_mappings_for_association(session, assoc.id)
+        assert len(remaining) == 1
+        assert remaining[0].role == ColumnRole.EXPECTED_OUTPUT
+
+        delete_project_service(session=session, project_id=project_id)
+
+
+def test_association_column_mappings_cascade_on_association_delete():
+    """Verify column mappings are cascade-deleted when the association is deleted."""
+    with get_db_session() as session:
+        project_id, _ = create_project_and_graph_runner(
+            session, project_name_prefix="col_mapping_cascade_test", description="Cascade delete test"
+        )
+        dataset_data = create_datasets_service(
+            session, ORGANIZATION_ID, DatasetCreateList(datasets_name=[f"col_mapping_cascade_ds_{project_id}"])
+        )
+        dataset_id = dataset_data.datasets[0].id
+
+        set_dataset_project_associations(session, dataset_id, [project_id])
+
+        assoc = (
+            session.query(DatasetProjectAssociation)
+            .filter(
+                DatasetProjectAssociation.dataset_id == dataset_id,
+                DatasetProjectAssociation.project_id == project_id,
+            )
+            .one()
+        )
+        assoc_id = assoc.id
+        assert len(get_column_mappings_for_association(session, assoc_id)) == 2
+
+        set_dataset_project_associations(session, dataset_id, [])
+
+        assert len(get_column_mappings_for_association(session, assoc_id)) == 0
+
+        delete_project_service(session=session, project_id=project_id)
+
+
+def test_ig_to_response_skips_orm_relationship():
+    """_ig_to_response builds a response from ORM columns, ignoring the cell_values relationship."""
+    now = datetime.now(tz=timezone.utc)
+    row_id = uuid4()
+    ds_id = uuid4()
+
+    fake_row = SimpleNamespace(
+        id=row_id,
+        dataset_id=ds_id,
+        position=1,
+        input={"key": "value"},
+        groundtruth="expected",
+        custom_columns=None,
+        cell_values=[],
+        created_at=now,
+        updated_at=now,
+    )
+
+    resp = _ig_to_response(fake_row, {"col1": "val1"})
+    assert resp.cell_values == {"col1": "val1"}
+    assert resp.id == row_id
+
+    resp_none = _ig_to_response(fake_row)
+    assert resp_none.cell_values is None


### PR DESCRIPTION
# feat(qa): add flexible dataset columns with normalized cell storage and dual-write

## Summary
- Introduces a normalized `DatasetCellValue` table (EAV-style) to store per-cell values for QA dataset rows, replacing the implicit `input`/`groundtruth`/`custom_columns` structure with a flexible column-based model.
- Adds `AssociationColumnMapping` to track which dataset columns serve as `input` vs `expected_output` for each project association, auto-populated from system columns when associations are created.
- Implements dual-write: all create/update operations on `InputGroundtruth` now also write to `DatasetCellValue`, and responses include the new `cell_values` field, enabling a gradual migration from the legacy column structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typed QA columns with roles (Input / Expected Output) and automatic per-association mappings
  * Per-row per-column cell_values in create/update/list responses and APIs; custom columns may include an optional default role
  * Dataset creation now auto-populates system columns for associations

* **Behavior Changes / Bug Fixes**
  * Column listings and CSV import/export use user-only columns by default
  * Deleting a custom column also removes its per-cell data; system columns cannot be modified/deleted

* **Documentation**
  * QA docs updated to describe roles, mappings, and service responsibilities

* **Tests**
  * Added mapping, cascade, and cell_values response tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->