### PR TITLE
feat(runs): Improve runs visualization dra-1276

### DIFF
--- a/ada_backend/database/alembic/versions/k2l3m4n5o6p7_add_env_to_runs.py
+++ b/ada_backend/database/alembic/versions/k2l3m4n5o6p7_add_env_to_runs.py
@@ -1,0 +1,27 @@
+"""add_env_to_runs
+
+Revision ID: k2l3m4n5o6p7
+Revises: 67df5c87b638
+Create Date: 2026-04-24
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "k2l3m4n5o6p7"
+down_revision: Union[str, None] = "67df5c87b638"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+env_type_enum = postgresql.ENUM("draft", "production", name="env_type", create_type=False)
+
+
+def upgrade() -> None:
+    op.add_column("runs", sa.Column("env", env_type_enum, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("runs", "env")

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -1447,6 +1447,7 @@ class Run(Base):
     )
     status = mapped_column(make_pg_enum(RunStatus), nullable=False, default=RunStatus.PENDING)
     trigger = mapped_column(make_pg_enum(CallType), nullable=False, default=CallType.API)
+    env = mapped_column(make_pg_enum(EnvType), nullable=True)
     trace_id = mapped_column(String, nullable=True, index=True)
     webhook_id = mapped_column(
         UUID(as_uuid=True),

--- a/ada_backend/docs/api-reference.md
+++ b/ada_backend/docs/api-reference.md
@@ -70,7 +70,7 @@ Complete endpoint reference for the Draft'n Run backend.
 | GET | `.../runs/{run_id}/result` | JWT(Member) | Get run result |
 | PATCH | `.../runs/{run_id}` | JWT(Member) | Update run status |
 | POST | `.../runs/{run_id}/retry` | JWT(Member) | Retry a specific run (202) |
-| GET | `/org/{organization_id}/runs` | JWT(Member) | List runs for org (paginated, filterable). Filters: `statuses` (list), `project_ids` (list), `trigger`, `date_from`, `date_to` |
+| GET | `/org/{organization_id}/runs` | JWT(Member) | List runs for org (paginated, filterable). Filters: `statuses` (list), `project_ids` (list), `triggers` (list), `envs` (list), `date_from`, `date_to` |
 | GET | `/org/{organization_id}/runs/{run_id}/input` | JWT(Member) | Get run input data (if available) |
 
 ### Run Retry

--- a/ada_backend/repositories/run_repository.py
+++ b/ada_backend/repositories/run_repository.py
@@ -20,6 +20,7 @@ def create_run(
     attempt_number: int = 1,
     event_id: str | None = None,
     retry_group_id: UUID | None = None,
+    env: db.EnvType | None = None,
 ) -> db.Run:
     """Create a new run with status pending. Caller manages transaction."""
     run_id = uuid4()
@@ -33,6 +34,7 @@ def create_run(
         "integration_trigger_id": integration_trigger_id,
         "attempt_number": attempt_number,
         "retry_group_id": run_retry_group_id,
+        "env": env,
     }
     if event_id is not None:
         kwargs["event_id"] = event_id
@@ -60,7 +62,8 @@ def _apply_run_filters(
     query,
     statuses: list[db.RunStatus] | None = None,
     project_ids: list[UUID] | None = None,
-    trigger: db.CallType | None = None,
+    triggers: list[db.CallType] | None = None,
+    envs: list[db.EnvType] | None = None,
     date_from: datetime | None = None,
     date_to: datetime | None = None,
 ):
@@ -68,8 +71,10 @@ def _apply_run_filters(
         query = query.filter(db.Run.status.in_(statuses))
     if project_ids:
         query = query.filter(db.Run.project_id.in_(project_ids))
-    if trigger is not None:
-        query = query.filter(db.Run.trigger == trigger)
+    if triggers:
+        query = query.filter(db.Run.trigger.in_(triggers))
+    if envs:
+        query = query.filter(db.Run.env.in_(envs))
     if date_from is not None:
         query = query.filter(db.Run.created_at >= date_from)
     if date_to is not None:
@@ -82,14 +87,16 @@ def count_runs_by_organization(
     organization_id: UUID,
     statuses: list[db.RunStatus] | None = None,
     project_ids: list[UUID] | None = None,
-    trigger: db.CallType | None = None,
+    triggers: list[db.CallType] | None = None,
+    envs: list[db.EnvType] | None = None,
     date_from: datetime | None = None,
     date_to: datetime | None = None,
 ) -> int:
     query = session.query(db.Run).join(db.Project, db.Run.project_id == db.Project.id)
     query = query.filter(db.Project.organization_id == organization_id)
     query = _apply_run_filters(
-        query, statuses=statuses, project_ids=project_ids, trigger=trigger, date_from=date_from, date_to=date_to
+        query, statuses=statuses, project_ids=project_ids, triggers=triggers, envs=envs,
+        date_from=date_from, date_to=date_to,
     )
     return query.count()
 
@@ -101,7 +108,8 @@ def get_runs_by_organization(
     offset: int = 0,
     statuses: list[db.RunStatus] | None = None,
     project_ids: list[UUID] | None = None,
-    trigger: db.CallType | None = None,
+    triggers: list[db.CallType] | None = None,
+    envs: list[db.EnvType] | None = None,
     date_from: datetime | None = None,
     date_to: datetime | None = None,
 ) -> list[OrgRunResponseSchema]:
@@ -133,7 +141,8 @@ def get_runs_by_organization(
         .filter(db.Project.organization_id == organization_id)
     )
     query = _apply_run_filters(
-        query, statuses=statuses, project_ids=project_ids, trigger=trigger, date_from=date_from, date_to=date_to
+        query, statuses=statuses, project_ids=project_ids, triggers=triggers, envs=envs,
+        date_from=date_from, date_to=date_to,
     )
 
     rows = query.order_by(db.Run.created_at.desc()).limit(limit).offset(offset).all()
@@ -145,6 +154,7 @@ def get_runs_by_organization(
             project_name=project_name,
             status=run.status,
             trigger=run.trigger,
+            env=run.env,
             trace_id=run.trace_id,
             error=run.error,
             retry_group_id=run.retry_group_id,

--- a/ada_backend/routers/project_router.py
+++ b/ada_backend/routers/project_router.py
@@ -254,6 +254,7 @@ async def run_env_agent_endpoint(
         return await run_with_tracking(
             project_id=project_id,
             trigger=CallType.API,
+            env=env,
             runner_coro=run_env_agent(
                 project_id=project_id,
                 input_data=input_data,
@@ -361,6 +362,7 @@ async def chat(
         return await run_with_tracking(
             project_id=project_id,
             trigger=CallType.SANDBOX,
+            env=environment,
             runner_coro=run_agent(
                 project_id=project_id,
                 graph_runner_id=graph_runner_id,
@@ -431,6 +433,7 @@ async def chat_async(
         session,
         project_id=project_id,
         trigger=CallType.SANDBOX,
+        env=environment,
     )
     setup_tracing_context(session=session, project_id=project_id)
     set_tracing_span(run_id=str(run.id))
@@ -485,6 +488,7 @@ async def chat_env(
         return await run_with_tracking(
             project_id=project_id,
             trigger=CallType.SANDBOX,
+            env=env,
             runner_coro=run_env_agent(
                 project_id=project_id,
                 input_data=input_data,

--- a/ada_backend/routers/run_router.py
+++ b/ada_backend/routers/run_router.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import CallType, RunStatus
+from ada_backend.database.models import CallType, EnvType, RunStatus
 from ada_backend.database.setup_db import get_db
 from ada_backend.routers.auth_router import (
     UserRights,
@@ -139,7 +139,7 @@ def retry_run_endpoint(
             session=session,
             run_id=run_id,
             project_id=project_id,
-            env=body.env.value if body.env else None,
+            env=body.env,
             graph_runner_id=body.graph_runner_id,
         )
     except RunNotFound as exc:
@@ -167,7 +167,8 @@ def list_organization_runs(
     page_size: int = Query(50, ge=1, le=100),
     statuses: List[RunStatus] = Query(None),
     project_ids: List[UUID] = Query(None),
-    trigger: Optional[CallType] = None,
+    triggers: List[CallType] = Query(None),
+    envs: List[EnvType] = Query(None),
     date_from: Optional[datetime] = None,
     date_to: Optional[datetime] = None,
 ) -> OrgRunListResponse:
@@ -178,7 +179,8 @@ def list_organization_runs(
         page_size=page_size,
         statuses=statuses,
         project_ids=project_ids,
-        trigger=trigger,
+        triggers=triggers,
+        envs=envs,
         date_from=date_from,
         date_to=date_to,
     )

--- a/ada_backend/routers/webhooks/webhook_internal_router.py
+++ b/ada_backend/routers/webhooks/webhook_internal_router.py
@@ -112,6 +112,7 @@ async def run_project_internal(
             project_id=project_id,
             trigger=trigger,
             event_id=event_id,
+            env=env,
         )
         run_id = run.id
 
@@ -178,14 +179,16 @@ async def run_workflow_internal(
     Internal endpoint for webhook workers, requires webhook API key.
     Deprecated: use POST /internal/webhooks/{webhook_id}/execute instead.
     """
+    env = EnvType.PRODUCTION
     try:
         return await run_with_tracking(
             project_id=project_id,
             trigger=CallType.WEBHOOK,
+            env=env,
             runner_coro=run_env_agent(
                 project_id=project_id,
                 input_data=input_data,
-                env=EnvType.PRODUCTION,
+                env=env,
                 call_type=CallType.WEBHOOK,
             ),
         )

--- a/ada_backend/schemas/run_schema.py
+++ b/ada_backend/schemas/run_schema.py
@@ -26,6 +26,7 @@ class RunResponseSchema(BaseModel):
     project_id: UUID
     status: RunStatus
     trigger: CallType
+    env: Optional[EnvType] = None
     webhook_id: Optional[UUID] = None
     integration_trigger_id: Optional[UUID] = None
     event_id: Optional[str] = None
@@ -71,6 +72,7 @@ class OrgRunResponseSchema(BaseModel):
     project_name: str
     status: RunStatus
     trigger: CallType
+    env: Optional[EnvType] = None
     trace_id: Optional[str] = None
     error: Optional[dict] = None
     retry_group_id: Optional[UUID] = None

--- a/ada_backend/services/run_service.py
+++ b/ada_backend/services/run_service.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from ada_backend.database.models import CallType, RunStatus
+from ada_backend.database.models import CallType, EnvType, RunStatus
 from ada_backend.database.setup_db import get_db_session
 from ada_backend.mixpanel_analytics import track_run_completed
 from ada_backend.repositories import run_repository
@@ -79,6 +79,7 @@ async def run_with_tracking(
     integration_trigger_id: UUID | None = None,
     run_id: UUID | None = None,
     event_id: str | None = None,
+    env: EnvType | None = None,
 ) -> ChatResponse:
     """
     Create a run record (or use existing run_id), set it to RUNNING, execute the runner coroutine,
@@ -97,6 +98,7 @@ async def run_with_tracking(
                 webhook_id=webhook_id,
                 integration_trigger_id=integration_trigger_id,
                 event_id=event_id,
+                env=env,
             )
             run_id = run.id
         set_tracing_span(run_id=str(run_id))
@@ -239,6 +241,7 @@ def create_run(
     attempt_number: int = 1,
     event_id: str | None = None,
     retry_group_id: UUID | None = None,
+    env: EnvType | None = None,
 ) -> RunResponseSchema:
     project = get_project(session, project_id=project_id)
     if not project:
@@ -252,6 +255,7 @@ def create_run(
         event_id=event_id,
         attempt_number=attempt_number,
         retry_group_id=retry_group_id,
+        env=env,
     )
     return RunResponseSchema.model_validate(run, from_attributes=True)
 
@@ -291,7 +295,8 @@ def get_org_runs(
     page_size: int = 50,
     statuses: list[RunStatus] | None = None,
     project_ids: list[UUID] | None = None,
-    trigger: CallType | None = None,
+    triggers: list[CallType] | None = None,
+    envs: list[EnvType] | None = None,
     date_from=None,
     date_to=None,
 ) -> tuple[list[OrgRunResponseSchema], int]:
@@ -300,7 +305,8 @@ def get_org_runs(
         organization_id=organization_id,
         statuses=statuses,
         project_ids=project_ids,
-        trigger=trigger,
+        triggers=triggers,
+        envs=envs,
         date_from=date_from,
         date_to=date_to,
     )
@@ -312,7 +318,8 @@ def get_org_runs(
         offset=offset,
         statuses=statuses,
         project_ids=project_ids,
-        trigger=trigger,
+        triggers=triggers,
+        envs=envs,
         date_from=date_from,
         date_to=date_to,
     )
@@ -406,7 +413,7 @@ def retry_run(
     session: Session,
     run_id: UUID,
     project_id: UUID,
-    env: str | None = None,
+    env: EnvType | None = None,
     graph_runner_id: UUID | None = None,
 ) -> AsyncRunAcceptedSchema:
     if env is None and graph_runner_id is None:
@@ -433,6 +440,7 @@ def retry_run(
         event_id=run.event_id,
         retry_group_id=retry_group_id,
         attempt_number=next_attempt,
+        env=env,
     )
 
     setup_tracing_context(session=session, project_id=project_id)
@@ -441,7 +449,7 @@ def retry_run(
     pushed = push_run_task(
         run_id=retried_run.id,
         project_id=project_id,
-        env=env,
+        env=env.value if env else None,
         input_data=input_data,
         trigger=run.trigger.value,
         graph_runner_id=graph_runner_id,

--- a/ada_backend/services/webhooks/webhook_service.py
+++ b/ada_backend/services/webhooks/webhook_service.py
@@ -157,6 +157,7 @@ async def process_direct_trigger_event(
         project_id=project_id,
         trigger=CallType.WEBHOOK,
         event_id=event_id,
+        env=EnvType(env),
     )
     if run.retry_group_id is None:
         raise WebhookServiceError("Run retry group id was not initialized")
@@ -295,6 +296,7 @@ async def _run_trigger(
     event_id: str | None = None,
 ) -> WebhookExecuteResult:
     project_id = UUID(trigger.project_id)
+    env = EnvType.PRODUCTION
     try:
         response = await run_with_tracking(
             project_id=project_id,
@@ -302,10 +304,11 @@ async def _run_trigger(
             webhook_id=UUID(trigger.webhook_id),
             integration_trigger_id=UUID(trigger.id),
             event_id=event_id,
+            env=env,
             runner_coro=run_env_agent(
                 project_id=project_id,
                 input_data=input_base,
-                env=EnvType.PRODUCTION,
+                env=env,
                 call_type=CallType.WEBHOOK,
             ),
         )

--- a/frontend/src/api/observability.ts
+++ b/frontend/src/api/observability.ts
@@ -15,7 +15,8 @@ export interface OrgRunsParams {
   page_size?: number
   statuses?: string[]
   project_ids?: string[]
-  trigger?: string
+  triggers?: string[]
+  envs?: string[]
   date_from?: string
   date_to?: string
 }

--- a/frontend/src/composables/queries/useOrgRunsQuery.ts
+++ b/frontend/src/composables/queries/useOrgRunsQuery.ts
@@ -10,6 +10,7 @@ export interface OrgRun {
   project_name: string
   status: 'pending' | 'running' | 'completed' | 'failed'
   trigger: string
+  env: 'draft' | 'production' | null
   trace_id: string | null
   error: Record<string, any> | null
   retry_group_id: string | null

--- a/frontend/src/pages/org/[orgId]/runs.vue
+++ b/frontend/src/pages/org/[orgId]/runs.vue
@@ -448,19 +448,25 @@ definePage({
             <VIcon icon="tabler-refresh" size="14" class="me-1" />
             Retry
           </VBtn>
-          <span v-else-if="item.input_available" class="d-inline-block">
-            <VBtn
-              size="x-small"
-              variant="tonal"
-              disabled
-            >
-              <VIcon icon="tabler-refresh" size="14" class="me-1" />
-              Retry
-            </VBtn>
-            <VTooltip activator="parent" location="top">
-              Environment missing — this legacy run cannot be retried
-            </VTooltip>
-          </span>
+          <VMenu v-else-if="item.input_available" location="bottom">
+            <template #activator="{ props: menuProps }">
+              <VBtn
+                v-bind="menuProps"
+                size="x-small"
+                variant="tonal"
+                :loading="retryLoading === item.id"
+              >
+                <VIcon icon="tabler-refresh" size="14" class="me-1" />
+                Retry
+                <VIcon icon="tabler-chevron-down" size="14" class="ms-1" />
+              </VBtn>
+            </template>
+            <VList density="compact">
+              <VListItem v-for="env in allEnvValues" :key="env" @click="retryRun(item, env)">
+                <VListItemTitle>{{ envLabelMap[env] ?? env }}</VListItemTitle>
+              </VListItem>
+            </VList>
+          </VMenu>
           <span v-else class="text-disabled">--</span>
         </template>
 

--- a/frontend/src/pages/org/[orgId]/runs.vue
+++ b/frontend/src/pages/org/[orgId]/runs.vue
@@ -32,7 +32,8 @@ const page = ref(1)
 const pageSize = ref(50)
 const selectedStatuses = ref<string[]>(['pending', 'running', 'completed', 'failed'])
 const selectedProjectIds = ref<string[]>([])
-const triggerFilter = ref<string | undefined>(undefined)
+const selectedTriggers = ref<string[]>(['api', 'sandbox', 'webhook', 'cron', 'qa'])
+const selectedEnvs = ref<string[]>(['draft', 'production'])
 const dateFrom = ref<string | undefined>(undefined)
 const dateTo = ref<string | undefined>(undefined)
 
@@ -53,12 +54,23 @@ const allStatusesSelected = computed(() =>
   selectedStatuses.value.length === allStatusValues.length
 )
 
+const allTriggerValues = ['api', 'sandbox', 'webhook', 'cron', 'qa']
+const allTriggersSelected = computed(() =>
+  selectedTriggers.value.length === allTriggerValues.length
+)
+
+const allEnvValues = ['draft', 'production']
+const allEnvsSelected = computed(() =>
+  selectedEnvs.value.length === allEnvValues.length
+)
+
 const params = computed<OrgRunsParams>(() => ({
   page: page.value,
   page_size: pageSize.value,
   ...(!allStatusesSelected.value && selectedStatuses.value.length > 0 && { statuses: selectedStatuses.value }),
   ...(!allProjectsSelected.value && selectedProjectIds.value.length > 0 && { project_ids: selectedProjectIds.value }),
-  ...(triggerFilter.value && { trigger: triggerFilter.value }),
+  ...(!allTriggersSelected.value && selectedTriggers.value.length > 0 && { triggers: selectedTriggers.value }),
+  ...(!allEnvsSelected.value && selectedEnvs.value.length > 0 && { envs: selectedEnvs.value }),
   ...(dateFrom.value && { date_from: dateFrom.value }),
   ...(dateTo.value && { date_to: dateTo.value }),
 }))
@@ -70,13 +82,51 @@ const totalItems = computed(() => data.value?.pagination.total_items ?? 0)
 
 const headers = [
   { title: 'Project', key: 'project_name', sortable: false },
+  { title: 'Trigger', key: 'trigger', sortable: false, width: '100px' },
+  { title: 'Env', key: 'env', sortable: false, width: '110px' },
   { title: 'Date', key: 'created_at', sortable: false },
   { title: 'Status', key: 'status', sortable: false },
   { title: 'Input', key: 'input', sortable: false, width: '80px' },
-  { title: 'Retry', key: 'retry', sortable: false, width: '140px' },
+  { title: 'Retry', key: 'retry', sortable: false, width: '100px' },
   { title: 'Attempts', key: 'attempt_count', sortable: false, width: '100px' },
   { title: 'Trace', key: 'trace', sortable: false, width: '80px' },
 ]
+
+const triggerLabelMap: Record<string, string> = {
+  api: 'API',
+  sandbox: 'Sandbox',
+  webhook: 'Webhook',
+  cron: 'Cron',
+  qa: 'QA',
+}
+
+const envColorMap: Record<string, string> = {
+  draft: 'warning',
+  production: 'success',
+}
+
+const envLabelMap: Record<string, string> = {
+  draft: 'Draft',
+  production: 'Prod',
+}
+
+const agentIdByProjectId = computed(() => {
+  const map = new Map<string, string>()
+  if (agents.value) {
+    for (const a of agents.value) {
+      if (a.project_id) map.set(a.project_id, a.id)
+    }
+  }
+  return map
+})
+
+const getProjectUrl = (projectId: string): string => {
+  const orgId = selectedOrgId.value
+  if (!orgId) return '#'
+  const agentId = agentIdByProjectId.value.get(projectId)
+  if (agentId) return `/org/${orgId}/agents/${agentId}`
+  return `/org/${orgId}/projects/${projectId}`
+}
 
 const statusOptions = [
   { title: 'Pending', value: 'pending' },
@@ -86,12 +136,16 @@ const statusOptions = [
 ]
 
 const triggerOptions = [
-  { title: 'All', value: undefined },
   { title: 'API', value: 'api' },
   { title: 'Sandbox', value: 'sandbox' },
   { title: 'Webhook', value: 'webhook' },
   { title: 'Cron', value: 'cron' },
   { title: 'QA', value: 'qa' },
+]
+
+const envOptions = [
+  { title: 'Draft', value: 'draft' },
+  { title: 'Production', value: 'production' },
 ]
 
 const statusColorMap: Record<string, string> = {
@@ -107,12 +161,13 @@ const resetFilters = () => {
   page.value = 1
   selectedStatuses.value = [...allStatusValues]
   selectedProjectIds.value = [...allProjectIds.value]
-  triggerFilter.value = undefined
+  selectedTriggers.value = [...allTriggerValues]
+  selectedEnvs.value = [...allEnvValues]
   dateFrom.value = undefined
   dateTo.value = undefined
 }
 
-watch([selectedStatuses, selectedProjectIds, triggerFilter, dateFrom, dateTo], () => {
+watch([selectedStatuses, selectedProjectIds, selectedTriggers, selectedEnvs, dateFrom, dateTo], () => {
   page.value = 1
 })
 
@@ -233,14 +288,54 @@ definePage({
           </VSelect>
 
           <VSelect
-            v-model="triggerFilter"
+            v-model="selectedTriggers"
             :items="triggerOptions"
-            label="Trigger"
+            multiple
             density="compact"
             variant="outlined"
             hide-details
-            style="min-inline-size: 140px; max-inline-size: 160px"
-          />
+            label="Trigger"
+            style="min-inline-size: 160px; max-inline-size: 220px"
+          >
+            <template #prepend-item>
+              <VListItem @click="selectedTriggers = allTriggersSelected ? [] : [...allTriggerValues]">
+                <template #prepend>
+                  <VCheckboxBtn :model-value="allTriggersSelected" :indeterminate="selectedTriggers.length > 0 && !allTriggersSelected" />
+                </template>
+                <VListItemTitle>All Triggers</VListItemTitle>
+              </VListItem>
+              <VDivider />
+            </template>
+            <template #selection="{ index }">
+              <span v-if="allTriggersSelected && index === 0">All Triggers</span>
+              <span v-else-if="!allTriggersSelected && index === 0">{{ selectedTriggers.length }} trigger{{ selectedTriggers.length > 1 ? 's' : '' }}</span>
+            </template>
+          </VSelect>
+
+          <VSelect
+            v-model="selectedEnvs"
+            :items="envOptions"
+            multiple
+            density="compact"
+            variant="outlined"
+            hide-details
+            label="Env"
+            style="min-inline-size: 140px; max-inline-size: 200px"
+          >
+            <template #prepend-item>
+              <VListItem @click="selectedEnvs = allEnvsSelected ? [] : [...allEnvValues]">
+                <template #prepend>
+                  <VCheckboxBtn :model-value="allEnvsSelected" :indeterminate="selectedEnvs.length > 0 && !allEnvsSelected" />
+                </template>
+                <VListItemTitle>All Envs</VListItemTitle>
+              </VListItem>
+              <VDivider />
+            </template>
+            <template #selection="{ index }">
+              <span v-if="allEnvsSelected && index === 0">All Envs</span>
+              <span v-else-if="!allEnvsSelected && index === 0">{{ selectedEnvs.length }} env{{ selectedEnvs.length > 1 ? 's' : '' }}</span>
+            </template>
+          </VSelect>
 
           <VTextField
             v-model="dateFrom"
@@ -263,7 +358,7 @@ definePage({
           />
 
           <VBtn
-            v-if="!allStatusesSelected || !allProjectsSelected || triggerFilter || dateFrom || dateTo"
+            v-if="!allStatusesSelected || !allProjectsSelected || !allTriggersSelected || !allEnvsSelected || dateFrom || dateTo"
             variant="text"
             size="small"
             @click="resetFilters"
@@ -298,7 +393,24 @@ definePage({
         @update:items-per-page="pageSize = $event"
       >
         <template #item.project_name="{ item }">
-          <span class="font-weight-medium">{{ item.project_name }}</span>
+          <RouterLink
+            :to="getProjectUrl(item.project_id)"
+            class="font-weight-medium text-primary text-decoration-none"
+            @click.stop
+          >
+            {{ item.project_name }}
+          </RouterLink>
+        </template>
+
+        <template #item.trigger="{ item }">
+          <span class="text-medium-emphasis text-caption">{{ triggerLabelMap[item.trigger] || item.trigger }}</span>
+        </template>
+
+        <template #item.env="{ item }">
+          <VChip v-if="item.env" :color="envColorMap[item.env] || 'default'" size="small" variant="tonal">
+            {{ envLabelMap[item.env] ?? item.env }}
+          </VChip>
+          <span v-else class="text-disabled">--</span>
         </template>
 
         <template #item.created_at="{ item }">
@@ -326,29 +438,29 @@ definePage({
         </template>
 
         <template #item.retry="{ item }">
-          <template v-if="item.input_available">
-            <VMenu location="bottom">
-              <template #activator="{ props: menuProps }">
-                <VBtn
-                  v-bind="menuProps"
-                  size="x-small"
-                  variant="tonal"
-                  :loading="retryLoading === item.id"
-                >
-                  Retry
-                  <VIcon icon="tabler-chevron-down" size="14" class="ms-1" />
-                </VBtn>
-              </template>
-              <VList density="compact">
-                <VListItem @click="retryRun(item, 'draft')">
-                  <VListItemTitle>Draft</VListItemTitle>
-                </VListItem>
-                <VListItem @click="retryRun(item, 'production')">
-                  <VListItemTitle>Production</VListItemTitle>
-                </VListItem>
-              </VList>
-            </VMenu>
-          </template>
+          <VBtn
+            v-if="item.input_available && item.env"
+            size="x-small"
+            variant="tonal"
+            :loading="retryLoading === item.id"
+            @click="retryRun(item, item.env)"
+          >
+            <VIcon icon="tabler-refresh" size="14" class="me-1" />
+            Retry
+          </VBtn>
+          <span v-else-if="item.input_available" class="d-inline-block">
+            <VBtn
+              size="x-small"
+              variant="tonal"
+              disabled
+            >
+              <VIcon icon="tabler-refresh" size="14" class="me-1" />
+              Retry
+            </VBtn>
+            <VTooltip activator="parent" location="top">
+              Environment missing — this legacy run cannot be retried
+            </VTooltip>
+          </span>
           <span v-else class="text-disabled">--</span>
         </template>
 

--- a/mcp_server/tools/runs.py
+++ b/mcp_server/tools/runs.py
@@ -73,7 +73,16 @@ def register(mcp: FastMCP) -> None:
         ] = None,
         trigger: Annotated[
             Optional[str],
-            Field(description="Filter by trigger type: 'api', 'sandbox', 'webhook', 'cron', or 'qa'."),
+            Field(
+                description=(
+                    "Filter by trigger type: 'api', 'sandbox', 'webhook', 'cron', or 'qa'. "
+                    "Comma-separated for multiple."
+                )
+            ),
+        ] = None,
+        env: Annotated[
+            Optional[str],
+            Field(description="Filter by environment: 'draft' or 'production'. Comma-separated for multiple."),
         ] = None,
         date_from: Annotated[
             Optional[str],
@@ -104,7 +113,9 @@ def register(mcp: FastMCP) -> None:
         if status is not None:
             params["statuses"] = status
         if trigger is not None:
-            params["trigger"] = trigger
+            params["triggers"] = [t for t in (t.strip() for t in trigger.split(",")) if t]
+        if env is not None:
+            params["envs"] = [e for e in (e.strip() for e in env.split(",")) if e]
         if date_from is not None:
             params["date_from"] = date_from
         if date_to is not None:
@@ -164,10 +175,7 @@ def register(mcp: FastMCP) -> None:
         payload: Annotated[
             dict,
             Field(
-                description=(
-                    'Request body dict — must contain "messages", may contain additional '
-                    "Start-node fields."
-                ),
+                description=('Request body dict — must contain "messages", may contain additional Start-node fields.'),
             ),
         ],
         timeout: Annotated[int, Field(description="Max seconds to wait for completion.")] = 60,
@@ -242,8 +250,7 @@ def register(mcp: FastMCP) -> None:
                         "status": "completed",
                         "run_id": run_id,
                         "hint": (
-                            f"Run completed but result fetch failed. "
-                            f"Use get_run_result('{project_id}', '{run_id}')."
+                            f"Run completed but result fetch failed. Use get_run_result('{project_id}', '{run_id}')."
                         ),
                     }
             if status == "failed":

--- a/tests/ada_backend/services/test_org_runs.py
+++ b/tests/ada_backend/services/test_org_runs.py
@@ -56,7 +56,8 @@ class TestGetOrgRuns:
             organization_id=org_id,
             statuses=None,
             project_ids=None,
-            trigger=None,
+            triggers=None,
+            envs=None,
             date_from=None,
             date_to=None,
         )
@@ -76,13 +77,13 @@ class TestGetOrgRuns:
                 organization_id=org_id,
                 statuses=[RunStatus.FAILED],
                 project_ids=[project_id],
-                trigger=CallType.WEBHOOK,
+                triggers=[CallType.WEBHOOK],
             )
 
         call_kwargs = repo.count_runs_by_organization.call_args.kwargs
         assert call_kwargs["statuses"] == [RunStatus.FAILED]
         assert call_kwargs["project_ids"] == [project_id]
-        assert call_kwargs["trigger"] == CallType.WEBHOOK
+        assert call_kwargs["triggers"] == [CallType.WEBHOOK]
 
     def test_string_error_coerced_to_dict(self):
         session = self._make_session()

--- a/tests/ada_backend/services/test_run_service.py
+++ b/tests/ada_backend/services/test_run_service.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import pytest
 
-from ada_backend.database.models import CallType, RunStatus
+from ada_backend.database.models import CallType, EnvType, RunStatus
 from ada_backend.services.errors import InvalidRunStatusTransition, RunNotFound
 from ada_backend.services.run_service import fail_pending_run, retry_run
 
@@ -23,6 +23,7 @@ def _make_fake_run(run_id, project_id, status=RunStatus.FAILED):
     run.trace_id = None
     run.result_id = None
     run.error = {"message": "timeout", "type": "DeadLetter"}
+    run.env = None
     run.retry_group_id = None
     run.attempt_number = 1
     run.started_at = None
@@ -167,7 +168,7 @@ class TestRetryRun:
                 session=session,
                 run_id=run_id,
                 project_id=project_id,
-                env="draft",
+                env=EnvType.DRAFT,
             )
 
         assert result.run_id == new_run_id
@@ -194,4 +195,4 @@ class TestRetryRun:
         ):
             repo.get_run.return_value = existing_run
             with pytest.raises(ValueError, match="Run input not found for retry"):
-                retry_run(session=session, run_id=run_id, project_id=project_id, env="production")
+                retry_run(session=session, run_id=run_id, project_id=project_id, env=EnvType.PRODUCTION)


### PR DESCRIPTION
# Improve runs visualization

## Summary
- Track the execution environment (draft/production) on every run and display it in the runs table
- Add Trigger and Env columns to the runs table with multi-select checkbox filters
- Make project names clickable — navigates to the workflow or agent page
- Retry runs directly from the original environment instead of asking the user to pick

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runs now include an environment context (draft, production) shown in run details and table.
  * Run list API and UI support multi-select triggers and environments via new "triggers" and "envs" filters.
  * Retry control uses the run's env when available and falls back to an env selector when needed.
  * Project links in runs table navigate to agent route when applicable; table includes Trigger and Env columns.

* **Tests**
  * Updated tests to use the new environment enum and pluralized filter interface.

* **Documentation**
  * API docs updated: GET /org/{organization_id}/runs now documents "triggers" and "envs" query params.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->