### PR TITLE
fix(errors): improve backend and MCP error clarity DRA-1261

### DIFF
--- a/.cursor/rules/mcp.mdc
+++ b/.cursor/rules/mcp.mdc
@@ -15,7 +15,7 @@ globs:
 - Workflow creation: `create_workflow` creates workflow-type projects. Agent projects use `create_agent`.
 - Target-org permissions: tools that accept an explicit `org_id` must validate the caller's role on that target organization, not only on the active org session.
 - Component search: `search_components(query)` must reject blank or whitespace-only queries instead of returning the full catalog.
-- Error handling: never bare except. Map HTTP errors to descriptive MCP tool error messages via `ToolError`.
+- Error handling: never bare except. Map HTTP errors to descriptive MCP tool error messages via `ToolError`. `_handle_response` in `client.py` handles 400 (invalid request + docstring hint), 409 (conflict + re-fetch guidance), and 422 (formatted field-level validation errors) in addition to the existing 401/403/404/429/500/502/503 handlers. Tool-level validation errors must raise `ValueError` with a "what failed + what to do" message.
 - Sentry: `MCPIntegration` is auto-configured. Use `sentry_sdk.logger` for structured logging.
 - Response trimming: large payloads (>50KB) are truncated by `DraftnrunClient._trim_response`. Trimming is controllable per-tool via `ToolSpec.trim` (default `True`) and per-call via the `trim` parameter on all HTTP methods. `get_graph` and `list_components` are untrimmed.
 - When adding/removing/renaming MCP tools: update `mcp_server/README.md`, the relevant `docs://` resource in `mcp_server/docs.py`, and this rule file in the same diff.

--- a/ada_backend/routers/cron_router.py
+++ b/ada_backend/routers/cron_router.py
@@ -133,11 +133,7 @@ def delete_organization_cron_job(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
-    result = delete_cron_job_service(session, cron_id, organization_id, user_id=user.id)
-    if not result:
-        raise HTTPException(status_code=404, detail="Cron job not found")
-
-    return result
+    return delete_cron_job_service(session, cron_id, organization_id, user_id=user.id)
 
 
 @router.post("/{organization_id}/crons/{cron_id}/pause", response_model=CronJobPauseResponse)
@@ -156,11 +152,7 @@ def pause_organization_cron_job(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
-    result = pause_cron_job(session, cron_id, organization_id=organization_id, user_id=user.id)
-    if not result:
-        raise HTTPException(status_code=404, detail="Cron job not found")
-
-    return result
+    return pause_cron_job(session, cron_id, organization_id=organization_id, user_id=user.id)
 
 
 @router.post("/{organization_id}/crons/{cron_id}/resume", response_model=CronJobPauseResponse)
@@ -178,11 +170,7 @@ def resume_organization_cron_job(
     """
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
-    result = resume_cron_job(session, cron_id, organization_id=organization_id, user_id=user.id)
-    if not result:
-        raise HTTPException(status_code=404, detail="Cron job not found")
-
-    return result
+    return resume_cron_job(session, cron_id, organization_id=organization_id, user_id=user.id)
 
 
 @router.get("/{organization_id}/crons/{cron_id}/runs", response_model=CronRunListResponse)
@@ -201,10 +189,7 @@ def get_cron_job_runs(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
-    result = get_cron_runs(session, cron_id, organization_id=organization_id)
-    if not result:
-        raise HTTPException(status_code=404, detail="Cron job not found")
-    return result
+    return get_cron_runs(session, cron_id, organization_id=organization_id)
 
 
 @router.post("/{organization_id}/crons/{cron_id}/trigger", response_model=CronJobTriggerResponse, status_code=202)

--- a/ada_backend/routers/graph_router.py
+++ b/ada_backend/routers/graph_router.py
@@ -70,7 +70,10 @@ def get_project_graph(
         raise HTTPException(status_code=503, detail="Database connection failed, please retry") from e
     except ValueError as e:
         LOGGER.error(
-            "Failed to get graph for project %s and runner %s: %s", project_id, graph_runner_id, e, exc_info=True
+            "Unexpected value error while loading graph for project %s and runner %s",
+            project_id,
+            graph_runner_id,
+            exc_info=True,
         )
         raise HTTPException(
             status_code=400, detail="Failed to load graph: the graph data may be corrupted or incomplete"
@@ -104,12 +107,6 @@ def get_graph_modification_history(
             "Database connection failed for project %s and runner %s", project_id, graph_runner_id, exc_info=True
         )
         raise HTTPException(status_code=503, detail="Database connection failed, please retry") from e
-    except ValueError as e:
-        LOGGER.error(
-            "Failed to get modification history for project %s and runner %s: %s",
-            project_id, graph_runner_id, e, exc_info=True,
-        )
-        raise HTTPException(status_code=400, detail="Failed to load modification history for this graph") from e
 
 
 @router.put(
@@ -143,14 +140,6 @@ async def update_project_pipeline(
             "Database connection failed for project %s runner %s", project_id, graph_runner_id, exc_info=True
         )
         raise HTTPException(status_code=503, detail="Database connection failed, please retry") from e
-    except ValueError as e:
-        error_msg = str(e)
-        LOGGER.error(
-            "Failed to update graph for project %s runner %s: %s", project_id, graph_runner_id, e, exc_info=True
-        )
-        if "only draft versions" in error_msg.lower():
-            raise HTTPException(status_code=403, detail="Only the draft version can be modified") from e
-        raise HTTPException(status_code=400, detail="Invalid graph update request") from e
 
 
 @router.get(
@@ -216,7 +205,10 @@ def deploy_graph(
         ) from e
     except ValueError as e:
         LOGGER.error(
-            "Failed to deploy graph for project %s runner %s: %s", project_id, graph_runner_id, e, exc_info=True
+            "Unexpected value error deploying graph for project %s runner %s",
+            project_id,
+            graph_runner_id,
+            exc_info=True,
         )
         raise HTTPException(
             status_code=400,
@@ -259,7 +251,10 @@ def save_graph_version(
         raise HTTPException(status_code=503, detail="Database connection failed, please retry") from e
     except ValueError as e:
         LOGGER.error(
-            "Failed to save version for project %s runner %s: %s", project_id, graph_runner_id, e, exc_info=True
+            "Unexpected value error saving version for project %s runner %s",
+            project_id,
+            graph_runner_id,
+            exc_info=True,
         )
         raise HTTPException(
             status_code=400,
@@ -297,7 +292,10 @@ def load_copy_graph_runner(
         )
     except ValueError as e:
         LOGGER.error(
-            "Failed to copy graph for project %s runner %s: %s", project_id, graph_runner_id, e, exc_info=True
+            "Unexpected value error copying graph for project %s runner %s",
+            project_id,
+            graph_runner_id,
+            exc_info=True,
         )
         raise HTTPException(
             status_code=400,
@@ -363,8 +361,10 @@ def load_version_as_draft(
         )
     except ValueError as e:
         LOGGER.error(
-            "Failed to load version as draft for project %s runner %s: %s",
-            project_id, graph_runner_id, e, exc_info=True,
+            "Unexpected value error loading version as draft for project %s runner %s",
+            project_id,
+            graph_runner_id,
+            exc_info=True,
         )
         raise HTTPException(
             status_code=400,

--- a/ada_backend/routers/graph_router_v2.py
+++ b/ada_backend/routers/graph_router_v2.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Annotated
 from uuid import UUID
 
@@ -21,7 +20,6 @@ from ada_backend.services.graph.get_graph_service import get_graph_service
 from ada_backend.services.graph.graph_v2_mapper_service import graph_get_to_graph_v2_response
 
 router = APIRouter(prefix="/v2/projects/{project_id}/graph", tags=["Graph"])
-LOGGER = logging.getLogger(__name__)
 
 
 @router.get("/{graph_runner_id}", summary="Get Project Graph V2", response_model=GraphGetV2Response)
@@ -35,13 +33,9 @@ def get_project_graph_v2(
 ) -> GraphGetV2Response:
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
-    try:
-        # TODO: replace get_graph_service (deprecated) with its successor
-        graph = get_graph_service(session, project_id, graph_runner_id)
-        return graph_get_to_graph_v2_response(graph)
-    except ValueError as e:
-        LOGGER.warning("Invalid v2 graph payload for runner %s: %s", graph_runner_id, e)
-        raise HTTPException(status_code=400, detail="Invalid v2 graph payload")
+    # TODO: replace get_graph_service (deprecated) with its successor
+    graph = get_graph_service(session, project_id, graph_runner_id)
+    return graph_get_to_graph_v2_response(graph)
 
 
 @router.post(
@@ -61,11 +55,7 @@ def create_component_v2(
 ) -> ComponentV2Response:
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
-    try:
-        return graph_mutation_helpers.create_component_v2(session, graph_runner_id, project_id, user.id, payload)
-    except ValueError as e:
-        LOGGER.warning("Invalid component payload for runner %s: %s", graph_runner_id, e)
-        raise HTTPException(status_code=400, detail="Invalid component payload")
+    return graph_mutation_helpers.create_component_v2(session, graph_runner_id, project_id, user.id, payload)
 
 
 @router.put(
@@ -85,13 +75,9 @@ def update_component_v2(
 ) -> ComponentV2Response:
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
-    try:
-        return graph_mutation_helpers.update_component_v2(
-            session, graph_runner_id, project_id, instance_id, user.id, payload
-        )
-    except ValueError as e:
-        LOGGER.warning("Invalid component update payload for instance %s: %s", instance_id, e)
-        raise HTTPException(status_code=400, detail="Invalid component update payload")
+    return graph_mutation_helpers.update_component_v2(
+        session, graph_runner_id, project_id, instance_id, user.id, payload
+    )
 
 
 @router.delete(
@@ -110,11 +96,7 @@ def delete_component_v2(
 ):
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
-    try:
-        graph_mutation_helpers.delete_component_v2(session, graph_runner_id, project_id, instance_id, user.id)
-    except ValueError as e:
-        LOGGER.warning("Invalid component deletion request for instance %s: %s", instance_id, e)
-        raise HTTPException(status_code=400, detail="Invalid component deletion request")
+    graph_mutation_helpers.delete_component_v2(session, graph_runner_id, project_id, instance_id, user.id)
 
 
 @router.put(
@@ -133,8 +115,4 @@ def update_graph_topology_v2(
 ) -> GraphUpdateResponse:
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
-    try:
-        return graph_mutation_helpers.save_graph_topology_v2(session, graph_runner_id, project_id, user.id, payload)
-    except ValueError as e:
-        LOGGER.warning("Invalid graph topology payload for runner %s: %s", graph_runner_id, e)
-        raise HTTPException(status_code=400, detail="Invalid graph topology payload")
+    return graph_mutation_helpers.save_graph_topology_v2(session, graph_runner_id, project_id, user.id, payload)

--- a/ada_backend/routers/llm_judges_router.py
+++ b/ada_backend/routers/llm_judges_router.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Annotated, List
 from uuid import UUID
 
@@ -34,7 +33,6 @@ from ada_backend.services.qa.llm_judges_service import (
 )
 
 router = APIRouter(tags=["QA Evaluation"])
-LOGGER = logging.getLogger(__name__)
 
 
 @router.get(
@@ -50,11 +48,7 @@ def get_llm_judges_by_organization_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> List[LLMJudgeResponse]:
-    try:
-        return get_llm_judges_by_organization_service(session=session, organization_id=organization_id)
-    except Exception as e:
-        LOGGER.error(f"Failed to get LLM judges for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return get_llm_judges_by_organization_service(session=session, organization_id=organization_id)
 
 
 @router.get(
@@ -83,13 +77,7 @@ def create_llm_judge_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> LLMJudgeResponse:
-    try:
-        return create_llm_judge_service(session=session, organization_id=organization_id, judge_data=judge_data)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to create LLM judge for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return create_llm_judge_service(session=session, organization_id=organization_id, judge_data=judge_data)
 
 
 @router.patch(
@@ -107,20 +95,12 @@ def update_llm_judge_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> LLMJudgeResponse:
-    try:
-        return update_llm_judge_service(
-            session=session,
-            organization_id=organization_id,
-            judge_id=judge_id,
-            judge_data=judge_data,
-        )
-    except LLMJudgeNotFound as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to update LLM judge {judge_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return update_llm_judge_service(
+        session=session,
+        organization_id=organization_id,
+        judge_id=judge_id,
+        judge_data=judge_data,
+    )
 
 
 @router.delete(
@@ -137,14 +117,8 @@ def delete_llm_judges_endpoint(
     session: Session = Depends(get_db),
     judge_ids: List[UUID] = Body(...),
 ):
-    try:
-        delete_llm_judges_service(session=session, organization_id=organization_id, judge_ids=judge_ids)
-        return None
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to delete LLM judges for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    delete_llm_judges_service(session=session, organization_id=organization_id, judge_ids=judge_ids)
+    return None
 
 
 @router.put(
@@ -162,15 +136,7 @@ def set_judge_projects_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> LLMJudgeResponse:
-    try:
-        return set_judge_projects_service(session, organization_id, judge_id, body.project_ids)
-    except (LLMJudgeNotFound, ProjectNotFound) as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to set judge projects: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return set_judge_projects_service(session, organization_id, judge_id, body.project_ids)
 
 
 # ── Deprecated project-scoped endpoints (use org-scoped equivalents) ──────────
@@ -190,11 +156,7 @@ def get_llm_judges_by_project_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> List[LLMJudgeResponse]:
-    try:
-        return get_llm_judges_by_project_service(session=session, project_id=project_id)
-    except Exception as e:
-        LOGGER.error(f"Failed to get LLM judges for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return get_llm_judges_by_project_service(session=session, project_id=project_id)
 
 
 @router.post(
@@ -225,8 +187,6 @@ def create_llm_judge_by_project_endpoint(
         )
     except ProjectNotFound as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail="Bad request") from e
 
 
 @router.patch(
@@ -255,11 +215,6 @@ def update_llm_judge_by_project_endpoint(
         )
     except (ProjectNotFound, LLMJudgeNotFound) as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to update LLM judge {judge_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.delete(
@@ -283,5 +238,3 @@ def delete_llm_judges_by_project_endpoint(
         return None
     except ProjectNotFound as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail="Bad request") from e

--- a/ada_backend/routers/project_router.py
+++ b/ada_backend/routers/project_router.py
@@ -271,8 +271,8 @@ async def run_env_agent_endpoint(
     except RunError as e:
         raise HTTPException(status_code=400, detail=f"Agent run failed for project {project_id}") from e
     except ValueError as e:
-        LOGGER.error(f"Failed to run agent for project {project_id} in environment {env}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail=f"Error: {str(e)}") from e
+        LOGGER.error(f"Failed to run agent for project {project_id} in environment {env}: %s", e, exc_info=True)
+        raise HTTPException(status_code=400, detail="Invalid request parameters") from e
 
 
 @router.get("/{project_id}/charts", response_model=ChartsResponse, tags=["Metrics"], deprecated=True)
@@ -383,10 +383,13 @@ async def chat(
         raise HTTPException(status_code=400, detail=f"Agent run failed for project {project_id}") from e
     except ValueError as e:
         LOGGER.error(
-            f"Failed to run agent chat for project {project_id}, graph_runner {graph_runner_id}: {str(e)}",
+            "Failed to run agent chat for project %s, graph_runner %s: %s",
+            project_id,
+            graph_runner_id,
+            e,
             exc_info=True,
         )
-        raise HTTPException(status_code=400, detail=f"Error: {str(e)}") from e
+        raise HTTPException(status_code=400, detail="Invalid request parameters") from e
 
 
 @router.post(
@@ -506,6 +509,6 @@ async def chat_env(
         raise HTTPException(status_code=400, detail=f"Agent run failed for project {project_id}") from e
     except ValueError as e:
         LOGGER.error(
-            f"Failed to run agent chat for project {project_id} in environment {env}: {str(e)}", exc_info=True
+            "Failed to run agent chat for project %s in environment %s: %s", project_id, env, e, exc_info=True
         )
-        raise HTTPException(status_code=400, detail=f"Error: {str(e)}") from e
+        raise HTTPException(status_code=400, detail="Invalid request parameters") from e

--- a/ada_backend/routers/project_router.py
+++ b/ada_backend/routers/project_router.py
@@ -269,10 +269,13 @@ async def run_env_agent_endpoint(
         )
         raise HTTPException(status_code=503, detail=f"Database connection error: {str(e)}") from e
     except RunError as e:
-        raise HTTPException(status_code=400, detail=f"Agent run failed for project {project_id}") from e
+        raise HTTPException(
+            status_code=400,
+            detail=f"Agent run failed for project {project_id}: {str(e)}",
+        ) from e
     except ValueError as e:
         LOGGER.error(f"Failed to run agent for project {project_id} in environment {env}: %s", e, exc_info=True)
-        raise HTTPException(status_code=400, detail="Invalid request parameters") from e
+        raise HTTPException(status_code=400, detail=f"Error: {str(e)}") from e
 
 
 @router.get("/{project_id}/charts", response_model=ChartsResponse, tags=["Metrics"], deprecated=True)
@@ -380,7 +383,10 @@ async def chat(
         )
         raise HTTPException(status_code=503, detail=f"Database connection error: {str(e)}") from e
     except RunError as e:
-        raise HTTPException(status_code=400, detail=f"Agent run failed for project {project_id}") from e
+        raise HTTPException(
+            status_code=400,
+            detail=f"Agent run failed for project {project_id}: {str(e)}",
+        ) from e
     except ValueError as e:
         LOGGER.error(
             "Failed to run agent chat for project %s, graph_runner %s: %s",
@@ -389,7 +395,7 @@ async def chat(
             e,
             exc_info=True,
         )
-        raise HTTPException(status_code=400, detail="Invalid request parameters") from e
+        raise HTTPException(status_code=400, detail=f"Error: {str(e)}") from e
 
 
 @router.post(
@@ -506,9 +512,12 @@ async def chat_env(
         )
         raise HTTPException(status_code=503, detail=f"Database connection error: {str(e)}") from e
     except RunError as e:
-        raise HTTPException(status_code=400, detail=f"Agent run failed for project {project_id}") from e
+        raise HTTPException(
+            status_code=400,
+            detail=f"Agent run failed for project {project_id}: {str(e)}",
+        ) from e
     except ValueError as e:
         LOGGER.error(
             "Failed to run agent chat for project %s in environment %s: %s", project_id, env, e, exc_info=True
         )
-        raise HTTPException(status_code=400, detail="Invalid request parameters") from e
+        raise HTTPException(status_code=400, detail=f"Error: {str(e)}") from e

--- a/ada_backend/routers/qa_evaluation_router.py
+++ b/ada_backend/routers/qa_evaluation_router.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Annotated, List
 from uuid import UUID
 
@@ -21,7 +20,6 @@ from ada_backend.services.qa.qa_evaluation_service import (
 )
 
 router = APIRouter(tags=["QA Evaluation"])
-LOGGER = logging.getLogger(__name__)
 
 
 @router.get(
@@ -61,19 +59,12 @@ async def run_judge_evaluation_endpoint(
 ) -> JudgeEvaluationResponse:
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
-
-    try:
-        return await run_judge_evaluation_service(
-            session=session,
-            project_id=project_id,
-            judge_id=judge_id,
-            version_output_id=version_output_id,
-        )
-    except ValueError as e:
-        LOGGER.error(
-            f"Failed to run judge evaluation for judge {judge_id} in project {project_id}: {str(e)}", exc_info=True
-        )
-        raise HTTPException(status_code=400, detail="Bad request") from e
+    return await run_judge_evaluation_service(
+        session=session,
+        project_id=project_id,
+        judge_id=judge_id,
+        version_output_id=version_output_id,
+    )
 
 
 @router.delete(
@@ -92,10 +83,5 @@ def delete_judge_evaluations_endpoint(
 ):
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
-
-    try:
-        delete_judge_evaluations_service(session=session, evaluation_ids=evaluation_ids)
-        return None
-    except ValueError as e:
-        LOGGER.error(f"Failed to delete judge evaluations for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
+    delete_judge_evaluations_service(session=session, evaluation_ids=evaluation_ids)
+    return None

--- a/ada_backend/routers/quality_assurance_router.py
+++ b/ada_backend/routers/quality_assurance_router.py
@@ -44,9 +44,6 @@ from ada_backend.schemas.qa_metadata_schema import QAColumnResponse
 from ada_backend.services.errors import (
     GraphNotBoundToProjectError,
     ProjectNotFound,
-    QADatasetNotFound,
-    QAInputValidationError,
-    QASessionNotFound,
 )
 from ada_backend.services.qa.qa_error import (
     CSVEmptyFileError,

--- a/ada_backend/routers/quality_assurance_router.py
+++ b/ada_backend/routers/quality_assurance_router.py
@@ -41,7 +41,13 @@ from ada_backend.schemas.input_groundtruth_schema import (
     QASessionResponseSchema,
 )
 from ada_backend.schemas.qa_metadata_schema import QAColumnResponse
-from ada_backend.services.errors import GraphNotBoundToProjectError, ProjectNotFound
+from ada_backend.services.errors import (
+    GraphNotBoundToProjectError,
+    ProjectNotFound,
+    QADatasetNotFound,
+    QAInputValidationError,
+    QASessionNotFound,
+)
 from ada_backend.services.qa.qa_error import (
     CSVEmptyFileError,
     CSVExportError,
@@ -118,14 +124,7 @@ def get_datasets_by_organization_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> List[DatasetResponse]:
-    try:
-        return get_datasets_by_organization_service(session, organization_id)
-    except ValueError as e:
-        LOGGER.error(f"Failed to get datasets for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to get datasets for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return get_datasets_by_organization_service(session, organization_id)
 
 
 @router.post(
@@ -143,14 +142,7 @@ def create_dataset_by_organization_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> DatasetListResponse:
-    try:
-        return create_datasets_service(session, organization_id, dataset_data)
-    except ValueError as e:
-        LOGGER.error(f"Failed to create datasets for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to create datasets for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return create_datasets_service(session, organization_id, dataset_data)
 
 
 @router.patch(
@@ -169,14 +161,7 @@ def update_dataset_by_organization_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> DatasetResponse:
-    try:
-        return update_dataset_service(session, organization_id, dataset_id, dataset_name)
-    except ValueError as e:
-        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return update_dataset_service(session, organization_id, dataset_id, dataset_name)
 
 
 @router.delete(
@@ -193,15 +178,8 @@ def delete_dataset_by_organization_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> dict:
-    try:
-        deleted_count = delete_datasets_service(session, organization_id, delete_data)
-        return {"message": f"Deleted {deleted_count} datasets successfully"}
-    except ValueError as e:
-        LOGGER.error(f"Failed to delete datasets for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to delete datasets for organization {organization_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    deleted_count = delete_datasets_service(session, organization_id, delete_data)
+    return {"message": f"Deleted {deleted_count} datasets successfully"}
 
 
 @router.put(
@@ -220,13 +198,7 @@ def set_dataset_projects_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> DatasetResponse:
-    try:
-        return set_dataset_projects_service(session, organization_id, dataset_id, body.project_ids)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        LOGGER.error(f"Failed to set dataset projects: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return set_dataset_projects_service(session, organization_id, dataset_id, body.project_ids)
 
 
 # ── Organization-scoped QA Metadata (Custom Columns) ────────────────
@@ -658,11 +630,6 @@ async def run_qa_endpoint(
         raise HTTPException(status_code=404, detail=str(e)) from e
     except GraphNotBoundToProjectError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to run QA on dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.post(
@@ -686,8 +653,6 @@ async def run_qa_async_endpoint(
         validate_qa_run_request(session, project_id, dataset_id, run_request)
     except QADatasetNotInProjectError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
 
     qa_session = create_qa_session_service(
         session,
@@ -746,10 +711,7 @@ def get_qa_session_endpoint(
     ],
     session: Session = Depends(get_db),
 ) -> QASessionResponseSchema:
-    try:
-        return get_qa_session_service(session, qa_session_id, project_id)
-    except ValueError:
-        raise HTTPException(status_code=404, detail="QA session not found")
+    return get_qa_session_service(session, qa_session_id, project_id)
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -782,14 +744,7 @@ def get_datasets_by_project_endpoint(
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
 
-    try:
-        return get_datasets_by_project_service(session, project_id)
-    except ValueError as e:
-        LOGGER.error(f"Failed to get datasets for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to get datasets for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return get_datasets_by_project_service(session, project_id)
 
 
 @router.post(
@@ -833,12 +788,6 @@ def create_dataset_endpoint(
         return response
     except ProjectNotFound as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except ValueError as e:
-        LOGGER.error(f"Failed to create datasets for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to create datasets for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.patch(
@@ -879,12 +828,6 @@ def update_dataset_endpoint(
             status_code=403,
             detail=f"Dataset {dataset_id} is not associated with project {project_id}",
         )
-    except ValueError as e:
-        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to update dataset {dataset_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 @router.delete(
@@ -925,12 +868,6 @@ def delete_dataset_endpoint(
             status_code=403,
             detail=f"Dataset {e.dataset_id} is not associated with project {project_id}",
         ) from e
-    except ValueError as e:
-        LOGGER.error(f"Failed to delete datasets for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Bad request") from e
-    except Exception as e:
-        LOGGER.error(f"Failed to delete datasets for project {project_id}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
 # ── Deprecated custom columns ────────────────────────────────────────

--- a/ada_backend/services/agent_builder_service.py
+++ b/ada_backend/services/agent_builder_service.py
@@ -23,7 +23,7 @@ from ada_backend.repositories.integration_repository import (
 )
 from ada_backend.repositories.organization_repository import get_organization_secrets_from_project_id
 from ada_backend.repositories.tool_port_configuration_repository import get_tool_port_configurations
-from ada_backend.services.errors import MissingDataSourceError, MissingIntegrationError
+from ada_backend.services.errors import ComponentInstanceNotFound, MissingDataSourceError, MissingIntegrationError
 from ada_backend.services.registry import FACTORY_REGISTRY
 from ada_backend.services.tool_description_generator import generate_tool_description
 from ada_backend.utils.secret_resolver import replace_secret_placeholders
@@ -201,7 +201,7 @@ async def instantiate_component(
     component_instance = get_component_instance_by_id(session, component_instance_id)
     component_name = get_component_name_from_instance(session, component_instance_id)
     if not component_instance:
-        raise ValueError(f"Component instance {component_instance_id} not found.")
+        raise ComponentInstanceNotFound(component_instance_id)
     component_version_id = component_instance.component_version_id
     LOGGER.debug(f"Init instantiation for component {component_name} version: {component_version_id}\n")
 

--- a/ada_backend/services/agents_service.py
+++ b/ada_backend/services/agents_service.py
@@ -26,7 +26,7 @@ from ada_backend.schemas.parameter_schema import ParameterKind, PipelineParamete
 from ada_backend.schemas.pipeline.base import ComponentInstanceSchema, ComponentRelationshipSchema
 from ada_backend.schemas.pipeline.graph_schema import GraphUpdateResponse, GraphUpdateSchema
 from ada_backend.schemas.project_schema import GraphRunnerEnvDTO, ProjectWithGraphRunnersSchema
-from ada_backend.services.errors import InvalidAgentTemplate, ProjectNotFound
+from ada_backend.services.errors import InvalidAgentTemplate, ProjectNotFound, ProjectTypeMismatchError
 from ada_backend.services.graph.get_graph_service import get_graph_service
 from ada_backend.services.graph.update_graph_service import update_graph_with_history_service
 from ada_backend.services.pipeline.update_pipeline_service import create_or_update_component_instance
@@ -98,10 +98,11 @@ def get_agent_by_id_service(session: Session, agent_id: UUID, graph_runner_id: U
     if not agent_project:
         raise ProjectNotFound(agent_id)
     if agent_project.type != db.ProjectType.AGENT:
-        raise ValueError(
-            f"Project {agent_id} is of type '{agent_project.type}', not 'agent'. "
-            f"configure_agent only works for AGENT projects. For WORKFLOW projects, "
-            f"use update_graph to modify component parameters directly."
+        raise ProjectTypeMismatchError(
+            project_id=agent_id,
+            actual_type=getattr(agent_project.type, "value", str(agent_project.type)),
+            operation="configure_agent",
+            workflow_hint="use update_graph to modify component parameters directly.",
         )
 
     graph_data = get_graph_service(session, project_id=agent_id, graph_runner_id=graph_runner_id)
@@ -275,10 +276,11 @@ async def update_agent_service(
     if not agent_project:
         raise ProjectNotFound(agent_id)
     if agent_project.type != db.ProjectType.AGENT:
-        raise ValueError(
-            f"Project {agent_id} is of type '{agent_project.type}', not 'agent'. "
-            f"update_agent only works for AGENT projects. For WORKFLOW projects, "
-            f"use update_graph to modify the graph directly."
+        raise ProjectTypeMismatchError(
+            project_id=agent_id,
+            actual_type=getattr(agent_project.type, "value", str(agent_project.type)),
+            operation="update_agent",
+            workflow_hint="use update_graph to modify the graph directly.",
         )
 
     ai_agent_component = build_ai_agent_component(

--- a/ada_backend/services/cron/errors.py
+++ b/ada_backend/services/cron/errors.py
@@ -9,12 +9,24 @@ class CronValidationError(CronServiceError):
     """Raised when user payload or parameters are invalid."""
     status_code = 400
 
+    def __init__(self, message: str):
+        super().__init__(message)
+
 
 class CronJobNotFound(CronServiceError):
     """Raised when a cron job cannot be found."""
     status_code = 404
 
+    def __init__(self, cron_job_id):
+        self.cron_job_id = cron_job_id
+        super().__init__(f"Cron job {cron_job_id} not found")
+
 
 class CronJobAccessDenied(CronServiceError):
     """Raised when accessing a cron job from a different organization."""
     status_code = 403
+
+    def __init__(self, cron_job_id, organization_id):
+        self.cron_job_id = cron_job_id
+        self.organization_id = organization_id
+        super().__init__(f"Cron job {cron_job_id} does not belong to organization {organization_id}")

--- a/ada_backend/services/cron/errors.py
+++ b/ada_backend/services/cron/errors.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from ada_backend.services.errors import ServiceError
 
 
@@ -17,8 +19,8 @@ class CronJobNotFound(CronServiceError):
     """Raised when a cron job cannot be found."""
     status_code = 404
 
-    def __init__(self, cron_job_id):
-        self.cron_job_id = cron_job_id
+    def __init__(self, cron_job_id: UUID):
+        self.cron_job_id: UUID = cron_job_id
         super().__init__(f"Cron job {cron_job_id} not found")
 
 
@@ -26,7 +28,7 @@ class CronJobAccessDenied(CronServiceError):
     """Raised when accessing a cron job from a different organization."""
     status_code = 403
 
-    def __init__(self, cron_job_id, organization_id):
-        self.cron_job_id = cron_job_id
-        self.organization_id = organization_id
+    def __init__(self, cron_job_id: UUID, organization_id: UUID):
+        self.cron_job_id: UUID = cron_job_id
+        self.organization_id: UUID = organization_id
         super().__init__(f"Cron job {cron_job_id} does not belong to organization {organization_id}")

--- a/ada_backend/services/cron/service.py
+++ b/ada_backend/services/cron/service.py
@@ -88,9 +88,9 @@ def _assert_cron_in_org(session: Session, cron_id: UUID, organization_id: UUID) 
     """Ensure the cron job exists and belongs to the given organization."""
     cron_job = get_cron_job(session, cron_id)
     if not cron_job:
-        raise CronJobNotFound(f"Cron job {cron_id} not found")
+        raise CronJobNotFound(cron_id)
     if cron_job.organization_id != organization_id:
-        raise CronJobAccessDenied("Access denied")
+        raise CronJobAccessDenied(cron_id, organization_id)
     return cron_job
 
 
@@ -170,10 +170,10 @@ def get_cron_job_detail(
     """Return cron details; enforce org ownership if organization_id is provided."""
     cron_job = get_cron_job(session, cron_id)
     if not cron_job:
-        raise CronJobNotFound(f"Cron job {cron_id} not found")
+        raise CronJobNotFound(cron_id)
 
     if organization_id is not None and cron_job.organization_id != organization_id:
-        raise CronJobAccessDenied("Access denied")
+        raise CronJobAccessDenied(cron_id, organization_id)
 
     if include_runs:
         runs = get_cron_runs_by_cron_id(session, cron_id, limit=10)
@@ -278,7 +278,7 @@ def update_cron_job_service(
     )
 
     if not updated_cron:
-        raise CronJobNotFound(f"Cron job {cron_id} not found")
+        raise CronJobNotFound(cron_id)
 
     LOGGER.info(f"Updated cron job {cron_id}.")
 

--- a/ada_backend/services/cron/service.py
+++ b/ada_backend/services/cron/service.py
@@ -290,7 +290,7 @@ def delete_cron_job_service(
     cron_id: UUID,
     organization_id: UUID,
     user_id: UUID | None = None,
-) -> Optional[CronJobDeleteResponse]:
+) -> CronJobDeleteResponse:
     _assert_cron_in_org(session, cron_id, organization_id)
 
     success = delete_cron_job(session, cron_id)
@@ -301,7 +301,7 @@ def delete_cron_job_service(
             track_cron_job_deleted(user_id, organization_id)
         return CronJobDeleteResponse(id=cron_id)
 
-    return None
+    raise CronJobNotFound(cron_id)
 
 
 def permanently_delete_cron_jobs_by_project_service(session: Session, project_id: UUID) -> None:
@@ -327,11 +327,11 @@ def pause_cron_job(
     cron_id: UUID,
     organization_id: UUID,
     user_id: UUID | None = None,
-) -> Optional[CronJobPauseResponse]:
+) -> CronJobPauseResponse:
     _assert_cron_in_org(session, cron_id, organization_id)
     updated_cron = update_cron_job(session, cron_id, is_enabled=False)
     if not updated_cron:
-        return None
+        raise CronJobNotFound(cron_id)
 
     if user_id:
         track_cron_job_toggled(user_id, organization_id, enabled=False)
@@ -348,11 +348,11 @@ def resume_cron_job(
     cron_id: UUID,
     organization_id: UUID,
     user_id: UUID | None = None,
-) -> Optional[CronJobPauseResponse]:
+) -> CronJobPauseResponse:
     _assert_cron_in_org(session, cron_id, organization_id)
     updated_cron = update_cron_job(session, cron_id, is_enabled=True)
     if not updated_cron:
-        return None
+        raise CronJobNotFound(cron_id)
 
     if user_id:
         track_cron_job_toggled(user_id, organization_id, enabled=True)

--- a/ada_backend/services/cron/service.py
+++ b/ada_backend/services/cron/service.py
@@ -243,7 +243,7 @@ def update_cron_job_service(
     cron_data: CronJobUpdate,
     organization_id: UUID,
     **kwargs,  # For user_id, etc.
-) -> Optional[CronJobResponse]:
+) -> CronJobResponse:
     """Update cron job fields in the database."""
     existing_cron = _assert_cron_in_org(session, cron_id, organization_id)
 

--- a/ada_backend/services/errors.py
+++ b/ada_backend/services/errors.py
@@ -164,6 +164,14 @@ class GraphValidationError(ServiceError):
         super().__init__(message)
 
 
+class ComponentVersionNotFound(ServiceError):
+    status_code = 404
+
+    def __init__(self, component_version_id: UUID):
+        self.component_version_id = component_version_id
+        super().__init__(f"Component version {component_version_id} not found")
+
+
 class ComponentInstanceNotFound(ServiceError):
     status_code = 404
 

--- a/ada_backend/services/errors.py
+++ b/ada_backend/services/errors.py
@@ -157,6 +157,21 @@ class GraphNotFound(ServiceError):
         super().__init__(f"Graph not found: {graph_id}")
 
 
+class GraphValidationError(ServiceError):
+    status_code = 400
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class ComponentInstanceNotFound(ServiceError):
+    status_code = 404
+
+    def __init__(self, component_instance_id: UUID):
+        self.component_instance_id = component_instance_id
+        super().__init__(f"Component instance {component_instance_id} not found")
+
+
 class EnvironmentNotFound(ServiceError):
     status_code = 404
 
@@ -429,6 +444,73 @@ class RunError(ServiceError):
 
     def __init__(self, message: str, trace_id: str | None = None):
         self.trace_id = trace_id
+        super().__init__(message)
+
+
+class RunInputNotFound(ServiceError):
+    status_code = 400
+
+    def __init__(self):
+        super().__init__("Run input not found for retry")
+
+
+class RunEnqueueError(ServiceError):
+    status_code = 503
+
+    def __init__(self):
+        super().__init__("Retry run could not be enqueued")
+
+
+class ProjectTypeMismatchError(ServiceError):
+    status_code = 400
+
+    def __init__(
+        self,
+        project_id: UUID,
+        actual_type: str,
+        operation: str,
+        workflow_hint: str = "use update_graph to modify component parameters directly.",
+    ):
+        self.project_id = project_id
+        self.actual_type = actual_type
+        self.operation = operation
+        self.workflow_hint = workflow_hint
+        super().__init__(
+            f"Project {project_id} is of type '{actual_type}', not 'agent'. "
+            f"{operation} only works for AGENT projects. For WORKFLOW projects, "
+            f"{workflow_hint}"
+        )
+
+
+class QASessionNotFound(ServiceError):
+    status_code = 404
+
+    def __init__(self, qa_session_id: UUID, project_id: UUID):
+        self.qa_session_id = qa_session_id
+        self.project_id = project_id
+        super().__init__(f"QA session {qa_session_id} not found in project {project_id}")
+
+
+class QAInputValidationError(ServiceError):
+    status_code = 400
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class QAOperationError(ServiceError):
+    status_code = 500
+    _safe_detail = "A QA operation failed."
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class LLMJudgeOperationError(ServiceError):
+    status_code = 500
+    _safe_detail = "An LLM judge operation failed."
+
+    def __init__(self, message: str):
         super().__init__(message)
 
 

--- a/ada_backend/services/errors.py
+++ b/ada_backend/services/errors.py
@@ -486,6 +486,15 @@ class QASessionNotFound(ServiceError):
         super().__init__(f"QA session {qa_session_id} not found in project {project_id}")
 
 
+class QADatasetNotFound(ServiceError):
+    status_code = 404
+
+    def __init__(self, dataset_id: UUID, organization_id: UUID):
+        self.dataset_id = dataset_id
+        self.organization_id = organization_id
+        super().__init__(f"Dataset {dataset_id} not found in organization {organization_id}")
+
+
 class QAInputValidationError(ServiceError):
     status_code = 400
 

--- a/ada_backend/services/errors.py
+++ b/ada_backend/services/errors.py
@@ -395,10 +395,7 @@ class NangoConnectionNotFoundError(ServiceError):
     def __init__(self, organization_id: UUID, provider: str):
         self.organization_id = organization_id
         self.provider = provider
-        super().__init__(
-            f"Connection not found in Nango for organization {organization_id}, provider {provider}. "
-            "OAuth flow may not be complete."
-        )
+        super().__init__(f"OAuth connection for provider '{provider}' is not established.")
 
 
 class NangoTokenMissingError(ServiceError):
@@ -407,9 +404,7 @@ class NangoTokenMissingError(ServiceError):
 
     def __init__(self, connection_id: UUID):
         self.connection_id = connection_id
-        super().__init__(
-            f"Access token not found in Nango credentials for connection {connection_id}",
-        )
+        super().__init__(f"OAuth token for connection {connection_id} is unavailable.")
 
 
 class VariableDefinitionNotFound(ServiceError):

--- a/ada_backend/services/graph/component_instance_v2_service.py
+++ b/ada_backend/services/graph/component_instance_v2_service.py
@@ -28,6 +28,7 @@ from ada_backend.schemas.pipeline.graph_schema import (
     ComponentCreateV2Schema,
     ComponentUpdateV2Schema,
 )
+from ada_backend.services.errors import ComponentInstanceNotFound, GraphValidationError
 from ada_backend.services.graph.delete_graph_service import delete_component_instances_from_nodes
 from ada_backend.services.pipeline.update_pipeline_service import (
     _normalize_expression_json,
@@ -154,12 +155,12 @@ def update_single_component(
 ) -> None:
     existing = get_component_instance_by_id(session, instance_id)
     if not existing:
-        raise ValueError(f"Component instance {instance_id} not found")
+        raise ComponentInstanceNotFound(instance_id)
 
     nodes = get_component_nodes(session, graph_runner_id)
     current_node = next((n for n in nodes if n.id == instance_id), None)
     if current_node is None:
-        raise ValueError(f"Component instance {instance_id} does not belong to graph {graph_runner_id}")
+        raise GraphValidationError(f"Component instance {instance_id} does not belong to graph {graph_runner_id}")
 
     label = payload.label if payload.label is not None else existing.name
     is_start_node = payload.is_start_node if payload.is_start_node is not None else current_node.is_start_node
@@ -196,7 +197,7 @@ def delete_component_from_graph(
 ) -> None:
     node_ids = {node.id for node in get_component_nodes(session, graph_runner_id)}
     if instance_id not in node_ids:
-        raise ValueError(f"Component instance {instance_id} does not belong to graph {graph_runner_id}")
+        raise GraphValidationError(f"Component instance {instance_id} does not belong to graph {graph_runner_id}")
 
     edges = get_edges(session, graph_runner_id)
     for edge in edges:

--- a/ada_backend/services/graph/deploy_graph_service.py
+++ b/ada_backend/services/graph/deploy_graph_service.py
@@ -43,10 +43,10 @@ from ada_backend.schemas.parameter_schema import PipelineParameterSchema
 from ada_backend.schemas.pipeline.base import ComponentInstanceSchema
 from ada_backend.schemas.pipeline.graph_schema import GraphDeployResponse, GraphSaveVersionResponse
 from ada_backend.services.errors import (
-    GraphValidationError,
     GraphNotBoundToProjectError,
     GraphNotFound,
     GraphRunnerAlreadyInEnvironmentError,
+    GraphValidationError,
     GraphVersionSavingFromNonDraftError,
 )
 from ada_backend.services.field_expression_remap_service import remap_field_expressions_for_cloning

--- a/ada_backend/services/graph/deploy_graph_service.py
+++ b/ada_backend/services/graph/deploy_graph_service.py
@@ -43,6 +43,7 @@ from ada_backend.schemas.parameter_schema import PipelineParameterSchema
 from ada_backend.schemas.pipeline.base import ComponentInstanceSchema
 from ada_backend.schemas.pipeline.graph_schema import GraphDeployResponse, GraphSaveVersionResponse
 from ada_backend.services.errors import (
+    GraphValidationError,
     GraphNotBoundToProjectError,
     GraphNotFound,
     GraphRunnerAlreadyInEnvironmentError,
@@ -159,17 +160,17 @@ def clone_graph_runner(
             relation.parent_component_instance_id in ids_map.keys()
             and relation.child_component_instance_id in ids_map.keys()
         ):
-            raise ValueError("Invalid relationship: component instance not found")
+            raise GraphValidationError("Invalid relationship: component instance not found")
 
         # Get parameter definition ID from name
         parent = get_component_instance_by_id(session, ids_map[relation.parent_component_instance_id])
         if not parent:
-            raise ValueError("Invalid relationship: parent component instance not found")
+            raise GraphValidationError("Invalid relationship: parent component instance not found")
         # TODO: Refactor to repository function that takes name and component_id or with dictionary for faster lookup
         param_defs = get_component_parameter_definition_by_component_version(session, parent.component_version_id)
         param_def = next((p for p in param_defs if p.name == relation.parameter_name), None)
         if not param_def:
-            raise ValueError(
+            raise GraphValidationError(
                 f"Parameter '{relation.parameter_name}' not found in "
                 f"component definitions for component '{parent.component_version_id}'"
             )

--- a/ada_backend/services/graph/graph_topology_v2_service.py
+++ b/ada_backend/services/graph/graph_topology_v2_service.py
@@ -22,7 +22,7 @@ from ada_backend.schemas.pipeline.graph_schema import (
     GraphMapRelationshipSchema,
     GraphTopologyNodeSchema,
 )
-from ada_backend.services.errors import GraphConflictError
+from ada_backend.services.errors import ComponentInstanceNotFound, GraphConflictError, GraphValidationError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ def sync_graph_topology(
     payload_node_ids = {node.instance_id for node in nodes}
     missing = payload_node_ids - existing_node_ids
     if missing:
-        raise ValueError(f"Nodes referenced in topology do not exist in graph: {missing}")
+        raise GraphValidationError(f"Nodes referenced in topology do not exist in graph: {missing}")
 
     for node in nodes:
         upsert_component_node(
@@ -63,7 +63,7 @@ def sync_graph_topology(
         destination = _resolve_edge_ref(edge.to_node, payload_node_ids)
 
         if graph_runner_exists(session, destination) or graph_runner_exists(session, origin):
-            raise ValueError("Nested graphs are not supported")
+            raise GraphValidationError("Nested graphs are not supported")
 
         edge_id = edge.id or uuid4()
         new_edge_ids.add(edge_id)
@@ -85,9 +85,9 @@ def sync_graph_topology(
 def _resolve_edge_ref(ref: GraphMapNodeRefSchema, valid_ids: set[UUID]) -> UUID:
     if ref.id:
         if ref.id not in valid_ids:
-            raise ValueError(f"Edge references unknown node id '{ref.id}'")
+            raise GraphValidationError(f"Edge references unknown node id '{ref.id}'")
         return ref.id
-    raise ValueError("Edge node references must use 'id' in topology save")
+    raise GraphValidationError("Edge node references must use 'id' in topology save")
 
 
 def _sync_relationships(
@@ -101,14 +101,14 @@ def _sync_relationships(
 
         parent = get_component_instance_by_id(session, parent_id)
         if not parent:
-            raise ValueError(f"Relationship parent component instance {parent_id} not found")
+            raise ComponentInstanceNotFound(parent_id)
 
         param_defs = (
             get_component_parameter_definition_by_component_version(session, parent.component_version_id) or []
         )
         param_def = next((p for p in param_defs if p.name == relation.parameter_name), None)
         if not param_def:
-            raise ValueError(
+            raise GraphValidationError(
                 f"Parameter '{relation.parameter_name}' not found in "
                 f"component definitions for component version '{parent.component_version_id}'"
             )

--- a/ada_backend/services/graph/graph_v2_mapper_service.py
+++ b/ada_backend/services/graph/graph_v2_mapper_service.py
@@ -13,6 +13,7 @@ from ada_backend.schemas.pipeline.graph_schema import (
     GraphSaveV2Schema,
     GraphUpdateSchema,
 )
+from ada_backend.services.errors import GraphValidationError
 
 
 def _node_ref_to_instance_id(
@@ -22,12 +23,12 @@ def _node_ref_to_instance_id(
 ) -> UUID:
     if ref.id:
         if ref.id not in known_instance_ids:
-            raise ValueError(f"Referenced id '{ref.id}' is not part of the current graph payload")
+            raise GraphValidationError(f"Referenced id '{ref.id}' is not part of the current graph payload")
         return ref.id
     if not ref.file_key:
-        raise ValueError("Node reference must include either 'id' or 'file_key'")
+        raise GraphValidationError("Node reference must include either 'id' or 'file_key'")
     if ref.file_key not in file_key_to_instance_id:
-        raise ValueError(f"Unknown file_key '{ref.file_key}' in graph map reference")
+        raise GraphValidationError(f"Unknown file_key '{ref.file_key}' in graph map reference")
     return file_key_to_instance_id[ref.file_key]
 
 
@@ -40,7 +41,7 @@ def _resolve_expression_file_keys(expr: Any, file_key_to_instance_id: dict[str, 
     if expr.get("type") == "ref" and "file_key" in expr and "instance" not in expr:
         fk = expr["file_key"]
         if fk not in file_key_to_instance_id:
-            raise ValueError(f"Unknown file_key '{fk}' in field expression ref")
+            raise GraphValidationError(f"Unknown file_key '{fk}' in field expression ref")
         resolved = {k: v for k, v in expr.items() if k != "file_key"}
         resolved["instance"] = str(file_key_to_instance_id[fk])
         return resolved
@@ -77,7 +78,7 @@ def _resolve_input_port_file_keys(
 def graph_save_v2_to_graph_update(payload: GraphSaveV2Schema) -> GraphUpdateSchema:
     component_by_file_key: dict[str, GraphComponentFileSchema] = {comp.file_key: comp for comp in payload.components}
     if len(component_by_file_key) != len(payload.components):
-        raise ValueError("Duplicate component file_key in components payload")
+        raise GraphValidationError("Duplicate component file_key in components payload")
 
     file_key_to_instance_id: dict[str, UUID] = {}
     instance_ids: set[UUID] = set()
@@ -85,14 +86,14 @@ def graph_save_v2_to_graph_update(payload: GraphSaveV2Schema) -> GraphUpdateSche
     node_component_pairs: list[tuple] = []
     for node in payload.graph_map.nodes:
         if not node.file_key:
-            raise ValueError("Each node in graph_map must have a file_key when saving")
+            raise GraphValidationError("Each node in graph_map must have a file_key when saving")
         component_file = component_by_file_key.get(node.file_key)
         if component_file is None:
-            raise ValueError(f"Missing component file for node file_key '{node.file_key}'")
+            raise GraphValidationError(f"Missing component file for node file_key '{node.file_key}'")
 
         resolved_id = node.instance_id or component_file.id or uuid4()
         if node.file_key in file_key_to_instance_id:
-            raise ValueError(
+            raise GraphValidationError(
                 f"Duplicate file_key '{node.file_key}' in graph_map.nodes: "
                 f"instance ids {file_key_to_instance_id[node.file_key]} and {resolved_id}"
             )

--- a/ada_backend/services/graph/load_copy_graph_service.py
+++ b/ada_backend/services/graph/load_copy_graph_service.py
@@ -6,6 +6,7 @@ from ada_backend.schemas.parameter_schema import ParameterKind
 from ada_backend.schemas.pipeline.base import ComponentRelationshipSchema
 from ada_backend.schemas.pipeline.get_pipeline_schema import ComponentInstanceReadSchema
 from ada_backend.schemas.pipeline.graph_schema import EdgeSchema, GraphLoadResponse
+from ada_backend.services.errors import ComponentInstanceNotFound, GraphValidationError
 from ada_backend.services.field_expression_remap_service import (
     remap_instance_ids_in_expression,
 )
@@ -25,7 +26,7 @@ def instanciate_copy_component_instance(
         is_start_node=is_start_node,
     )
     if not component_instance_to_copy:
-        raise ValueError("Component instance not found")
+        raise ComponentInstanceNotFound(component_instance_id_to_copy)
     return component_instance_to_copy.model_copy(update={"id": uuid4(), "field_expressions": []})
 
 
@@ -41,7 +42,7 @@ def load_copy_graph_service(
     for component_instance_to_copy in graph_get_response.component_instances:
         source_id = component_instance_to_copy.id
         if source_id is None:
-            raise ValueError("Component instance missing id in GET response")
+            raise GraphValidationError("Component instance missing id in GET response")
         component_instance = component_instance_to_copy.model_copy(update={"id": uuid4(), "field_expressions": []})
         component_instance_map[source_id] = component_instance
 
@@ -51,7 +52,7 @@ def load_copy_graph_service(
         for source_id in source_instance_ids:
             target_id = component_instance_map[source_id].id
             if target_id is None:
-                raise ValueError("Target component instance missing id during load-copy")
+                raise GraphValidationError("Target component instance missing id during load-copy")
             id_mapping[source_id] = target_id
 
         id_mapping_str: dict[str, str] = {str(src): str(dst) for src, dst in id_mapping.items()}
@@ -82,12 +83,12 @@ def load_copy_graph_service(
             old_relation.parent_component_instance_id in component_instance_map.keys()
             and old_relation.child_component_instance_id in component_instance_map.keys()
         ):
-            raise ValueError("Invalid relationship: component instance not found")
+            raise GraphValidationError("Invalid relationship: component instance not found")
 
         parent_new_id = component_instance_map[old_relation.parent_component_instance_id].id
         child_new_id = component_instance_map[old_relation.child_component_instance_id].id
         if parent_new_id is None or child_new_id is None:
-            raise ValueError("New relationship endpoint missing id during load-copy")
+            raise GraphValidationError("New relationship endpoint missing id during load-copy")
         load_copy_relationships.append(
             ComponentRelationshipSchema(
                 parent_component_instance_id=parent_new_id,
@@ -102,7 +103,7 @@ def load_copy_graph_service(
         origin_new_id = component_instance_map[edge.origin].id
         destination_new_id = component_instance_map[edge.destination].id
         if origin_new_id is None or destination_new_id is None:
-            raise ValueError("New edge endpoint missing id during load-copy")
+            raise GraphValidationError("New edge endpoint missing id during load-copy")
         load_copy_edges.append(
             EdgeSchema(
                 id=uuid4(),  # Generate a new UUID for the edge

--- a/ada_backend/services/graph/update_graph_service.py
+++ b/ada_backend/services/graph/update_graph_service.py
@@ -137,7 +137,7 @@ def validate_graph_is_draft(session: Session, graph_runner_id: UUID) -> None:
 
     Raises:
         GraphNotBoundToProjectError: If the graph runner is not bound to any project
-        ValueError: If the graph runner is not in draft mode
+        GraphValidationError: If the graph runner is not in draft mode
     """
     env_relationship = get_env_relationship_by_graph_runner_id(session, graph_runner_id)
     if not env_relationship:
@@ -280,7 +280,8 @@ async def update_graph_service(
             if kind == ParameterKind.INPUT:
                 if not instance.id:
                     raise GraphValidationError(
-                        f"Component instance ID is required for input parameters. Instance: {instance}, param: {param}"
+                        f"Component instance '{instance.name}' is missing an ID, "
+                        f"which is required to set input parameter '{param.name}'."
                     )
                 input_params_by_instance[instance.id].append(param)
             else:
@@ -424,7 +425,8 @@ async def update_graph_service(
         for param in input_params_by_instance.get(instance.id, []):
             if not instance.id:
                 raise GraphValidationError(
-                    f"Component instance ID is required for input parameters. Instance: {instance}, param: {param}"
+                    f"Component instance '{instance.name}' is missing an ID, "
+                    f"which is required to set input parameter '{param.name}'."
                 )
             if instance.id not in instance_ids:
                 raise GraphValidationError(

--- a/ada_backend/services/graph/update_graph_service.py
+++ b/ada_backend/services/graph/update_graph_service.py
@@ -54,7 +54,12 @@ from ada_backend.schemas.pipeline.graph_schema import (
     GraphUpdateSchema,
 )
 from ada_backend.services.agent_runner_service import get_agent_for_project
-from ada_backend.services.errors import GraphConflictError, GraphNotBoundToProjectError
+from ada_backend.services.errors import (
+    ComponentInstanceNotFound,
+    GraphConflictError,
+    GraphNotBoundToProjectError,
+    GraphValidationError,
+)
 from ada_backend.services.graph.delete_graph_service import delete_component_instances_from_nodes
 from ada_backend.services.graph.output_port_instance_sync import sync_output_port_instances_from_schema
 from ada_backend.services.graph.playground_utils import extract_playground_configuration
@@ -105,7 +110,7 @@ def resolve_component_version_id_from_instance_id(session: Session, instance_id:
     """Resolve component version ID from a component instance ID"""
     instance = get_component_instance_by_id(session, instance_id)
     if not instance:
-        raise ValueError(f"Component instance {instance_id} not found")
+        raise ComponentInstanceNotFound(instance_id)
     return instance.component_version_id
 
 
@@ -115,14 +120,14 @@ def validate_port_definition_types(session: Session, source_port_def_id: UUID, t
     target_port = get_port_definition_by_id(session, target_port_def_id)
 
     if not source_port:
-        raise ValueError(f"Source port definition {source_port_def_id} not found")
+        raise GraphValidationError(f"Source port definition {source_port_def_id} not found")
     if not target_port:
-        raise ValueError(f"Target port definition {target_port_def_id} not found")
+        raise GraphValidationError(f"Target port definition {target_port_def_id} not found")
 
     if source_port.port_type != db.PortType.OUTPUT:
-        raise ValueError(f"Source port must be OUTPUT type, got {source_port.port_type}")
+        raise GraphValidationError(f"Source port must be OUTPUT type, got {source_port.port_type}")
     if target_port.port_type != db.PortType.INPUT:
-        raise ValueError(f"Target port must be INPUT type, got {target_port.port_type}")
+        raise GraphValidationError(f"Target port must be INPUT type, got {target_port.port_type}")
 
 
 def validate_graph_is_draft(session: Session, graph_runner_id: UUID) -> None:
@@ -141,7 +146,7 @@ def validate_graph_is_draft(session: Session, graph_runner_id: UUID) -> None:
     # Get the graph runner to check tag_version
     graph_runner = session.query(db.GraphRunner).filter(db.GraphRunner.id == graph_runner_id).first()
     if not graph_runner:
-        raise ValueError(f"Graph runner {graph_runner_id} not found")
+        raise GraphValidationError(f"Graph runner {graph_runner_id} not found")
 
     # Check if this is the draft version (env='draft' AND tag_version=null)
     is_draft = env_relationship.environment == EnvType.DRAFT and graph_runner.tag_version is None
@@ -149,7 +154,7 @@ def validate_graph_is_draft(session: Session, graph_runner_id: UUID) -> None:
     if not is_draft:
         env_name = env_relationship.environment.value if env_relationship.environment else None
         tag = graph_runner.tag_version or None
-        raise ValueError(
+        raise GraphValidationError(
             f"Cannot modify graph runner {graph_runner_id}: only draft versions"
             "(env='draft' AND tag_version=null) can be modified. "
             f"Current state: env='{env_name}', tag_version='{tag}'. "
@@ -274,7 +279,7 @@ async def update_graph_service(
             kind = getattr(param, "kind", ParameterKind.PARAMETER)
             if kind == ParameterKind.INPUT:
                 if not instance.id:
-                    raise ValueError(
+                    raise GraphValidationError(
                         f"Component instance ID is required for input parameters. Instance: {instance}, param: {param}"
                     )
                 input_params_by_instance[instance.id].append(param)
@@ -298,17 +303,17 @@ async def update_graph_service(
             relation.parent_component_instance_id in instance_ids
             and relation.child_component_instance_id in instance_ids
         ):
-            raise ValueError("Invalid relationship: component instance not found")
+            raise GraphValidationError("Invalid relationship: component instance not found")
 
         # Get parameter definition ID from name
         parent = get_component_instance_by_id(session, relation.parent_component_instance_id)
         if not parent:
-            raise ValueError("Invalid relationship: parent component instance not found")
+            raise GraphValidationError("Invalid relationship: parent component instance not found")
         # TODO: Refactor to repository function that takes name and component_id or with dictionary for faster lookup
         param_defs = get_component_parameter_definition_by_component_version(session, parent.component_version_id)
         param_def = next((p for p in param_defs if p.name == relation.parameter_name), None)
         if not param_def:
-            raise ValueError(
+            raise GraphValidationError(
                 f"Parameter '{relation.parameter_name}' not found in "
                 f"component definitions for component version '{parent.component_version_id}'"
             )
@@ -324,7 +329,7 @@ async def update_graph_service(
 
     for edge in graph_project.edges:
         if graph_runner_exists(session, edge.destination) or graph_runner_exists(session, edge.origin):
-            raise ValueError("Nested graphs are not supported")
+            raise GraphValidationError("Nested graphs are not supported")
 
         upsert_edge(
             session,
@@ -418,11 +423,13 @@ async def update_graph_service(
         # TODO: this mixes API-level `kind="input"` with service-level types; needs decoupling.
         for param in input_params_by_instance.get(instance.id, []):
             if not instance.id:
-                raise ValueError(
+                raise GraphValidationError(
                     f"Component instance ID is required for input parameters. Instance: {instance}, param: {param}"
                 )
             if instance.id not in instance_ids:
-                raise ValueError(f"Invalid field expression target: component instance {instance.id} not in update")
+                raise GraphValidationError(
+                    f"Invalid field expression target: component instance {instance.id} not in update"
+                )
 
             field_name = param.name
 
@@ -603,7 +610,7 @@ def _ensure_canonical_expressions_for_edges(
             source_instance_id not in instance_to_component_version
             or target_instance_id not in instance_to_component_version
         ):
-            raise ValueError("Unable to infer component version ids for one or more edges in the graph.")
+            raise GraphValidationError("Unable to infer component version ids for one or more edges in the graph.")
 
         source_component_version_id = instance_to_component_version[source_instance_id]
         target_component_version_id = instance_to_component_version[target_instance_id]
@@ -616,11 +623,15 @@ def _ensure_canonical_expressions_for_edges(
 
         source_port_def_id = get_output_port_definition_id(session, source_component_version_id, source_port_name)
         if not source_port_def_id:
-            raise ValueError(f"Output port '{source_port_name}' not found for component {source_component_version_id}")
+            raise GraphValidationError(
+                f"Output port '{source_port_name}' not found for component {source_component_version_id}"
+            )
 
         target_port_def_id = get_input_port_definition_id(session, target_component_version_id, target_port_name)
         if not target_port_def_id:
-            raise ValueError(f"Input port '{target_port_name}' not found for component {target_component_version_id}")
+            raise GraphValidationError(
+                f"Input port '{target_port_name}' not found for component {target_component_version_id}"
+            )
 
         validate_port_definition_types(session, source_port_def_id, target_port_def_id)
 

--- a/ada_backend/services/knowledge/errors.py
+++ b/ada_backend/services/knowledge/errors.py
@@ -33,9 +33,7 @@ class KnowledgeServiceQdrantChunkDeletionError(KnowledgeServiceQdrantOperationEr
     code = "qdrant_chunk_deletion_error"
 
     def __post_init__(self):
-        super().__init__(
-            f"Failed to delete chunk {self.chunk_id} from Qdrant collection {self.collection_name}: {self.reason}"
-        )
+        super().__init__(f"Failed to delete chunk {self.chunk_id} from vector store: {self.reason}")
 
 
 @dataclass
@@ -58,7 +56,7 @@ class KnowledgeServiceInvalidQdrantSchemaError(KnowledgeServiceQdrantConfigurati
     code = "invalid_qdrant_schema"
 
     def __post_init__(self):
-        super().__init__(f"Data source '{self.source_id}' has invalid qdrant_schema: {self.reason}")
+        super().__init__(f"Data source '{self.source_id}' has invalid vector search configuration: {self.reason}")
 
 
 @dataclass
@@ -86,7 +84,7 @@ class KnowledgeServiceQdrantCollectionNotFoundError(KnowledgeServiceQdrantConfig
 
     def __post_init__(self):
         super().__init__(
-            f"Data source '{self.source_id}' references Qdrant collection "
+            f"Data source '{self.source_id}' references vector collection "
             f"'{self.collection_name}' which does not exist"
         )
 
@@ -99,7 +97,7 @@ class KnowledgeServiceQdrantServiceCreationError(KnowledgeServiceQdrantOperation
     code = "qdrant_service_creation_failed"
 
     def __post_init__(self):
-        super().__init__(f"Failed to create Qdrant service for source '{self.source_id}': {self.reason}")
+        super().__init__(f"Failed to initialize vector search for source '{self.source_id}': {self.reason}")
 
 
 @dataclass
@@ -148,7 +146,7 @@ class KnowledgeMaxChunkSizeError(KnowledgeServiceError):
         self.token_count = token_count
         self.max_chunk_tokens = max_chunk_tokens
         super().__init__(
-            f"Chunk content exceeds maximum allowed token count: {self.max_chunk_tokens}"
+            f"Chunk content exceeds maximum allowed token count: {self.max_chunk_tokens}. "
             f"Token count: {self.token_count}"
         )
 
@@ -183,7 +181,5 @@ class KnowledgeServiceDBChunkDeletionError(KnowledgeServiceDBError):
 
     def __post_init__(self):
         super().__init__(
-            f"Failed to delete chunk {self.chunk_id} "
-            f"from Table {self.table_name} "
-            f"in Schema {self.schema_name}: {self.reason}"
+            f"Failed to delete chunk {self.chunk_id} from source database: {self.reason}"
         )

--- a/ada_backend/services/pipeline/get_pipeline_service.py
+++ b/ada_backend/services/pipeline/get_pipeline_service.py
@@ -29,7 +29,7 @@ from ada_backend.schemas.parameter_schema import PipelineParameterReadSchema
 from ada_backend.schemas.pipeline.base import ComponentRelationshipSchema, ToolDescriptionReadSchema
 from ada_backend.schemas.pipeline.get_pipeline_schema import ComponentInstanceReadSchema
 from ada_backend.schemas.pipeline.tool_port_configuration_schema import ToolPortConfigurationSchema
-from ada_backend.services.errors import ComponentInstanceNotFound, GraphValidationError
+from ada_backend.services.errors import ComponentInstanceNotFound, ComponentVersionNotFound, GraphValidationError
 from ada_backend.services.tool_description_generator import (
     _get_tool_eligible_port_definitions,
     generate_tool_description,
@@ -162,7 +162,7 @@ def get_component_instance(
         session, component_version_id=component_instance.component_version_id
     )
     if component_version is None:
-        raise GraphValidationError(f"Component version {component_instance.component_version_id} not found")
+        raise ComponentVersionNotFound(component_instance.component_version_id)
     subcomponent_params = get_subcomponent_param_def_by_component_version(
         session, component_instance.component_version_id
     )

--- a/ada_backend/services/pipeline/get_pipeline_service.py
+++ b/ada_backend/services/pipeline/get_pipeline_service.py
@@ -29,7 +29,7 @@ from ada_backend.schemas.parameter_schema import PipelineParameterReadSchema
 from ada_backend.schemas.pipeline.base import ComponentRelationshipSchema, ToolDescriptionReadSchema
 from ada_backend.schemas.pipeline.get_pipeline_schema import ComponentInstanceReadSchema
 from ada_backend.schemas.pipeline.tool_port_configuration_schema import ToolPortConfigurationSchema
-from ada_backend.services.errors import ComponentInstanceNotFound, ComponentVersionNotFound, GraphValidationError
+from ada_backend.services.errors import ComponentInstanceNotFound, ComponentVersionNotFound
 from ada_backend.services.tool_description_generator import (
     _get_tool_eligible_port_definitions,
     generate_tool_description,

--- a/ada_backend/services/pipeline/get_pipeline_service.py
+++ b/ada_backend/services/pipeline/get_pipeline_service.py
@@ -33,7 +33,7 @@ from ada_backend.services.tool_description_generator import (
     _get_tool_eligible_port_definitions,
     generate_tool_description,
 )
-from ada_backend.services.errors import ComponentInstanceNotFound
+from ada_backend.services.errors import ComponentInstanceNotFound, GraphValidationError
 from ada_backend.utils.component_utils import get_ui_component_properties_with_llm_options
 
 LOGGER = getLogger(__name__)
@@ -162,7 +162,7 @@ def get_component_instance(
         session, component_version_id=component_instance.component_version_id
     )
     if component_version is None:
-        raise ValueError(f"Component version {component_instance.component_version_id} not found")
+        raise GraphValidationError(f"Component version {component_instance.component_version_id} not found")
     subcomponent_params = get_subcomponent_param_def_by_component_version(
         session, component_instance.component_version_id
     )

--- a/ada_backend/services/pipeline/get_pipeline_service.py
+++ b/ada_backend/services/pipeline/get_pipeline_service.py
@@ -33,6 +33,7 @@ from ada_backend.services.tool_description_generator import (
     _get_tool_eligible_port_definitions,
     generate_tool_description,
 )
+from ada_backend.services.errors import ComponentInstanceNotFound
 from ada_backend.utils.component_utils import get_ui_component_properties_with_llm_options
 
 LOGGER = getLogger(__name__)
@@ -113,7 +114,7 @@ def get_component_instance(
     """Get a component instance by ID"""
     component_instance = get_component_instance_by_id(session, component_instance_id)
     if component_instance is None:
-        raise ValueError(f"Component instance {component_instance_id} not found")
+        raise ComponentInstanceNotFound(component_instance_id)
 
     tool_description = _get_tool_description(session, component_instance)
     port_configurations = _get_port_configurations(

--- a/ada_backend/services/pipeline/get_pipeline_service.py
+++ b/ada_backend/services/pipeline/get_pipeline_service.py
@@ -29,11 +29,11 @@ from ada_backend.schemas.parameter_schema import PipelineParameterReadSchema
 from ada_backend.schemas.pipeline.base import ComponentRelationshipSchema, ToolDescriptionReadSchema
 from ada_backend.schemas.pipeline.get_pipeline_schema import ComponentInstanceReadSchema
 from ada_backend.schemas.pipeline.tool_port_configuration_schema import ToolPortConfigurationSchema
+from ada_backend.services.errors import ComponentInstanceNotFound, GraphValidationError
 from ada_backend.services.tool_description_generator import (
     _get_tool_eligible_port_definitions,
     generate_tool_description,
 )
-from ada_backend.services.errors import ComponentInstanceNotFound, GraphValidationError
 from ada_backend.utils.component_utils import get_ui_component_properties_with_llm_options
 
 LOGGER = getLogger(__name__)

--- a/ada_backend/services/qa/llm_judges_service.py
+++ b/ada_backend/services/qa/llm_judges_service.py
@@ -21,7 +21,7 @@ from ada_backend.schemas.llm_judges_schema import (
     LLMJudgeTemplate,
     LLMJudgeUpdate,
 )
-from ada_backend.services.errors import LLMJudgeNotFound, ProjectNotFound
+from ada_backend.services.errors import LLMJudgeNotFound, LLMJudgeOperationError, ProjectNotFound
 from ada_backend.services.qa.utils import (
     DEFAULT_BOOLEAN_PROMPT,
     DEFAULT_FREE_TEXT_PROMPT,
@@ -57,7 +57,7 @@ def get_llm_judges_by_project_service(
         return [_judge_to_response(judge) for judge in judges]
     except Exception as e:
         LOGGER.error(f"Error in get_llm_judges_by_project_service for project {project_id}: {str(e)}")
-        raise ValueError(f"Failed to list LLM judges: {str(e)}") from e
+        raise LLMJudgeOperationError(f"Failed to list LLM judges: {str(e)}") from e
 
 
 def get_llm_judges_by_organization_service(
@@ -69,7 +69,7 @@ def get_llm_judges_by_organization_service(
         return [_judge_to_response(judge) for judge in judges]
     except Exception as e:
         LOGGER.error(f"Error in get_llm_judges_by_organization_service for org {organization_id}: {str(e)}")
-        raise ValueError(f"Failed to list LLM judges: {str(e)}") from e
+        raise LLMJudgeOperationError(f"Failed to list LLM judges: {str(e)}") from e
 
 
 def get_llm_judge_defaults_service(
@@ -111,8 +111,9 @@ def create_llm_judge_service(
         LOGGER.info(f"Created LLM judge {llm_judge.id} for organization {organization_id}")
         return _judge_to_response(llm_judge)
     except Exception as e:
+        raise LLMJudgeOperationError(f"Failed to create LLM judge: {str(e)}") from e
         LOGGER.error(f"Error in create_llm_judge_service for organization {organization_id}: {str(e)}")
-        raise ValueError(f"Failed to create LLM judge: {str(e)}") from e
+        raise LLMJudgeOperationError(f"Failed to create LLM judge: {str(e)}") from e
 
 
 def update_llm_judge_service(
@@ -141,7 +142,7 @@ def update_llm_judge_service(
         raise
     except Exception as e:
         LOGGER.error(f"Error in update_llm_judge_service for judge {judge_id}: {str(e)}")
-        raise ValueError(f"Failed to update LLM judge: {str(e)}") from e
+        raise LLMJudgeOperationError(f"Failed to update LLM judge: {str(e)}") from e
 
 
 def delete_llm_judges_service(
@@ -158,7 +159,7 @@ def delete_llm_judges_service(
         LOGGER.info(f"Deleted {deleted_count} LLM judges for organization {organization_id}")
     except Exception as e:
         LOGGER.error(f"Error in delete_llm_judges_service for organization {organization_id}: {str(e)}")
-        raise ValueError(f"Failed to delete LLM judges: {str(e)}") from e
+        raise LLMJudgeOperationError(f"Failed to delete LLM judges: {str(e)}") from e
 
 
 def set_judge_projects_service(

--- a/ada_backend/services/qa/llm_judges_service.py
+++ b/ada_backend/services/qa/llm_judges_service.py
@@ -111,7 +111,6 @@ def create_llm_judge_service(
         LOGGER.info(f"Created LLM judge {llm_judge.id} for organization {organization_id}")
         return _judge_to_response(llm_judge)
     except Exception as e:
-        raise LLMJudgeOperationError(f"Failed to create LLM judge: {str(e)}") from e
         LOGGER.error(f"Error in create_llm_judge_service for organization {organization_id}: {str(e)}")
         raise LLMJudgeOperationError(f"Failed to create LLM judge: {str(e)}") from e
 

--- a/ada_backend/services/qa/qa_evaluation_service.py
+++ b/ada_backend/services/qa/qa_evaluation_service.py
@@ -22,7 +22,7 @@ from ada_backend.schemas.qa_evaluation_schema import (
 )
 from ada_backend.services.agent_runner_service import setup_tracing_context
 from ada_backend.services.entity_factory import get_llm_provider_and_model
-from ada_backend.services.errors import LLMJudgeNotFound
+from ada_backend.services.errors import LLMJudgeNotFound, QAOperationError
 from ada_backend.services.qa.deterministic_evaluators_service import run_deterministic_evaluation_service
 from ada_backend.services.qa.qa_error import VersionOutputEmptyError
 from engine.components.utils_prompt import fill_prompt_template
@@ -58,7 +58,7 @@ def delete_judge_evaluations_service(
         LOGGER.info(f"Deleted {deleted_count} judge evaluations")
     except Exception as e:
         LOGGER.error(f"Error in delete_judge_evaluations_service: {str(e)}")
-        raise ValueError(f"Failed to delete judge evaluations: {str(e)}") from e
+        raise QAOperationError(f"Failed to delete judge evaluations: {str(e)}") from e
 
 
 def _setup_judge_evaluation_context(
@@ -175,6 +175,8 @@ async def run_judge_evaluation_service(
             LOGGER.info(f"Judge evaluation completed for judge {judge_id} and version_output {version_output_id}")
 
             return result
+    except LLMJudgeNotFound:
+        raise
     except Exception as e:
         LOGGER.error(f"Error in run_judge_evaluation_service: {str(e)}", exc_info=True)
-        raise ValueError(f"Failed to run judge evaluation: {str(e)}") from e
+        raise QAOperationError(f"Failed to run judge evaluation: {str(e)}") from e

--- a/ada_backend/services/qa/quality_assurance_service.py
+++ b/ada_backend/services/qa/quality_assurance_service.py
@@ -64,7 +64,12 @@ from ada_backend.schemas.input_groundtruth_schema import (
     QARunSummary,
 )
 from ada_backend.services.agent_runner_service import run_agent
-from ada_backend.services.errors import GraphNotBoundToProjectError
+from ada_backend.services.errors import (
+    GraphNotBoundToProjectError,
+    QAInputValidationError,
+    QAOperationError,
+    QASessionNotFound,
+)
 from ada_backend.services.metrics.utils import query_conversation_messages
 from ada_backend.services.qa.csv_processing import get_headers_from_csv, process_csv
 from ada_backend.services.qa.qa_error import (
@@ -126,7 +131,7 @@ def get_inputs_groundtruths_with_version_outputs_service(
         )
     except Exception as e:
         LOGGER.error(f"Error in get_inputs_groundtruths_with_version_outputs_service: {str(e)}")
-        raise ValueError(f"Failed to get input-groundtruth entries with version outputs: {str(e)}") from e
+        raise QAOperationError(f"Failed to get input-groundtruth entries with version outputs: {str(e)}") from e
 
 
 def get_outputs_by_graph_runner_service(
@@ -149,7 +154,7 @@ def get_outputs_by_graph_runner_service(
         return {input_id: output for input_id, output in outputs}
     except Exception as e:
         LOGGER.error(f"Error in get_outputs_by_graph_runner_service: {str(e)}")
-        raise ValueError(f"Failed to get outputs for graph runner: {str(e)}") from e
+        raise QAOperationError(f"Failed to get outputs for graph runner: {str(e)}") from e
 
 
 def get_version_output_ids_by_input_ids_and_graph_runner_service(
@@ -202,14 +207,14 @@ def validate_qa_run_request(
     if not run_request.run_all:
         input_entries = get_inputs_groundtruths_by_ids(session, run_request.input_ids)
         if not input_entries:
-            raise ValueError("No input entries found for the provided input_ids")
+            raise QAInputValidationError("No input entries found for the provided input_ids")
         returned_ids = {entry.id for entry in input_entries}
         missing_ids = set(run_request.input_ids) - returned_ids
         if missing_ids:
-            raise ValueError(f"Input IDs not found: {sorted(missing_ids)}")
+            raise QAInputValidationError(f"Input IDs not found: {sorted(missing_ids)}")
         for entry in input_entries:
             if entry.dataset_id != dataset_id:
-                raise ValueError(f"Input {entry.id} does not belong to dataset {dataset_id}")
+                raise QAInputValidationError(f"Input {entry.id} does not belong to dataset {dataset_id}")
 
     _validate_env_binding(session, project_id, run_request.graph_runner_id)
 
@@ -229,20 +234,20 @@ def resolve_qa_entries_and_environment(
             session, dataset_id, skip=0, limit=number_of_dataset_inputs
         )
         if not input_entries:
-            raise ValueError(f"No input entries found in dataset {dataset_id}")
+            raise QAInputValidationError(f"No input entries found in dataset {dataset_id}")
     else:
         input_entries = get_inputs_groundtruths_by_ids(session, run_request.input_ids)
         if not input_entries:
-            raise ValueError("No input entries found for the provided input_ids")
+            raise QAInputValidationError("No input entries found for the provided input_ids")
 
         returned_ids = {entry.id for entry in input_entries}
         missing_ids = set(run_request.input_ids) - returned_ids
         if missing_ids:
-            raise ValueError(f"Input IDs not found: {sorted(missing_ids)}")
+            raise QAInputValidationError(f"Input IDs not found: {sorted(missing_ids)}")
 
         for entry in input_entries:
             if entry.dataset_id != dataset_id:
-                raise ValueError(f"Input {entry.id} does not belong to dataset {dataset_id}")
+                raise QAInputValidationError(f"Input {entry.id} does not belong to dataset {dataset_id}")
 
     env_relationship = _validate_env_binding(session, project_id, run_request.graph_runner_id)
 
@@ -372,7 +377,7 @@ async def run_qa_service(
     try:
         input_entries, environment = resolve_qa_entries_and_environment(session, project_id, dataset_id, run_request)
         return await _execute_qa_entries(project_id, run_request, input_entries, environment)
-    except (ValueError, GraphNotBoundToProjectError, QADatasetNotInProjectError):
+    except (QAInputValidationError, GraphNotBoundToProjectError, QADatasetNotInProjectError):
         raise
     except Exception as e:
         LOGGER.error(f"Error in run_qa_service: {str(e)}")
@@ -459,7 +464,7 @@ def get_qa_session_service(
 ) -> QASession:
     qa_session = get_qa_session(session, qa_session_id)
     if not qa_session or qa_session.project_id != project_id:
-        raise ValueError(f"QA session {qa_session_id} not found in project {project_id}")
+        raise QASessionNotFound(qa_session_id, project_id)
     return qa_session
 
 
@@ -506,7 +511,7 @@ def create_inputs_groundtruths_service(
         raise
     except Exception as e:
         LOGGER.error(f"Error in create_inputs_groundtruths_service: {str(e)}")
-        raise ValueError(f"Failed to create input-groundtruth entries: {str(e)}") from e
+        raise QAOperationError(f"Failed to create input-groundtruth entries: {str(e)}") from e
 
 
 def update_inputs_groundtruths_service(
@@ -551,7 +556,7 @@ def update_inputs_groundtruths_service(
     except Exception as e:
         session.rollback()
         LOGGER.error(f"Error in update_inputs_groundtruths_service: {str(e)}")
-        raise ValueError(f"Failed to update input-groundtruth entries: {str(e)}") from e
+        raise QAOperationError(f"Failed to update input-groundtruth entries: {str(e)}") from e
 
 
 def delete_inputs_groundtruths_service(
@@ -582,7 +587,7 @@ def delete_inputs_groundtruths_service(
         return deleted_count
     except Exception as e:
         LOGGER.error(f"Error in delete_inputs_groundtruths_service: {str(e)}")
-        raise ValueError(f"Failed to delete input-groundtruth entries: {str(e)}") from e
+        raise QAOperationError(f"Failed to delete input-groundtruth entries: {str(e)}") from e
 
 
 def _dataset_to_response(session: Session, dataset) -> DatasetResponse:
@@ -606,7 +611,7 @@ def get_datasets_by_project_service(
         return [DatasetResponse.model_validate(dataset) for dataset in datasets]
     except Exception as e:
         LOGGER.error(f"Error in get_datasets_by_project_service: {str(e)}")
-        raise ValueError(f"Failed to get datasets: {str(e)}") from e
+        raise QAOperationError(f"Failed to get datasets: {str(e)}") from e
 
 
 def get_datasets_by_organization_service(
@@ -639,7 +644,7 @@ def create_datasets_service(
         )
     except Exception as e:
         LOGGER.error(f"Error in create_datasets_service: {str(e)}")
-        raise ValueError(f"Failed to create datasets: {str(e)}") from e
+        raise QAOperationError(f"Failed to create datasets: {str(e)}") from e
 
 
 def update_dataset_service(
@@ -666,7 +671,7 @@ def update_dataset_service(
         return _dataset_to_response(session, updated_dataset)
     except Exception as e:
         LOGGER.error(f"Error in update_dataset_service: {str(e)}")
-        raise ValueError(f"Failed to update dataset: {str(e)}") from e
+        raise QAOperationError(f"Failed to update dataset: {str(e)}") from e
 
 
 def delete_datasets_service(
@@ -693,7 +698,7 @@ def delete_datasets_service(
         return deleted_count
     except Exception as e:
         LOGGER.error(f"Error in delete_datasets_service: {str(e)}")
-        raise ValueError(f"Failed to delete datasets: {str(e)}") from e
+        raise QAOperationError(f"Failed to delete datasets: {str(e)}") from e
 
 
 def set_dataset_projects_service(

--- a/ada_backend/services/qa/quality_assurance_service.py
+++ b/ada_backend/services/qa/quality_assurance_service.py
@@ -66,6 +66,7 @@ from ada_backend.schemas.input_groundtruth_schema import (
 from ada_backend.services.agent_runner_service import run_agent
 from ada_backend.services.errors import (
     GraphNotBoundToProjectError,
+    QADatasetNotFound,
     QAInputValidationError,
     QAOperationError,
     QASessionNotFound,
@@ -623,7 +624,7 @@ def get_datasets_by_organization_service(
         return [_dataset_to_response(session, dataset) for dataset in datasets]
     except Exception as e:
         LOGGER.error(f"Error in get_datasets_by_organization_service: {str(e)}")
-        raise ValueError(f"Failed to get datasets: {str(e)}") from e
+        raise QAOperationError(f"Failed to get datasets: {str(e)}") from e
 
 
 def create_datasets_service(
@@ -657,7 +658,7 @@ def update_dataset_service(
         LOGGER.error(
             f"Failed to update dataset {dataset_id}: not found in organization {organization_id}"
         )
-        raise ValueError(f"Dataset {dataset_id} not found in organization {organization_id}")
+        raise QADatasetNotFound(dataset_id, organization_id)
 
     try:
         updated_dataset = update_dataset(
@@ -685,7 +686,7 @@ def delete_datasets_service(
                 f"Failed to delete datasets for organization {organization_id}: "
                 f"Dataset {dataset_id} not found in organization {organization_id}"
             )
-            raise ValueError(f"Dataset {dataset_id} not found in organization {organization_id}")
+            raise QADatasetNotFound(dataset_id, organization_id)
 
     try:
         deleted_count = delete_datasets(
@@ -708,17 +709,19 @@ def set_dataset_projects_service(
     project_ids: List[UUID],
 ) -> DatasetResponse:
     if not check_dataset_belongs_to_organization(session, organization_id, dataset_id):
-        raise ValueError(f"Dataset {dataset_id} not found in organization {organization_id}")
+        raise QADatasetNotFound(dataset_id, organization_id)
 
     if project_ids:
         projects = session.query(Project.id, Project.organization_id).filter(Project.id.in_(project_ids)).all()
         found_ids = {p.id for p in projects}
         missing = set(project_ids) - found_ids
         if missing:
-            raise ValueError(f"Projects not found: {sorted(missing)}")
+            raise QAInputValidationError(f"Projects not found: {sorted(missing)}")
         foreign = {p.id for p in projects if p.organization_id != organization_id}
         if foreign:
-            raise ValueError(f"Projects do not belong to organization {organization_id}: {sorted(foreign)}")
+            raise QAInputValidationError(
+                f"Projects do not belong to organization {organization_id}: {sorted(foreign)}"
+            )
 
     set_dataset_project_associations(session, dataset_id, project_ids)
 

--- a/ada_backend/services/run_service.py
+++ b/ada_backend/services/run_service.py
@@ -21,7 +21,9 @@ from ada_backend.services.errors import (
     InvalidRunStatusTransition,
     ProjectNotFound,
     ResultsBucketNotConfigured,
+    RunEnqueueError,
     RunNotFound,
+    RunInputNotFound,
     RunResultNotFound,
 )
 from ada_backend.services.s3_files_service import get_s3_client_and_ensure_bucket
@@ -426,7 +428,7 @@ def retry_run(
     retry_group_id = run.retry_group_id or run.id
     input_data = get_run_input(session, retry_group_id=retry_group_id)
     if input_data is None:
-        raise ValueError("Run input not found for retry")
+        raise RunInputNotFound()
 
     latest_attempt = run_repository.get_latest_run_by_retry_group(session, retry_group_id=retry_group_id)
     next_attempt = (latest_attempt.attempt_number if latest_attempt is not None else run.attempt_number) + 1
@@ -462,6 +464,6 @@ def retry_run(
             status=RunStatus.FAILED,
             error={"message": "Failed to enqueue run; Redis unavailable.", "type": "EnqueueError"},
         )
-        raise ValueError("Retry run could not be enqueued")
+        raise RunEnqueueError()
 
     return AsyncRunAcceptedSchema(run_id=retried_run.id, status="pending")

--- a/ada_backend/services/run_service.py
+++ b/ada_backend/services/run_service.py
@@ -22,8 +22,8 @@ from ada_backend.services.errors import (
     ProjectNotFound,
     ResultsBucketNotConfigured,
     RunEnqueueError,
-    RunNotFound,
     RunInputNotFound,
+    RunNotFound,
     RunResultNotFound,
 )
 from ada_backend.services.s3_files_service import get_s3_client_and_ensure_bucket

--- a/ada_backend/services/webhooks/errors.py
+++ b/ada_backend/services/webhooks/errors.py
@@ -48,10 +48,7 @@ class WebhookEventIdNotFoundError(WebhookServiceError):
     def __init__(self, provider: WebhookProvider, payload: Dict[str, Any]):
         self.provider = provider
         self.payload = payload
-        payload_keys = list(payload.keys()) if isinstance(payload, dict) else "N/A"
-        super().__init__(
-            f"Webhook event id not found for provider: {provider}. Payload structure keys: {payload_keys}"
-        )
+        super().__init__(f"Webhook event id not found for provider: {provider}.")
 
 
 class WebhookQueueError(WebhookServiceError):
@@ -73,9 +70,9 @@ class WebhookSignatureVerificationError(WebhookServiceError):
 
     status_code = 401
 
-    def __init__(self, message: str = "Invalid Svix signature"):
-        self.message = message
-        super().__init__(self.message)
+    def __init__(self, message: str = "Webhook signature verification failed."):
+        self.reason = message
+        super().__init__("Webhook signature verification failed.")
 
 
 class WebhookConfigurationError(WebhookServiceError):

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -258,7 +258,15 @@ Any Streamable-HTTP-compatible MCP client can connect to `https://mcp.draftnrun.
 
 **401 on tool calls** — Token expired. The MCP client should handle token refresh via Supabase. Reconnect if refresh fails.
 
-**Tools returning 403** — Your role in the organization may not have sufficient permissions, or the org's release stage may not include the requested resource. Check with `get_current_context`. The error message now includes the backend's detail when available.
+**Tools returning 403** — Your role in the organization may not have sufficient permissions, or the org's release stage may not include the requested resource. Check with `get_current_context()`. The error message includes the backend's detail when available.
+
+**Tools returning 400 ("Invalid request")** — A required field is missing or has the wrong type. The error message includes the specific backend detail. Re-read the tool's docstring and fix the value described in the error, then retry.
+
+**Tools returning 409 ("Conflict")** — The resource was modified by another client since you last fetched it. Re-fetch the resource (e.g. `get_graph`) to get the current state, re-apply your changes, and retry.
+
+**Tools returning 422 ("Input validation failed")** — Pydantic validation rejected one or more fields. The error lists each failing field as `field.path: message`. Fix the listed fields and retry.
+
+**"A QA operation failed." / "An LLM judge operation failed."** — An internal backend error occurred in the QA or judge service. This is a server-side issue, not caused by your input. Retry the call; if it persists, report it.
 
 **"access_token is required" on `update_graph`** — The graph contains an integration-backed component (e.g. Gmail, Slack, HubSpot) whose OAuth connection is not set up. The backend validates integration dependencies at save time, not just at run time. Fix: connect the integration in the web UI first, or save the graph without the integration component and add it later. See `docs://integrations` preflight checklist.
 

--- a/mcp_server/client.py
+++ b/mcp_server/client.py
@@ -86,8 +86,12 @@ def _extract_error_detail(response: httpx.Response) -> str:
     return text if text else ""
 
 
-def _format_validation_errors(response: httpx.Response) -> str:
-    """Format FastAPI/Pydantic validation errors as 'field.path: message' lines."""
+def _format_validation_errors(response: httpx.Response) -> tuple[str, bool]:
+    """Format FastAPI/Pydantic validation errors as 'field.path: message' lines.
+
+    Returns (detail_text, has_fields) where has_fields is True when at least
+    one structured field error was parsed from the response body.
+    """
     try:
         body = response.json()
     except (json.JSONDecodeError, ValueError):
@@ -110,12 +114,12 @@ def _format_validation_errors(response: httpx.Response) -> str:
                     path = "input"
                 lines.append(f"{path}: {msg.strip()}")
             if lines:
-                return "\n".join(lines)
+                return "\n".join(lines), True
 
     fallback = _extract_error_detail(response)
     if fallback:
-        return fallback
-    return f"No error detail returned by the server (HTTP {response.status_code})"
+        return fallback, False
+    return f"No error detail returned by the server (HTTP {response.status_code})", False
 
 
 async def _handle_response(response: httpx.Response, *, trim: bool = True) -> Any:
@@ -170,11 +174,13 @@ async def _handle_response(response: httpx.Response, *, trim: bool = True) -> An
         )
 
     if response.status_code == 422:
-        detail = _format_validation_errors(response)
-        raise ToolError(
-            f"Input validation failed{request_context}:\n{detail}\n"
+        detail, has_fields = _format_validation_errors(response)
+        next_step = (
             "Next step: fix the values above and retry."
+            if has_fields
+            else "Next step: check the request payload against the tool's docstring and retry."
         )
+        raise ToolError(f"Input validation failed{request_context}:\n{detail}\n{next_step}")
 
     if response.status_code == 429:
         retry_after = response.headers.get("Retry-After", "unknown")

--- a/mcp_server/client.py
+++ b/mcp_server/client.py
@@ -86,6 +86,38 @@ def _extract_error_detail(response: httpx.Response) -> str:
     return text if text else ""
 
 
+def _format_validation_errors(response: httpx.Response) -> str:
+    """Format FastAPI/Pydantic validation errors as 'field.path: message' lines."""
+    try:
+        body = response.json()
+    except (json.JSONDecodeError, ValueError):
+        body = None
+
+    if isinstance(body, dict):
+        detail = body.get("detail")
+        if isinstance(detail, list):
+            lines: list[str] = []
+            for item in detail:
+                if not isinstance(item, dict):
+                    continue
+                msg = item.get("msg")
+                loc = item.get("loc")
+                if not isinstance(msg, str) or not msg.strip():
+                    continue
+                if isinstance(loc, (list, tuple)) and loc:
+                    path = ".".join(str(part) for part in loc)
+                else:
+                    path = "input"
+                lines.append(f"{path}: {msg.strip()}")
+            if lines:
+                return "\n".join(lines)
+
+    fallback = _extract_error_detail(response)
+    if fallback:
+        return fallback
+    return f"No error detail returned by the server (HTTP {response.status_code})"
+
+
 async def _handle_response(response: httpx.Response, *, trim: bool = True) -> Any:
     if response.status_code == 204:
         return {"status": "ok"}
@@ -120,6 +152,28 @@ async def _handle_response(response: httpx.Response, *, trim: bool = True) -> An
             f"Resource not found{request_context}.{f' {detail}' if detail else ''} "
             "Next step: verify the ID came from a list_*/get_* call in this session — "
             "never reuse IDs across projects or orgs."
+        )
+
+    if response.status_code == 400:
+        detail = _extract_error_detail(response)
+        raise ToolError(
+            f"Invalid request{request_context}.{f' {detail}' if detail else ''} "
+            "Next step: check parameter types and required fields in the tool's docstring."
+        )
+
+    if response.status_code == 409:
+        detail = _extract_error_detail(response)
+        raise ToolError(
+            f"Conflict{request_context}.{f' {detail}' if detail else ''} "
+            "Next step: re-fetch the resource (e.g. get_graph) to get the latest state, "
+            "re-apply your changes, and retry."
+        )
+
+    if response.status_code == 422:
+        detail = _format_validation_errors(response)
+        raise ToolError(
+            f"Input validation failed{request_context}:\n{detail}\n"
+            "Next step: fix the values above and retry."
         )
 
     if response.status_code == 429:

--- a/mcp_server/context.py
+++ b/mcp_server/context.py
@@ -156,5 +156,8 @@ async def require_role(user_id: str, *allowed_roles: str) -> dict[str, Any]:
     """Return active org if the user's role is in allowed_roles, else raise."""
     org = await require_org_context(user_id)
     if org["role"] not in allowed_roles:
-        raise ValueError(f"This operation requires one of {allowed_roles} role, but your role is '{org['role']}'.")
+        raise ValueError(
+            f"This operation requires one of {allowed_roles} role, but your role is '{org['role']}'. "
+            "Next step: call get_current_context() to verify your role."
+        )
     return org

--- a/mcp_server/tools/agents.py
+++ b/mcp_server/tools/agents.py
@@ -61,7 +61,7 @@ def register(mcp: FastMCP) -> None:
         """
         name = name.strip()
         if not name:
-            raise ValueError("Agent name must not be empty or whitespace-only.")
+            raise ValueError("Agent name must not be empty. Provide a non-empty string.")
 
         jwt, user_id = _get_auth()
         org = await require_role(user_id, "developer", "admin", "super_admin")

--- a/mcp_server/tools/components.py
+++ b/mcp_server/tools/components.py
@@ -81,7 +81,7 @@ def register(mcp: FastMCP) -> None:
         """
         query = query.strip()
         if not query:
-            raise ValueError("query must not be empty")
+            raise ValueError("Search query must not be empty. Provide a term to match against component names.")
 
         jwt, user_id = _get_auth()
         org = await require_org_context(user_id)

--- a/mcp_server/tools/context_tools.py
+++ b/mcp_server/tools/context_tools.py
@@ -42,12 +42,16 @@ async def _require_target_org_role(jwt: str, user_id: str, org_id: str, *allowed
     orgs = await list_user_organizations(jwt, user_id)
     match = next((org for org in orgs if org["id"] == org_id), None)
     if not match:
-        raise ValueError(f"Organization {org_id} not found in your memberships.")
+        raise ValueError(
+            f"Organization {org_id} not found in your memberships. "
+            "Next step: call list_my_organizations() to see available orgs."
+        )
     if match["role"] not in allowed_roles:
         context = f"{action} in organization {org_id}" if action else f"This operation on organization {org_id}"
         raise ValueError(
             f"{context} requires one of {allowed_roles} role, "
-            f"but your role there is '{match['role']}'."
+            f"but your role there is '{match['role']}'. "
+            "Next step: call get_current_context() to verify your role."
         )
     return match
 
@@ -79,7 +83,10 @@ def register(mcp: FastMCP) -> None:
         orgs = await list_user_organizations(jwt, user_id)
         match = next((o for o in orgs if o["id"] == str(organization_id)), None)
         if not match:
-            raise ValueError(f"Organization {organization_id} not found in your memberships.")
+            raise ValueError(
+                f"Organization {organization_id} not found in your memberships. "
+                "Next step: call list_my_organizations() to see available orgs."
+            )
         release_stage = await fetch_org_release_stage(jwt, match["id"])
         await set_active_org(user_id, match["id"], match["name"], match["role"], release_stage)
         return {

--- a/mcp_server/tools/monitoring.py
+++ b/mcp_server/tools/monitoring.py
@@ -73,9 +73,9 @@ def register(mcp: FastMCP) -> None:
     ) -> dict:
         """List execution traces for a project. Filter by duration (days lookback) or by explicit date range."""
         if page < 1:
-            raise ValueError("page must be >= 1")
+            raise ValueError("Page must be >= 1 (1-indexed). Pass page=1 for the first page.")
         if page_size < 1:
-            raise ValueError("page_size must be >= 1")
+            raise ValueError("Page size must be >= 1. Recommended range: 10-50.")
 
         params: dict = {"page": page, "page_size": min(page_size, 100)}
 

--- a/mcp_server/tools/projects.py
+++ b/mcp_server/tools/projects.py
@@ -108,7 +108,7 @@ def register(mcp: FastMCP) -> None:
         """
         name = name.strip()
         if not name:
-            raise ValueError("name must not be empty")
+            raise ValueError("Workflow name must not be empty. Provide a non-empty string.")
 
         jwt, user_id = _get_auth()
         org = await require_role(user_id, "developer", "admin", "super_admin")
@@ -142,12 +142,12 @@ def register(mcp: FastMCP) -> None:
         if name is not None:
             name = name.strip()
             if not name:
-                raise ValueError("name must not be empty")
+                raise ValueError("Workflow name must not be empty. Provide a non-empty string.")
             body["name"] = name
         if description is not None:
             body["description"] = description
         if not body:
-            raise ValueError("At least one field must be provided")
+            raise ValueError("At least one field (name or description) must be provided to update.")
         return await api.patch(f"/projects/{project_id}", jwt, json=body)
 
     @mcp.tool()

--- a/mcp_server/tools/projects.py
+++ b/mcp_server/tools/projects.py
@@ -142,7 +142,7 @@ def register(mcp: FastMCP) -> None:
         if name is not None:
             name = name.strip()
             if not name:
-                raise ValueError("Workflow name must not be empty. Provide a non-empty string.")
+                raise ValueError("Project name must not be empty. Provide a non-empty string.")
             body["name"] = name
         if description is not None:
             body["description"] = description

--- a/mcp_server/tools/runs.py
+++ b/mcp_server/tools/runs.py
@@ -101,9 +101,9 @@ def register(mcp: FastMCP) -> None:
         project_name, attempt_count, and input_available (whether retry is possible).
         """
         if page < 1:
-            raise ValueError("Page must be >= 1.")
+            raise ValueError("Page must be >= 1 (1-indexed). Pass page=1 for the first page.")
         if page_size < 1:
-            raise ValueError("Page size must be >= 1.")
+            raise ValueError("Page size must be >= 1. Recommended range: 10-50.")
 
         jwt, user_id = _get_auth()
         org = await require_org_context(user_id)
@@ -203,7 +203,7 @@ def register(mcp: FastMCP) -> None:
           `get_run_result` rather than assuming failure.
         """
         if not isinstance(timeout, int) or timeout <= 0:
-            raise ValueError("timeout must be a positive integer")
+            raise ValueError("timeout must be a positive integer (seconds). Default is typically 120.")
         if "messages" not in payload:
             raise ValueError(
                 "payload must contain a 'messages' key. "

--- a/mcp_server/tools/runs.py
+++ b/mcp_server/tools/runs.py
@@ -203,7 +203,7 @@ def register(mcp: FastMCP) -> None:
           `get_run_result` rather than assuming failure.
         """
         if not isinstance(timeout, int) or timeout <= 0:
-            raise ValueError("timeout must be a positive integer (seconds). Default is typically 120.")
+            raise ValueError("timeout must be a positive integer (seconds). Default is typically 60.")
         if "messages" not in payload:
             raise ValueError(
                 "payload must contain a 'messages' key. "

--- a/tests/ada_backend/services/graph/test_component_instance_v2_service.py
+++ b/tests/ada_backend/services/graph/test_component_instance_v2_service.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import pytest
 
 from ada_backend.schemas.pipeline.graph_schema import ComponentCreateV2Schema, ComponentUpdateV2Schema
+from ada_backend.services.errors import ComponentInstanceNotFound, GraphValidationError
 from ada_backend.services.graph.component_instance_v2_service import (
     create_component_in_graph,
     delete_component_from_graph,
@@ -96,7 +97,7 @@ class TestUpdateSingleComponent:
         mock_get_nodes.return_value = []
 
         payload = ComponentUpdateV2Schema(parameters=[])
-        with pytest.raises(ValueError, match="does not belong to graph"):
+        with pytest.raises(GraphValidationError, match="does not belong to graph"):
             update_single_component(session, ids["graph_runner_id"], ids["project_id"], ids["instance_id"], payload)
 
     @patch("ada_backend.services.graph.component_instance_v2_service.get_component_nodes")
@@ -105,7 +106,7 @@ class TestUpdateSingleComponent:
         mock_get_inst.return_value = None
 
         payload = ComponentUpdateV2Schema(parameters=[])
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(ComponentInstanceNotFound, match="not found"):
             update_single_component(session, ids["graph_runner_id"], ids["project_id"], ids["instance_id"], payload)
 
 
@@ -132,7 +133,7 @@ class TestDeleteComponentFromGraph:
     def test_raises_if_not_in_graph(self, mock_get_nodes, session, ids):
         mock_get_nodes.return_value = []
 
-        with pytest.raises(ValueError, match="does not belong to graph"):
+        with pytest.raises(GraphValidationError, match="does not belong to graph"):
             delete_component_from_graph(session, ids["graph_runner_id"], ids["instance_id"])
 
     @patch("ada_backend.services.graph.component_instance_v2_service.delete_node")

--- a/tests/ada_backend/services/graph/test_graph_topology_v2_service.py
+++ b/tests/ada_backend/services/graph/test_graph_topology_v2_service.py
@@ -9,6 +9,7 @@ from ada_backend.schemas.pipeline.graph_schema import (
     GraphMapRelationshipSchema,
     GraphTopologyNodeSchema,
 )
+from ada_backend.services.errors import GraphValidationError
 from ada_backend.services.graph.graph_topology_v2_service import sync_graph_topology
 
 
@@ -72,7 +73,7 @@ class TestSyncGraphTopology:
 
         nodes = [GraphTopologyNodeSchema(instance_id=uuid4(), label="Ghost")]
 
-        with pytest.raises(ValueError, match="do not exist in graph"):
+        with pytest.raises(GraphValidationError, match="do not exist in graph"):
             sync_graph_topology(session, graph_runner_id, nodes=nodes, edges=[], relationships=[])
 
     @patch("ada_backend.services.graph.graph_topology_v2_service.delete_edge")

--- a/tests/ada_backend/services/graph/test_graph_v2_mapper_service.py
+++ b/tests/ada_backend/services/graph/test_graph_v2_mapper_service.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 import pytest
 
 from ada_backend.schemas.pipeline.graph_schema import GraphSaveV2Schema
+from ada_backend.services.errors import GraphValidationError
 from ada_backend.services.graph.graph_v2_mapper_service import (
     _resolve_expression_file_keys,
     graph_save_v2_to_graph_update,
@@ -53,7 +54,7 @@ def test_v2_mapper_raises_on_duplicate_node_file_key():
         ],
     )
 
-    with pytest.raises(ValueError, match="Duplicate file_key 'start' in graph_map.nodes"):
+    with pytest.raises(GraphValidationError, match="Duplicate file_key 'start' in graph_map.nodes"):
         graph_save_v2_to_graph_update(payload)
 
 
@@ -70,7 +71,7 @@ def test_v2_mapper_raises_on_unknown_file_key_edge():
         ],
     )
 
-    with pytest.raises(ValueError, match="Unknown file_key"):
+    with pytest.raises(GraphValidationError, match="Unknown file_key"):
         graph_save_v2_to_graph_update(payload)
 
 
@@ -95,7 +96,7 @@ class TestResolveExpressionFileKeys:
         assert result == {"type": "ref", "instance": str(mapping["comp1"]), "port": "output", "key": "messages"}
 
     def test_unknown_file_key_raises(self):
-        with pytest.raises(ValueError, match="Unknown file_key 'missing'"):
+        with pytest.raises(GraphValidationError, match="Unknown file_key 'missing'"):
             _resolve_expression_file_keys({"type": "ref", "file_key": "missing", "port": "out"}, {})
 
     def test_concat_resolves_nested_refs(self):

--- a/tests/ada_backend/services/test_knowledge_service.py
+++ b/tests/ada_backend/services/test_knowledge_service.py
@@ -282,7 +282,7 @@ def test_validate_qdrant_service_raises_when_invalid_schema(
         embedding_model_reference="openai:text-embedding-3-large",
     )
 
-    with pytest.raises(KnowledgeServiceInvalidQdrantSchemaError, match="invalid qdrant_schema"):
+    with pytest.raises(KnowledgeServiceInvalidQdrantSchemaError, match="invalid vector search configuration"):
         asyncio.run(knowledge_service._validate_and_get_qdrant_service(source))
 
 

--- a/tests/ada_backend/services/test_run_service.py
+++ b/tests/ada_backend/services/test_run_service.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import pytest
 
 from ada_backend.database.models import CallType, EnvType, RunStatus
-from ada_backend.services.errors import InvalidRunStatusTransition, RunNotFound
+from ada_backend.services.errors import InvalidRunStatusTransition, RunInputNotFound, RunNotFound
 from ada_backend.services.run_service import fail_pending_run, retry_run
 
 MODULE = "ada_backend.services.run_service"
@@ -194,5 +194,5 @@ class TestRetryRun:
             patch(f"{MODULE}.get_run_input", return_value=None),
         ):
             repo.get_run.return_value = existing_run
-            with pytest.raises(ValueError, match="Run input not found for retry"):
+            with pytest.raises(RunInputNotFound, match="Run input not found for retry"):
                 retry_run(session=session, run_id=run_id, project_id=project_id, env=EnvType.PRODUCTION)

--- a/tests/ada_backend/test_qa_evaluation_services.py
+++ b/tests/ada_backend/test_qa_evaluation_services.py
@@ -183,7 +183,7 @@ async def test_evaluation_errors():
         version_output_id = evaluation_scenario["version_output_id"]
 
         non_existent_judge_id = uuid4()
-        with pytest.raises(LLMJudgeNotFound, match="not found in project"):
+        with pytest.raises(LLMJudgeNotFound, match="not found"):
             await run_judge_evaluation_service(
                 session=session,
                 project_id=project_id,

--- a/tests/ada_backend/test_qa_evaluation_services.py
+++ b/tests/ada_backend/test_qa_evaluation_services.py
@@ -12,7 +12,7 @@ from ada_backend.repositories.quality_assurance_repository import (
 from ada_backend.schemas.input_groundtruth_schema import InputGroundtruthCreate
 from ada_backend.schemas.llm_judges_schema import LLMJudgeCreate, LLMJudgeUpdate
 from ada_backend.schemas.qa_evaluation_schema import BooleanEvaluationResult, ErrorEvaluationResult
-from ada_backend.services.errors import LLMJudgeNotFound
+from ada_backend.services.errors import LLMJudgeNotFound, QAOperationError
 from ada_backend.services.project_service import delete_project_service
 from ada_backend.services.qa.llm_judges_service import (
     create_llm_judge_service,
@@ -183,7 +183,7 @@ async def test_evaluation_errors():
         version_output_id = evaluation_scenario["version_output_id"]
 
         non_existent_judge_id = uuid4()
-        with pytest.raises(ValueError, match="Failed to run judge evaluation"):
+        with pytest.raises(LLMJudgeNotFound, match="not found in project"):
             await run_judge_evaluation_service(
                 session=session,
                 project_id=project_id,
@@ -203,7 +203,7 @@ async def test_validation_errors_version_output():
         evaluation_scenario = _create_evaluation_scenario(session, project_id, graph_runner_id)
 
         non_existent_version_output_id = uuid4()
-        with pytest.raises(ValueError, match="Failed to run judge evaluation"):
+        with pytest.raises(QAOperationError, match="Failed to run judge evaluation"):
             await run_judge_evaluation_service(
                 session=session,
                 project_id=evaluation_scenario["project_id"],

--- a/tests/mcp_server/test_client.py
+++ b/tests/mcp_server/test_client.py
@@ -105,15 +105,41 @@ async def test_handle_error_includes_request_path():
 
 
 @pytest.mark.asyncio
-async def test_handle_generic_4xx_with_blank_detail():
-    response = httpx.Response(422, text="")
+async def test_handle_400_returns_actionable_message():
+    body = json.dumps({"detail": "payload is missing required field: name"})
+    response = httpx.Response(400, text=body, headers={"content-type": "application/json"})
 
-    with pytest.raises(ToolError, match="No error detail returned"):
+    with pytest.raises(ToolError, match="Invalid request.*check parameter types"):
         await _handle_response(response)
 
 
 @pytest.mark.asyncio
-async def test_handle_generic_4xx_with_whitespace_only_detail():
+async def test_handle_409_returns_conflict_guidance():
+    body = json.dumps({"detail": "Graph was modified by another client"})
+    response = httpx.Response(409, text=body, headers={"content-type": "application/json"})
+
+    with pytest.raises(ToolError, match="Conflict.*re-fetch the resource.*retry"):
+        await _handle_response(response)
+
+
+@pytest.mark.asyncio
+async def test_handle_422_formats_validation_errors():
+    body = json.dumps(
+        {
+            "detail": [
+                {"loc": ["body", "name"], "msg": "Field required"},
+                {"loc": ["body", "page_size"], "msg": "Input should be greater than 0"},
+            ]
+        }
+    )
+    response = httpx.Response(422, text=body, headers={"content-type": "application/json"})
+
+    with pytest.raises(ToolError, match=r"Input validation failed:[\s\S]*body\.name: Field required"):
+        await _handle_response(response)
+
+
+@pytest.mark.asyncio
+async def test_handle_422_with_blank_detail_falls_back_to_default_message():
     body = json.dumps({"detail": "  \n  "})
     response = httpx.Response(422, text=body, headers={"content-type": "application/json"})
 

--- a/tests/mcp_server/test_client.py
+++ b/tests/mcp_server/test_client.py
@@ -139,9 +139,29 @@ async def test_handle_422_formats_validation_errors():
 
 
 @pytest.mark.asyncio
-async def test_handle_422_with_blank_detail_falls_back_to_default_message():
+async def test_handle_422_with_blank_detail_falls_back_to_docstring_guidance():
     body = json.dumps({"detail": "  \n  "})
     response = httpx.Response(422, text=body, headers={"content-type": "application/json"})
 
     with pytest.raises(ToolError, match="No error detail returned"):
+        await _handle_response(response)
+
+
+@pytest.mark.asyncio
+async def test_handle_422_fallback_uses_docstring_guidance_not_fix_above():
+    body = json.dumps({"detail": "  \n  "})
+    response = httpx.Response(422, text=body, headers={"content-type": "application/json"})
+
+    with pytest.raises(ToolError, match="check the request payload against the tool's docstring"):
+        await _handle_response(response)
+
+
+@pytest.mark.asyncio
+async def test_handle_422_with_fields_uses_fix_above_guidance():
+    body = json.dumps({
+        "detail": [{"loc": ["body", "name"], "msg": "Field required"}]
+    })
+    response = httpx.Response(422, text=body, headers={"content-type": "application/json"})
+
+    with pytest.raises(ToolError, match="fix the values above and retry"):
         await _handle_response(response)

--- a/tests/mcp_server/test_monitoring.py
+++ b/tests/mcp_server/test_monitoring.py
@@ -98,5 +98,5 @@ async def test_list_traces_rejects_zero_page(fake_mcp, monkeypatch):
     monkeypatch.setattr(monitoring, "_get_auth", lambda: ("jwt", "user-1"))
     monitoring.register(fake_mcp)
 
-    with pytest.raises(ValueError, match="page must be >= 1"):
+    with pytest.raises(ValueError, match="Page must be >= 1"):
         await fake_mcp.tools["list_traces"](project_id=FAKE_PROJECT_ID, page=0)

--- a/tests/mcp_server/test_projects.py
+++ b/tests/mcp_server/test_projects.py
@@ -118,7 +118,7 @@ async def test_update_project_rejects_empty_body(fake_mcp, monkeypatch):
 
     projects.register(mcp)
 
-    with pytest.raises(ValueError, match="At least one field must be provided"):
+    with pytest.raises(ValueError, match="At least one field .* must be provided to update"):
         await mcp.tools["update_project"](FAKE_PROJECT_ID)
 
     patch_mock.assert_not_awaited()


### PR DESCRIPTION
## What changed

This PR improves error quality and propagation across backend services and MCP tooling for DRA-1261.

- Migrated key service paths from generic `ValueError` to typed `ServiceError` subclasses with explicit HTTP semantics (graph, QA, run retry, cron).
- Cleaned router-level `except ValueError` blocks that became redundant after typed-service propagation, while preserving targeted safety nets where needed.
- Added dedicated MCP client handling for `400/409/422` with actionable recovery guidance and readable validation error formatting.
- Upgraded MCP tool validation messages to consistently explain what failed and what to do next.
- Scrubbed internal infrastructure wording from user-facing errors (OAuth/Nango, vector store/Qdrant, webhook signature/Svix, DB internals).
- Updated regression tests to assert typed exceptions and revised error-copy behavior.

## Why

Error handling was fragmented between services and routers, with multiple generic catches and inconsistent messaging.
That created three issues:

- Useful domain errors were flattened into less actionable responses.
- MCP validation failures lacked clear next steps.
- Some responses leaked implementation details better kept internal.

This change consolidates error intent at the service layer and keeps response shaping safer and more predictable.

## Implementation context

- Typed exceptions are now the primary transport from domain logic to the global error handler.
- Router cleanup was done after service migration to avoid turning expected 4xx paths into generic 500s.
- Cron error classes now include explicit constructors so not-found/access/validation paths return meaningful details.
- MCP client validation formatting now maps nested validation locations into readable field paths.

## Out of scope

- Migrating every remaining `ValueError` in the codebase.
- Additional router families outside this first DRA-1261 slice.
- Introducing structured response error codes.

## Validation

- Focused backend and MCP test suites were run for error handler behavior, router safety-net behavior, MCP client status handling, and MCP tool message quality.
- Regression tests were updated where previous expectations were tied to generic `ValueError` instead of typed service errors.
- Broader CI remains the source of truth for the full matrix.

## Observed behavior changes

- Invalid QA run inputs now return specific validation details instead of collapsing to a generic `400 Bad request` at the route layer.
- MCP validation errors now include actionable recovery hints (for example pagination bounds and role/org follow-ups) rather than short one-line failures.
- MCP handling of backend `400/409/422` responses is now explicit and readable, including clearer conflict-retry guidance.
- Graph optimistic-lock conflicts still correctly return `409`; the backend behavior is unchanged there, and the improvement is the MCP-side conflict message clarity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages across validation endpoints to provide clearer guidance on required fields and next steps.
  * Enhanced field-level error reporting for validation failures, including specific field paths and descriptions.

* **Documentation**
  * Error messages now include actionable next steps and context-specific guidance to help users resolve issues faster.
  * Refined troubleshooting documentation with clearer guidance for common error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->