### PR TITLE
feat(Ingestion): use uuid for chunks for db ingetsion DRA-1173

### DIFF
--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -143,6 +143,19 @@ def upgrade() -> None:
         LOGGER.info("INGESTION_DB_URL not set. Skipping chunk_id UUID migration.")
         return
 
+    backend_conn = op.get_bind()
+    db_source_rows = backend_conn.execute(
+        text("SELECT id::text, qdrant_collection_name FROM data_sources WHERE type = 'database'")
+    ).fetchall()
+    db_source_ids = {row[0] for row in db_source_rows}
+    source_to_collection = {sid: col for sid, col in db_source_rows if col is not None}
+
+    if not db_source_ids:
+        LOGGER.info("No database-type sources found. Nothing to migrate.")
+        return
+
+    LOGGER.info(f"Found {len(db_source_ids)} database-type sources")
+
     ingestion_engine = create_engine(settings.INGESTION_DB_URL, isolation_level="AUTOCOMMIT")
     ingestion_conn = ingestion_engine.connect()
 
@@ -158,30 +171,31 @@ def upgrade() -> None:
             LOGGER.info("No org chunk tables found. Nothing to migrate.")
             return
 
+        source_ids_sql = ", ".join(f"'{sid}'" for sid in db_source_ids)
         all_mappings: dict[str, list[tuple[str, str, str]]] = {}
 
         for (table_name,) in tables:
-            has_sync_id = ingestion_conn.execute(
+            has_source_id = ingestion_conn.execute(
                 text(
                     "SELECT 1 FROM information_schema.columns "
-                    "WHERE table_schema = 'public' AND table_name = :tn AND column_name = 'sync_id'"
+                    "WHERE table_schema = 'public' AND table_name = :tn AND column_name = 'source_id'"
                 ),
                 {"tn": table_name},
             ).fetchone()
 
-            if not has_sync_id:
-                LOGGER.info(f"Table {table_name} has no sync_id column, skipping")
+            if not has_source_id:
+                LOGGER.info(f"Table {table_name} has no source_id column, skipping")
                 continue
 
             rows = ingestion_conn.execute(
                 text(
                     f'SELECT chunk_id, source_id::text FROM public."{table_name}" '
-                    f"WHERE sync_id IS NOT NULL AND chunk_id !~* '{UUID_REGEX}'"
+                    f"WHERE source_id::text IN ({source_ids_sql}) AND chunk_id !~* '{UUID_REGEX}'"
                 )
             ).fetchall()
 
             if not rows:
-                LOGGER.info(f"Table {table_name}: no non-UUID chunk_ids found")
+                LOGGER.info(f"Table {table_name}: no non-UUID chunk_ids found for database sources")
                 continue
 
             table_mapping = [(old_cid, sid, str(uuid4())) for old_cid, sid in rows]
@@ -232,23 +246,13 @@ def upgrade() -> None:
             LOGGER.info("QDRANT_CLUSTER_URL or QDRANT_API_KEY not set. Skipping Qdrant payload update.")
             return
 
-        LOGGER.info("Phase 2: Updating Qdrant payloads...")
-        qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
-        headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
-
-        backend_conn = op.get_bind()
-        db_sources = backend_conn.execute(
-            text(
-                "SELECT id::text, qdrant_collection_name FROM data_sources "
-                "WHERE type = 'database' AND qdrant_collection_name IS NOT NULL"
-            )
-        ).fetchall()
-
-        source_to_collection = {sid: col for sid, col in db_sources}
-
         if not source_to_collection:
             LOGGER.info("No DB sources with Qdrant collections found. Skipping Qdrant update.")
             return
+
+        LOGGER.info("Phase 2: Updating Qdrant payloads...")
+        qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
+        headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
 
         source_chunk_maps: dict[str, dict[str, str]] = {}
         log_rows = ingestion_conn.execute(

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -1,0 +1,370 @@
+"""migrate_db_source_chunk_ids_to_uuid
+
+Revision ID: c7d8e9f0a1b2
+Revises: 67df5c87b638
+Create Date: 2026-04-27
+
+"""
+
+import logging
+from typing import Sequence, Union
+from uuid import uuid4
+
+import httpx
+from sqlalchemy import create_engine, text
+
+from settings import settings
+
+revision: str = "c7d8e9f0a1b2"
+down_revision: Union[str, None] = "67df5c87b638"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy = "migrate-first"
+
+LOGGER = logging.getLogger("alembic.migration")
+LOGGER.setLevel(logging.DEBUG)
+
+if not LOGGER.handlers:
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(levelname)-5.5s [%(name)s] %(message)s")
+    console_handler.setFormatter(formatter)
+    LOGGER.addHandler(console_handler)
+    LOGGER.propagate = False
+
+UUID_REGEX = r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+MIGRATION_LOG_TABLE = "_chunk_id_migration_log"
+DB_BATCH_SIZE = 500
+QDRANT_SCROLL_BATCH = 256
+
+
+def _batch_update_db(ingestion_conn, table_name: str, mapping: list[tuple[str, str, str]]):
+    for i in range(0, len(mapping), DB_BATCH_SIZE):
+        batch = mapping[i : i + DB_BATCH_SIZE]
+        values_parts = []
+        params = {}
+        for idx, (old_cid, sid, new_uuid) in enumerate(batch):
+            values_parts.append(f"(:old_{idx}, CAST(:sid_{idx} AS uuid), :new_{idx})")
+            params[f"old_{idx}"] = old_cid
+            params[f"sid_{idx}"] = sid
+            params[f"new_{idx}"] = new_uuid
+        values_sql = ", ".join(values_parts)
+        ingestion_conn.execute(
+            text(
+                f'UPDATE public."{table_name}" AS t '
+                f"SET chunk_id = v.new_uuid "
+                f"FROM (VALUES {values_sql}) AS v(old_cid, sid, new_uuid) "
+                f"WHERE t.chunk_id = v.old_cid AND t.source_id = v.sid"
+            ),
+            params,
+        )
+        LOGGER.info(f"  DB batch {i // DB_BATCH_SIZE + 1}: updated {len(batch)} rows")
+
+
+def _scroll_and_update_qdrant(
+    client: httpx.Client,
+    qdrant_url: str,
+    headers: dict,
+    collection_name: str,
+    source_id: str,
+    chunk_id_map: dict[str, str],
+):
+    offset = None
+    updated = 0
+
+    while True:
+        scroll_body: dict = {
+            "limit": QDRANT_SCROLL_BATCH,
+            "with_payload": ["chunk_id", "source_id"],
+            "with_vector": False,
+            "filter": {"must": [{"key": "source_id", "match": {"value": source_id}}]},
+        }
+        if offset is not None:
+            scroll_body["offset"] = offset
+
+        resp = client.post(
+            f"{qdrant_url}/collections/{collection_name}/points/scroll",
+            headers=headers,
+            json=scroll_body,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("result", {})
+        points = result.get("points", [])
+
+        if not points:
+            break
+
+        for point in points:
+            old_cid = point.get("payload", {}).get("chunk_id")
+            new_uuid = chunk_id_map.get(old_cid)
+            if new_uuid is None:
+                continue
+            client.post(
+                f"{qdrant_url}/collections/{collection_name}/points/payload?wait=true",
+                headers=headers,
+                json={"payload": {"chunk_id": new_uuid}, "points": [point["id"]]},
+            ).raise_for_status()
+            updated += 1
+
+        if updated and updated % 500 == 0:
+            LOGGER.info(f"    Qdrant source {source_id}: {updated} points updated so far")
+
+        offset = result.get("next_page_offset")
+        if offset is None:
+            break
+
+    return updated
+
+
+def upgrade() -> None:
+    if not settings.INGESTION_DB_URL:
+        LOGGER.info("INGESTION_DB_URL not set. Skipping chunk_id UUID migration.")
+        return
+
+    ingestion_engine = create_engine(settings.INGESTION_DB_URL, isolation_level="AUTOCOMMIT")
+    ingestion_conn = ingestion_engine.connect()
+
+    try:
+        tables = ingestion_conn.execute(
+            text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'public' AND table_name LIKE 'org_%_chunks'"
+            )
+        ).fetchall()
+
+        if not tables:
+            LOGGER.info("No org chunk tables found. Nothing to migrate.")
+            return
+
+        all_mappings: dict[str, list[tuple[str, str, str]]] = {}
+
+        for (table_name,) in tables:
+            has_sync_id = ingestion_conn.execute(
+                text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema = 'public' AND table_name = :tn AND column_name = 'sync_id'"
+                ),
+                {"tn": table_name},
+            ).fetchone()
+
+            if not has_sync_id:
+                LOGGER.info(f"Table {table_name} has no sync_id column, skipping")
+                continue
+
+            rows = ingestion_conn.execute(
+                text(
+                    f'SELECT chunk_id, source_id::text FROM public."{table_name}" '
+                    f"WHERE sync_id IS NOT NULL AND chunk_id !~ '{UUID_REGEX}'"
+                )
+            ).fetchall()
+
+            if not rows:
+                LOGGER.info(f"Table {table_name}: no non-UUID chunk_ids found")
+                continue
+
+            table_mapping = [(old_cid, sid, str(uuid4())) for old_cid, sid in rows]
+            all_mappings[table_name] = table_mapping
+            LOGGER.info(f"Table {table_name}: {len(table_mapping)} chunk_ids to migrate")
+
+        if not all_mappings:
+            LOGGER.info("No non-UUID chunk_ids found across any table. Migration complete.")
+            return
+
+        ingestion_conn.execute(
+            text(
+                f"CREATE TABLE IF NOT EXISTS public.{MIGRATION_LOG_TABLE} ("
+                "  table_name VARCHAR NOT NULL,"
+                "  old_chunk_id VARCHAR NOT NULL,"
+                "  source_id VARCHAR NOT NULL,"
+                "  new_chunk_id VARCHAR NOT NULL"
+                ")"
+            )
+        )
+        for table_name, mapping in all_mappings.items():
+            for i in range(0, len(mapping), DB_BATCH_SIZE):
+                batch = mapping[i : i + DB_BATCH_SIZE]
+                values_parts = []
+                params = {}
+                for idx, (old_cid, sid, new_uuid) in enumerate(batch):
+                    values_parts.append(f"(:tn_{idx}, :old_{idx}, :sid_{idx}, :new_{idx})")
+                    params[f"tn_{idx}"] = table_name
+                    params[f"old_{idx}"] = old_cid
+                    params[f"sid_{idx}"] = sid
+                    params[f"new_{idx}"] = new_uuid
+                ingestion_conn.execute(
+                    text(
+                        f"INSERT INTO public.{MIGRATION_LOG_TABLE} "
+                        f"(table_name, old_chunk_id, source_id, new_chunk_id) "
+                        f"VALUES {', '.join(values_parts)}"
+                    ),
+                    params,
+                )
+        LOGGER.info(f"Saved migration log ({sum(len(m) for m in all_mappings.values())} entries)")
+
+        LOGGER.info("Phase 1: Updating ingestion DB...")
+        for table_name, mapping in all_mappings.items():
+            _batch_update_db(ingestion_conn, table_name, mapping)
+            LOGGER.info(f"Finished DB update for {table_name} ({len(mapping)} rows)")
+
+        if not settings.QDRANT_CLUSTER_URL or not settings.QDRANT_API_KEY:
+            LOGGER.info("QDRANT_CLUSTER_URL or QDRANT_API_KEY not set. Skipping Qdrant payload update.")
+            return
+
+        LOGGER.info("Phase 2: Updating Qdrant payloads...")
+        qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
+        headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
+
+        from alembic import op
+
+        backend_conn = op.get_bind()
+        db_sources = backend_conn.execute(
+            text(
+                "SELECT id::text, qdrant_collection_name FROM data_sources "
+                "WHERE type = 'database' AND qdrant_collection_name IS NOT NULL"
+            )
+        ).fetchall()
+
+        source_to_collection = {sid: col for sid, col in db_sources}
+
+        if not source_to_collection:
+            LOGGER.info("No DB sources with Qdrant collections found. Skipping Qdrant update.")
+            return
+
+        source_chunk_maps: dict[str, dict[str, str]] = {}
+        for mapping in all_mappings.values():
+            for old_cid, sid, new_uuid in mapping:
+                source_chunk_maps.setdefault(sid, {})[old_cid] = new_uuid
+
+        with httpx.Client(timeout=60) as qdrant_client:
+            resp = qdrant_client.get(f"{qdrant_url}/collections", headers=headers)
+            resp.raise_for_status()
+            existing_collections = {c["name"] for c in resp.json().get("result", {}).get("collections", [])}
+
+            total_updated = 0
+            total_skipped = 0
+
+            for source_id, chunk_id_map in source_chunk_maps.items():
+                collection_name = source_to_collection.get(source_id)
+                if not collection_name or collection_name not in existing_collections:
+                    total_skipped += len(chunk_id_map)
+                    LOGGER.info(
+                        f"  Source {source_id}: collection '{collection_name}' not found, "
+                        f"skipping {len(chunk_id_map)} chunks"
+                    )
+                    continue
+
+                LOGGER.info(
+                    f"  Source {source_id}: scrolling collection '{collection_name}' "
+                    f"({len(chunk_id_map)} chunks to update)"
+                )
+                updated = _scroll_and_update_qdrant(
+                    qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map
+                )
+                total_updated += updated
+                LOGGER.info(f"  Source {source_id}: {updated} Qdrant points updated")
+
+        LOGGER.info(f"Qdrant update complete: {total_updated} updated, {total_skipped} skipped")
+
+    except Exception as e:
+        LOGGER.error(f"Error during chunk_id UUID migration: {e}", exc_info=True)
+        raise
+    finally:
+        ingestion_conn.close()
+        ingestion_engine.dispose()
+
+
+def downgrade() -> None:
+    if not settings.INGESTION_DB_URL:
+        LOGGER.info("INGESTION_DB_URL not set. Skipping downgrade.")
+        return
+
+    ingestion_engine = create_engine(settings.INGESTION_DB_URL, isolation_level="AUTOCOMMIT")
+    ingestion_conn = ingestion_engine.connect()
+
+    try:
+        log_exists = ingestion_conn.execute(
+            text(
+                "SELECT 1 FROM information_schema.tables "
+                f"WHERE table_schema = 'public' AND table_name = '{MIGRATION_LOG_TABLE}'"
+            )
+        ).fetchone()
+
+        if not log_exists:
+            LOGGER.info(f"Migration log table {MIGRATION_LOG_TABLE} not found. Cannot downgrade.")
+            return
+
+        log_rows = ingestion_conn.execute(
+            text(f"SELECT table_name, old_chunk_id, source_id, new_chunk_id FROM public.{MIGRATION_LOG_TABLE}")
+        ).fetchall()
+
+        if not log_rows:
+            LOGGER.info("Migration log is empty. Nothing to downgrade.")
+            return
+
+        all_mappings: dict[str, list[tuple[str, str, str]]] = {}
+        for table_name, old_cid, sid, new_uuid in log_rows:
+            all_mappings.setdefault(table_name, []).append((new_uuid, sid, old_cid))
+
+        LOGGER.info(f"Loaded {len(log_rows)} entries from migration log")
+
+        LOGGER.info("Phase 1: Reverting ingestion DB...")
+        for table_name, mapping in all_mappings.items():
+            _batch_update_db(ingestion_conn, table_name, mapping)
+            LOGGER.info(f"Finished DB revert for {table_name} ({len(mapping)} rows)")
+
+        if not settings.QDRANT_CLUSTER_URL or not settings.QDRANT_API_KEY:
+            LOGGER.info("QDRANT_CLUSTER_URL or QDRANT_API_KEY not set. Skipping Qdrant revert.")
+        else:
+            LOGGER.info("Phase 2: Reverting Qdrant payloads...")
+            qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
+            headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
+
+            from alembic import op
+
+            backend_conn = op.get_bind()
+            db_sources = backend_conn.execute(
+                text(
+                    "SELECT id::text, qdrant_collection_name FROM data_sources "
+                    "WHERE type = 'database' AND qdrant_collection_name IS NOT NULL"
+                )
+            ).fetchall()
+
+            source_to_collection = {sid: col for sid, col in db_sources}
+
+            source_chunk_maps: dict[str, dict[str, str]] = {}
+            for mapping in all_mappings.values():
+                for new_uuid, sid, old_cid in mapping:
+                    source_chunk_maps.setdefault(sid, {})[new_uuid] = old_cid
+
+            with httpx.Client(timeout=60) as qdrant_client:
+                resp = qdrant_client.get(f"{qdrant_url}/collections", headers=headers)
+                resp.raise_for_status()
+                existing_collections = {c["name"] for c in resp.json().get("result", {}).get("collections", [])}
+
+                total_updated = 0
+                for source_id, chunk_id_map in source_chunk_maps.items():
+                    collection_name = source_to_collection.get(source_id)
+                    if not collection_name or collection_name not in existing_collections:
+                        continue
+
+                    LOGGER.info(
+                        f"  Source {source_id}: reverting {len(chunk_id_map)} chunks in collection '{collection_name}'"
+                    )
+                    updated = _scroll_and_update_qdrant(
+                        qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map
+                    )
+                    total_updated += updated
+                    LOGGER.info(f"  Source {source_id}: {updated} Qdrant points reverted")
+
+            LOGGER.info(f"Qdrant revert complete: {total_updated} points reverted")
+
+        ingestion_conn.execute(text(f"DROP TABLE IF EXISTS public.{MIGRATION_LOG_TABLE}"))
+        LOGGER.info(f"Dropped migration log table {MIGRATION_LOG_TABLE}")
+
+    except Exception as e:
+        LOGGER.error(f"Error during chunk_id UUID downgrade: {e}", exc_info=True)
+        raise
+    finally:
+        ingestion_conn.close()
+        ingestion_engine.dispose()

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -1,7 +1,7 @@
 """migrate_db_source_chunk_ids_to_uuid
 
 Revision ID: c7d8e9f0a1b2
-Revises: k2l3m4n5o6p7
+Revises: 93189a98fdf2
 Create Date: 2026-04-27
 
 """
@@ -17,7 +17,7 @@ from sqlalchemy import create_engine, text
 from settings import settings
 
 revision: str = "c7d8e9f0a1b2"
-down_revision: Union[str, None] = "k2l3m4n5o6p7"
+down_revision: Union[str, None] = "93189a98fdf2"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -8,7 +8,7 @@ Create Date: 2026-04-27
 
 import logging
 from typing import Sequence, Union
-from uuid import uuid4
+from uuid import NAMESPACE_DNS, uuid4, uuid5
 
 import httpx
 from alembic import op
@@ -63,6 +63,10 @@ def _batch_update_db(ingestion_conn, table_name: str, mapping: list[tuple[str, s
         LOGGER.info(f"  DB batch {i // DB_BATCH_SIZE + 1}: updated {len(batch)} rows")
 
 
+def _build_legacy_point_id(chunk_id: str, source_id: str) -> str:
+    return str(uuid5(NAMESPACE_DNS, f"{source_id}:{chunk_id}"))
+
+
 def _scroll_and_update_qdrant(
     client: httpx.Client,
     qdrant_url: str,
@@ -70,6 +74,7 @@ def _scroll_and_update_qdrant(
     collection_name: str,
     source_id: str,
     chunk_id_map: dict[str, str],
+    compute_point_id=None,
 ):
     offset = None
     updated = 0
@@ -79,8 +84,8 @@ def _scroll_and_update_qdrant(
     while True:
         scroll_body: dict = {
             "limit": QDRANT_SCROLL_BATCH,
-            "with_payload": ["chunk_id", "source_id"],
-            "with_vector": False,
+            "with_payload": True,
+            "with_vector": True,
             "filter": {"must": [{"key": "source_id", "match": {"value": source_id}}]},
         }
         if offset is not None:
@@ -99,33 +104,57 @@ def _scroll_and_update_qdrant(
             break
 
         page_num += 1
-        page_updated = 0
-        page_failed = 0
+        new_points = []
+        old_ids = []
 
         for point in points:
             old_cid = point.get("payload", {}).get("chunk_id")
-            new_uuid = chunk_id_map.get(old_cid)
-            if new_uuid is None:
+            new_cid = chunk_id_map.get(old_cid)
+            if new_cid is None:
                 continue
+            new_point_id = compute_point_id(new_cid, source_id) if compute_point_id else new_cid
+            payload = {**point["payload"], "chunk_id": new_cid}
+            new_points.append({"id": new_point_id, "payload": payload, "vector": point["vector"]})
+            old_ids.append(point["id"])
+
+        page_updated = 0
+        page_failed = 0
+
+        if new_points:
             try:
-                client.post(
-                    f"{qdrant_url}/collections/{collection_name}/points/payload",
+                client.put(
+                    f"{qdrant_url}/collections/{collection_name}/points?wait=true",
                     headers=headers,
-                    json={"payload": {"chunk_id": new_uuid}, "points": [point["id"]]},
+                    json={"points": new_points},
                 ).raise_for_status()
-                page_updated += 1
             except httpx.HTTPStatusError as exc:
                 LOGGER.warning(
-                    f"    Qdrant set_payload failed for point {point['id']} "
+                    f"    Qdrant upsert failed for page {page_num} "
                     f"(source {source_id}): {exc.response.status_code}"
                 )
-                failed_ids.append(str(point["id"]))
-                page_failed += 1
+                failed_ids.extend(str(pid) for pid in old_ids)
+                page_failed = len(old_ids)
+            else:
+                try:
+                    client.post(
+                        f"{qdrant_url}/collections/{collection_name}/points/delete",
+                        headers=headers,
+                        json={"points": old_ids},
+                    ).raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    LOGGER.warning(
+                        f"    Qdrant delete-old failed for page {page_num} "
+                        f"(source {source_id}): {exc.response.status_code}"
+                    )
+                    failed_ids.extend(str(pid) for pid in old_ids)
+                    page_failed = len(old_ids)
+                else:
+                    page_updated = len(new_points)
 
         updated += page_updated
         LOGGER.info(
             f"    Qdrant source {source_id} page {page_num}: "
-            f"{page_updated} updated, {page_failed} failed, {updated} total"
+            f"{page_updated} replaced, {page_failed} failed, {updated} total"
         )
 
         offset = result.get("next_page_offset")
@@ -371,7 +400,8 @@ def downgrade() -> None:
                         f"  Source {source_id}: reverting {len(chunk_id_map)} chunks in collection '{collection_name}'"
                     )
                     updated = _scroll_and_update_qdrant(
-                        qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map
+                        qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map,
+                        compute_point_id=_build_legacy_point_id,
                     )
                     total_updated += updated
                     LOGGER.info(f"  Source {source_id}: {updated} Qdrant points reverted")

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -1,7 +1,7 @@
 """migrate_db_source_chunk_ids_to_uuid
 
 Revision ID: c7d8e9f0a1b2
-Revises: 67df5c87b638
+Revises: k2l3m4n5o6p7
 Create Date: 2026-04-27
 
 """
@@ -16,7 +16,7 @@ from sqlalchemy import create_engine, text
 from settings import settings
 
 revision: str = "c7d8e9f0a1b2"
-down_revision: Union[str, None] = "67df5c87b638"
+down_revision: Union[str, None] = "k2l3m4n5o6p7"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -11,6 +11,7 @@ from typing import Sequence, Union
 from uuid import uuid4
 
 import httpx
+from alembic import op
 from sqlalchemy import create_engine, text
 
 from settings import settings
@@ -72,6 +73,8 @@ def _scroll_and_update_qdrant(
 ):
     offset = None
     updated = 0
+    failed_ids: list[str] = []
+    page_num = 0
 
     while True:
         scroll_body: dict = {
@@ -95,24 +98,42 @@ def _scroll_and_update_qdrant(
         if not points:
             break
 
+        page_num += 1
+        page_updated = 0
+        page_failed = 0
+
         for point in points:
             old_cid = point.get("payload", {}).get("chunk_id")
             new_uuid = chunk_id_map.get(old_cid)
             if new_uuid is None:
                 continue
-            client.post(
-                f"{qdrant_url}/collections/{collection_name}/points/payload?wait=true",
-                headers=headers,
-                json={"payload": {"chunk_id": new_uuid}, "points": [point["id"]]},
-            ).raise_for_status()
-            updated += 1
+            try:
+                client.post(
+                    f"{qdrant_url}/collections/{collection_name}/points/payload",
+                    headers=headers,
+                    json={"payload": {"chunk_id": new_uuid}, "points": [point["id"]]},
+                ).raise_for_status()
+                page_updated += 1
+            except httpx.HTTPStatusError as exc:
+                LOGGER.warning(
+                    f"    Qdrant set_payload failed for point {point['id']} "
+                    f"(source {source_id}): {exc.response.status_code}"
+                )
+                failed_ids.append(str(point["id"]))
+                page_failed += 1
 
-        if updated and updated % 500 == 0:
-            LOGGER.info(f"    Qdrant source {source_id}: {updated} points updated so far")
+        updated += page_updated
+        LOGGER.info(
+            f"    Qdrant source {source_id} page {page_num}: "
+            f"{page_updated} updated, {page_failed} failed, {updated} total"
+        )
 
         offset = result.get("next_page_offset")
         if offset is None:
             break
+
+    if failed_ids:
+        LOGGER.warning(f"    Qdrant source {source_id}: {len(failed_ids)} points failed: {failed_ids[:20]}")
 
     return updated
 
@@ -155,7 +176,7 @@ def upgrade() -> None:
             rows = ingestion_conn.execute(
                 text(
                     f'SELECT chunk_id, source_id::text FROM public."{table_name}" '
-                    f"WHERE sync_id IS NOT NULL AND chunk_id !~ '{UUID_REGEX}'"
+                    f"WHERE sync_id IS NOT NULL AND chunk_id !~* '{UUID_REGEX}'"
                 )
             ).fetchall()
 
@@ -215,8 +236,6 @@ def upgrade() -> None:
         qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
         headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
 
-        from alembic import op
-
         backend_conn = op.get_bind()
         db_sources = backend_conn.execute(
             text(
@@ -232,9 +251,11 @@ def upgrade() -> None:
             return
 
         source_chunk_maps: dict[str, dict[str, str]] = {}
-        for mapping in all_mappings.values():
-            for old_cid, sid, new_uuid in mapping:
-                source_chunk_maps.setdefault(sid, {})[old_cid] = new_uuid
+        log_rows = ingestion_conn.execute(
+            text(f"SELECT old_chunk_id, source_id, new_chunk_id FROM public.{MIGRATION_LOG_TABLE}")
+        ).fetchall()
+        for old_cid, sid, new_uuid in log_rows:
+            source_chunk_maps.setdefault(sid, {})[old_cid] = new_uuid
 
         with httpx.Client(timeout=60) as qdrant_client:
             resp = qdrant_client.get(f"{qdrant_url}/collections", headers=headers)
@@ -319,8 +340,6 @@ def downgrade() -> None:
             LOGGER.info("Phase 2: Reverting Qdrant payloads...")
             qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
             headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
-
-            from alembic import op
 
             backend_conn = op.get_bind()
             db_sources = backend_conn.execute(

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -8,7 +8,7 @@ Create Date: 2026-04-27
 
 import logging
 from typing import Sequence, Union
-from uuid import NAMESPACE_DNS, uuid4, uuid5
+from uuid import uuid4
 
 import httpx
 from alembic import op
@@ -63,10 +63,6 @@ def _batch_update_db(ingestion_conn, table_name: str, mapping: list[tuple[str, s
         LOGGER.info(f"  DB batch {i // DB_BATCH_SIZE + 1}: updated {len(batch)} rows")
 
 
-def _build_legacy_point_id(chunk_id: str, source_id: str) -> str:
-    return str(uuid5(NAMESPACE_DNS, f"{source_id}:{chunk_id}"))
-
-
 def _scroll_and_update_qdrant(
     client: httpx.Client,
     qdrant_url: str,
@@ -74,7 +70,6 @@ def _scroll_and_update_qdrant(
     collection_name: str,
     source_id: str,
     chunk_id_map: dict[str, str],
-    compute_point_id=None,
 ):
     offset = None
     updated = 0
@@ -84,8 +79,8 @@ def _scroll_and_update_qdrant(
     while True:
         scroll_body: dict = {
             "limit": QDRANT_SCROLL_BATCH,
-            "with_payload": True,
-            "with_vector": True,
+            "with_payload": ["chunk_id", "source_id"],
+            "with_vector": False,
             "filter": {"must": [{"key": "source_id", "match": {"value": source_id}}]},
         }
         if offset is not None:
@@ -104,57 +99,33 @@ def _scroll_and_update_qdrant(
             break
 
         page_num += 1
-        new_points = []
-        old_ids = []
+        page_updated = 0
+        page_failed = 0
 
         for point in points:
             old_cid = point.get("payload", {}).get("chunk_id")
             new_cid = chunk_id_map.get(old_cid)
             if new_cid is None:
                 continue
-            new_point_id = compute_point_id(new_cid, source_id) if compute_point_id else new_cid
-            payload = {**point["payload"], "chunk_id": new_cid}
-            new_points.append({"id": new_point_id, "payload": payload, "vector": point["vector"]})
-            old_ids.append(point["id"])
-
-        page_updated = 0
-        page_failed = 0
-
-        if new_points:
             try:
-                client.put(
-                    f"{qdrant_url}/collections/{collection_name}/points?wait=true",
+                client.post(
+                    f"{qdrant_url}/collections/{collection_name}/points/payload",
                     headers=headers,
-                    json={"points": new_points},
+                    json={"payload": {"chunk_id": new_cid}, "points": [point["id"]]},
                 ).raise_for_status()
+                page_updated += 1
             except httpx.HTTPStatusError as exc:
                 LOGGER.warning(
-                    f"    Qdrant upsert failed for page {page_num} "
+                    f"    Qdrant set_payload failed for point {point['id']} "
                     f"(source {source_id}): {exc.response.status_code}"
                 )
-                failed_ids.extend(str(pid) for pid in old_ids)
-                page_failed = len(old_ids)
-            else:
-                try:
-                    client.post(
-                        f"{qdrant_url}/collections/{collection_name}/points/delete",
-                        headers=headers,
-                        json={"points": old_ids},
-                    ).raise_for_status()
-                except httpx.HTTPStatusError as exc:
-                    LOGGER.warning(
-                        f"    Qdrant delete-old failed for page {page_num} "
-                        f"(source {source_id}): {exc.response.status_code}"
-                    )
-                    failed_ids.extend(str(pid) for pid in old_ids)
-                    page_failed = len(old_ids)
-                else:
-                    page_updated = len(new_points)
+                failed_ids.append(str(point["id"]))
+                page_failed += 1
 
         updated += page_updated
         LOGGER.info(
             f"    Qdrant source {source_id} page {page_num}: "
-            f"{page_updated} replaced, {page_failed} failed, {updated} total"
+            f"{page_updated} updated, {page_failed} failed, {updated} total"
         )
 
         offset = result.get("next_page_offset")
@@ -400,8 +371,7 @@ def downgrade() -> None:
                         f"  Source {source_id}: reverting {len(chunk_id_map)} chunks in collection '{collection_name}'"
                     )
                     updated = _scroll_and_update_qdrant(
-                        qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map,
-                        compute_point_id=_build_legacy_point_id,
+                        qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map
                     )
                     total_updated += updated
                     LOGGER.info(f"  Source {source_id}: {updated} Qdrant points reverted")

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -1,7 +1,7 @@
 """migrate_db_source_chunk_ids_to_uuid
 
 Revision ID: c7d8e9f0a1b2
-Revises: 93189a98fdf2
+Revises: l3m4n5o6p7q8
 Create Date: 2026-04-27
 
 """
@@ -17,7 +17,7 @@ from sqlalchemy import create_engine, text
 from settings import settings
 
 revision: str = "c7d8e9f0a1b2"
-down_revision: Union[str, None] = "93189a98fdf2"
+down_revision: Union[str, None] = "l3m4n5o6p7q8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -94,12 +94,11 @@ def _scroll_and_replace_qdrant_points(
     qdrant_url: str,
     headers: dict,
     collection_name: str,
-    source_id: str,
     chunk_id_map: dict[str, str],
     build_point_id=None,
 ):
     if build_point_id is None:
-        def build_point_id(_src, cid):
+        def build_point_id(cid):
             return cid
 
     offset = None
@@ -111,7 +110,6 @@ def _scroll_and_replace_qdrant_points(
             "limit": QDRANT_SCROLL_BATCH,
             "with_payload": True,
             "with_vector": True,
-            "filter": {"must": [{"key": "source_id", "match": {"value": source_id}}]},
         }
         if offset is not None:
             scroll_body["offset"] = offset
@@ -127,10 +125,7 @@ def _scroll_and_replace_qdrant_points(
 
         if not points:
             if page_num == 0:
-                LOGGER.warning(
-                    f"    Qdrant scroll returned 0 points for source_id={source_id} "
-                    f"in collection={collection_name}"
-                )
+                LOGGER.warning(f"    Qdrant scroll returned 0 points in collection={collection_name}")
             break
 
         page_num += 1
@@ -151,7 +146,7 @@ def _scroll_and_replace_qdrant_points(
             payload = dict(point.get("payload", {}))
             payload["chunk_id"] = new_cid
             new_points.append({
-                "id": build_point_id(source_id, new_cid),
+                "id": build_point_id(new_cid),
                 "payload": payload,
                 "vector": point["vector"],
             })
@@ -163,7 +158,7 @@ def _scroll_and_replace_qdrant_points(
 
         replaced += len(new_points)
         LOGGER.info(
-            f"    Qdrant source {source_id} page {page_num}: "
+            f"    Qdrant collection {collection_name} page {page_num}: "
             f"{len(new_points)}/{len(points)} replaced, {replaced} total"
         )
 
@@ -293,16 +288,22 @@ def upgrade() -> None:
         qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
         headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
 
-        source_chunk_maps: dict[str, dict[str, str]] = {}
         log_rows = ingestion_conn.execute(
             text(f"SELECT old_chunk_id, source_id, new_chunk_id FROM public.{MIGRATION_LOG_TABLE}")
         ).fetchall()
+
+        collection_chunk_maps: dict[str, dict[str, str]] = {}
         for old_cid, sid, new_uuid in log_rows:
-            source_chunk_maps.setdefault(sid, {})[old_cid] = new_uuid
-        LOGGER.info(f"Migration log: {len(log_rows)} entries across {len(source_chunk_maps)} sources")
-        for sid, cmap in source_chunk_maps.items():
+            col = source_to_collection.get(sid)
+            if col:
+                collection_chunk_maps.setdefault(col, {})[old_cid] = new_uuid
+        LOGGER.info(
+            f"Migration log: {len(log_rows)} entries, "
+            f"{len(collection_chunk_maps)} collections to update"
+        )
+        for col, cmap in collection_chunk_maps.items():
             sample = list(cmap.items())[:3]
-            LOGGER.info(f"  source {sid}: {len(cmap)} mappings, sample: {sample}")
+            LOGGER.info(f"  collection {col}: {len(cmap)} mappings, sample: {sample}")
 
         with httpx.Client(timeout=60) as qdrant_client:
             resp = qdrant_client.get(f"{qdrant_url}/collections", headers=headers)
@@ -311,29 +312,26 @@ def upgrade() -> None:
             LOGGER.info(f"Qdrant has {len(existing_collections)} collections: {existing_collections}")
 
             total_replaced = 0
-            total_skipped = 0
 
-            for source_id, chunk_id_map in source_chunk_maps.items():
-                collection_name = source_to_collection.get(source_id)
-                if not collection_name or collection_name not in existing_collections:
-                    total_skipped += len(chunk_id_map)
+            for collection_name, chunk_id_map in collection_chunk_maps.items():
+                if collection_name not in existing_collections:
                     LOGGER.info(
-                        f"  Source {source_id}: collection '{collection_name}' not found, "
+                        f"  Collection '{collection_name}' not found in Qdrant, "
                         f"skipping {len(chunk_id_map)} chunks"
                     )
                     continue
 
                 LOGGER.info(
-                    f"  Source {source_id}: replacing points in collection '{collection_name}' "
+                    f"  Collection '{collection_name}': replacing points "
                     f"({len(chunk_id_map)} chunks to migrate)"
                 )
                 replaced = _scroll_and_replace_qdrant_points(
-                    qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map,
+                    qdrant_client, qdrant_url, headers, collection_name, chunk_id_map,
                 )
                 total_replaced += replaced
-                LOGGER.info(f"  Source {source_id}: {replaced} Qdrant points replaced")
+                LOGGER.info(f"  Collection '{collection_name}': {replaced} Qdrant points replaced")
 
-        LOGGER.info(f"Qdrant update complete: {total_replaced} replaced, {total_skipped} skipped")
+        LOGGER.info(f"Qdrant update complete: {total_replaced} replaced")
 
     except Exception as e:
         LOGGER.error(f"Error during chunk_id UUID migration: {e}", exc_info=True)
@@ -399,10 +397,20 @@ def downgrade() -> None:
 
             source_to_collection = {sid: col for sid, col in db_sources}
 
-            source_chunk_maps: dict[str, dict[str, str]] = {}
+            collection_chunk_maps: dict[str, dict[str, str]] = {}
+            old_cid_to_source: dict[str, str] = {}
             for mapping in all_mappings.values():
                 for new_uuid, sid, old_cid in mapping:
-                    source_chunk_maps.setdefault(sid, {})[new_uuid] = old_cid
+                    col = source_to_collection.get(sid)
+                    if col:
+                        collection_chunk_maps.setdefault(col, {})[new_uuid] = old_cid
+                        old_cid_to_source[old_cid] = sid
+
+            def _legacy_build_point_id(cid):
+                sid = old_cid_to_source.get(cid)
+                if sid:
+                    return _legacy_point_id(sid, cid)
+                return cid
 
             with httpx.Client(timeout=60) as qdrant_client:
                 resp = qdrant_client.get(f"{qdrant_url}/collections", headers=headers)
@@ -410,21 +418,19 @@ def downgrade() -> None:
                 existing_collections = {c["name"] for c in resp.json().get("result", {}).get("collections", [])}
 
                 total_reverted = 0
-                for source_id, chunk_id_map in source_chunk_maps.items():
-                    collection_name = source_to_collection.get(source_id)
-                    if not collection_name or collection_name not in existing_collections:
+                for collection_name, chunk_id_map in collection_chunk_maps.items():
+                    if collection_name not in existing_collections:
                         continue
 
                     LOGGER.info(
-                        f"  Source {source_id}: reverting {len(chunk_id_map)} points "
-                        f"in collection '{collection_name}'"
+                        f"  Collection '{collection_name}': reverting {len(chunk_id_map)} points"
                     )
                     reverted = _scroll_and_replace_qdrant_points(
-                        qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map,
-                        build_point_id=_legacy_point_id,
+                        qdrant_client, qdrant_url, headers, collection_name, chunk_id_map,
+                        build_point_id=_legacy_build_point_id,
                     )
                     total_reverted += reverted
-                    LOGGER.info(f"  Source {source_id}: {reverted} Qdrant points reverted")
+                    LOGGER.info(f"  Collection '{collection_name}': {reverted} Qdrant points reverted")
 
             LOGGER.info(f"Qdrant revert complete: {total_reverted} points reverted")
 

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -7,6 +7,7 @@ Create Date: 2026-04-27
 """
 
 import logging
+import uuid
 from typing import Sequence, Union
 from uuid import uuid4
 
@@ -38,6 +39,7 @@ UUID_REGEX = r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 MIGRATION_LOG_TABLE = "_chunk_id_migration_log"
 DB_BATCH_SIZE = 500
 QDRANT_SCROLL_BATCH = 100
+QDRANT_UPSERT_BATCH = 50
 
 
 def _batch_update_db(ingestion_conn, table_name: str, mapping: list[tuple[str, str, str]]):
@@ -63,24 +65,52 @@ def _batch_update_db(ingestion_conn, table_name: str, mapping: list[tuple[str, s
         LOGGER.info(f"  DB batch {i // DB_BATCH_SIZE + 1}: updated {len(batch)} rows")
 
 
-def _scroll_and_update_qdrant_payload(
+def _upsert_points(client: httpx.Client, qdrant_url: str, headers: dict, collection_name: str, points: list[dict]):
+    for i in range(0, len(points), QDRANT_UPSERT_BATCH):
+        batch = points[i : i + QDRANT_UPSERT_BATCH]
+        client.put(
+            f"{qdrant_url}/collections/{collection_name}/points?wait=true",
+            headers=headers,
+            json={"points": batch},
+        ).raise_for_status()
+
+
+def _delete_points(client: httpx.Client, qdrant_url: str, headers: dict, collection_name: str, point_ids: list):
+    for i in range(0, len(point_ids), QDRANT_UPSERT_BATCH):
+        batch = point_ids[i : i + QDRANT_UPSERT_BATCH]
+        client.post(
+            f"{qdrant_url}/collections/{collection_name}/points/delete?wait=true",
+            headers=headers,
+            json={"points": batch},
+        ).raise_for_status()
+
+
+def _legacy_point_id(source_id: str, chunk_id: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{source_id}:{chunk_id}"))
+
+
+def _scroll_and_replace_qdrant_points(
     client: httpx.Client,
     qdrant_url: str,
     headers: dict,
     collection_name: str,
     source_id: str,
     chunk_id_map: dict[str, str],
+    build_point_id=None,
 ):
+    if build_point_id is None:
+        def build_point_id(_src, cid):
+            return cid
+
     offset = None
-    updated = 0
-    failed = 0
+    replaced = 0
     page_num = 0
 
     while True:
         scroll_body: dict = {
             "limit": QDRANT_SCROLL_BATCH,
-            "with_payload": ["chunk_id"],
-            "with_vector": False,
+            "with_payload": True,
+            "with_vector": True,
             "filter": {"must": [{"key": "source_id", "match": {"value": source_id}}]},
         }
         if offset is not None:
@@ -110,40 +140,38 @@ def _scroll_and_update_qdrant_payload(
             f"Sample chunk_ids: {sample_cids}"
         )
 
-        page_updated = 0
+        new_points = []
+        old_ids = []
         for point in points:
             cur_cid = point.get("payload", {}).get("chunk_id")
             new_cid = chunk_id_map.get(cur_cid)
             if new_cid is None:
                 continue
-            try:
-                client.post(
-                    f"{qdrant_url}/collections/{collection_name}/points/payload",
-                    headers=headers,
-                    json={"payload": {"chunk_id": new_cid}, "points": [point["id"]]},
-                ).raise_for_status()
-                page_updated += 1
-            except httpx.HTTPStatusError as exc:
-                LOGGER.warning(
-                    f"    set_payload failed for point {point['id']}: "
-                    f"HTTP {exc.response.status_code} — {exc.response.text[:300]}"
-                )
-                failed += 1
 
-        updated += page_updated
+            payload = dict(point.get("payload", {}))
+            payload["chunk_id"] = new_cid
+            new_points.append({
+                "id": build_point_id(source_id, new_cid),
+                "payload": payload,
+                "vector": point["vector"],
+            })
+            old_ids.append(point["id"])
+
+        if new_points:
+            _upsert_points(client, qdrant_url, headers, collection_name, new_points)
+            _delete_points(client, qdrant_url, headers, collection_name, old_ids)
+
+        replaced += len(new_points)
         LOGGER.info(
             f"    Qdrant source {source_id} page {page_num}: "
-            f"{page_updated}/{len(points)} updated, {updated} total"
+            f"{len(new_points)}/{len(points)} replaced, {replaced} total"
         )
 
         offset = result.get("next_page_offset")
         if offset is None:
             break
 
-    if failed:
-        LOGGER.warning(f"    Qdrant source {source_id}: {failed} points failed")
-
-    return updated
+    return replaced
 
 
 def upgrade() -> None:
@@ -282,7 +310,7 @@ def upgrade() -> None:
             existing_collections = {c["name"] for c in resp.json().get("result", {}).get("collections", [])}
             LOGGER.info(f"Qdrant has {len(existing_collections)} collections: {existing_collections}")
 
-            total_updated = 0
+            total_replaced = 0
             total_skipped = 0
 
             for source_id, chunk_id_map in source_chunk_maps.items():
@@ -299,13 +327,13 @@ def upgrade() -> None:
                     f"  Source {source_id}: replacing points in collection '{collection_name}' "
                     f"({len(chunk_id_map)} chunks to migrate)"
                 )
-                updated = _scroll_and_update_qdrant_payload(
+                replaced = _scroll_and_replace_qdrant_points(
                     qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map,
                 )
-                total_updated += updated
-                LOGGER.info(f"  Source {source_id}: {updated} Qdrant points replaced")
+                total_replaced += replaced
+                LOGGER.info(f"  Source {source_id}: {replaced} Qdrant points replaced")
 
-        LOGGER.info(f"Qdrant update complete: {total_updated} replaced, {total_skipped} skipped")
+        LOGGER.info(f"Qdrant update complete: {total_replaced} replaced, {total_skipped} skipped")
 
     except Exception as e:
         LOGGER.error(f"Error during chunk_id UUID migration: {e}", exc_info=True)
@@ -381,7 +409,7 @@ def downgrade() -> None:
                 resp.raise_for_status()
                 existing_collections = {c["name"] for c in resp.json().get("result", {}).get("collections", [])}
 
-                total_updated = 0
+                total_reverted = 0
                 for source_id, chunk_id_map in source_chunk_maps.items():
                     collection_name = source_to_collection.get(source_id)
                     if not collection_name or collection_name not in existing_collections:
@@ -391,13 +419,14 @@ def downgrade() -> None:
                         f"  Source {source_id}: reverting {len(chunk_id_map)} points "
                         f"in collection '{collection_name}'"
                     )
-                    updated = _scroll_and_update_qdrant_payload(
+                    reverted = _scroll_and_replace_qdrant_points(
                         qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map,
+                        build_point_id=_legacy_point_id,
                     )
-                    total_updated += updated
-                    LOGGER.info(f"  Source {source_id}: {updated} Qdrant points reverted")
+                    total_reverted += reverted
+                    LOGGER.info(f"  Source {source_id}: {reverted} Qdrant points reverted")
 
-            LOGGER.info(f"Qdrant revert complete: {total_updated} points reverted")
+            LOGGER.info(f"Qdrant revert complete: {total_reverted} points reverted")
 
         ingestion_conn.execute(text(f"DROP TABLE IF EXISTS public.{MIGRATION_LOG_TABLE}"))
         LOGGER.info(f"Dropped migration log table {MIGRATION_LOG_TABLE}")

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -1,7 +1,7 @@
 """migrate_db_source_chunk_ids_to_uuid
 
 Revision ID: c7d8e9f0a1b2
-Revises: l3m4n5o6p7q8
+Revises: 88538199bc7b
 Create Date: 2026-04-27
 
 """
@@ -17,7 +17,7 @@ from sqlalchemy import create_engine, text
 from settings import settings
 
 revision: str = "c7d8e9f0a1b2"
-down_revision: Union[str, None] = "l3m4n5o6p7q8"
+down_revision: Union[str, None] = "88538199bc7b"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -70,6 +70,19 @@ def _legacy_point_id(source_id: str, chunk_id: str) -> str:
     return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{source_id}:{chunk_id}"))
 
 
+def _resolve_qdrant_collection_name(collection_name: str, existing_collections: set[str]) -> str | None:
+    candidates = [collection_name]
+    if not collection_name.endswith("_hybrid"):
+        candidates.append(f"{collection_name}_hybrid")
+
+    for candidate in candidates:
+        if candidate in existing_collections:
+            if candidate != collection_name:
+                LOGGER.info(f"  Collection '{collection_name}' not found; using existing '{candidate}'")
+            return candidate
+    return None
+
+
 async def _scroll_and_replace_qdrant_points(
     qdrant_service: QdrantService,
     collection_name: str,
@@ -183,20 +196,23 @@ async def _run_qdrant_upgrade(source_to_collection, ingestion_conn):
     total_replaced = 0
     expected_replacements = 0
     for collection_name, chunk_id_map in collection_chunk_maps.items():
-        if collection_name not in existing_collections:
+        qdrant_collection_name = _resolve_qdrant_collection_name(collection_name, existing_collections)
+        if not qdrant_collection_name:
             raise RuntimeError(
                 f"Qdrant collection '{collection_name}' not found; cannot migrate {len(chunk_id_map)} chunks"
             )
 
         expected_replacements += len(chunk_id_map)
-        LOGGER.info(f"  Collection '{collection_name}': replacing points ({len(chunk_id_map)} chunks to migrate)")
+        LOGGER.info(
+            f"  Collection '{qdrant_collection_name}': replacing points ({len(chunk_id_map)} chunks to migrate)"
+        )
         replaced = await _scroll_and_replace_qdrant_points(
             qdrant_service,
-            collection_name,
+            qdrant_collection_name,
             chunk_id_map,
         )
         total_replaced += replaced
-        LOGGER.info(f"  Collection '{collection_name}': {replaced} Qdrant points replaced")
+        LOGGER.info(f"  Collection '{qdrant_collection_name}': {replaced} Qdrant points replaced")
 
     if expected_replacements and total_replaced == 0:
         raise RuntimeError(
@@ -228,18 +244,19 @@ async def _run_qdrant_downgrade(source_to_collection, all_mappings):
 
     total_reverted = 0
     for collection_name, chunk_id_map in collection_chunk_maps.items():
-        if collection_name not in existing_collections:
+        qdrant_collection_name = _resolve_qdrant_collection_name(collection_name, existing_collections)
+        if not qdrant_collection_name:
             continue
 
-        LOGGER.info(f"  Collection '{collection_name}': reverting {len(chunk_id_map)} points")
+        LOGGER.info(f"  Collection '{qdrant_collection_name}': reverting {len(chunk_id_map)} points")
         reverted = await _scroll_and_replace_qdrant_points(
             qdrant_service,
-            collection_name,
+            qdrant_collection_name,
             chunk_id_map,
             build_point_id=_legacy_build_point_id,
         )
         total_reverted += reverted
-        LOGGER.info(f"  Collection '{collection_name}': {reverted} Qdrant points reverted")
+        LOGGER.info(f"  Collection '{qdrant_collection_name}': {reverted} Qdrant points reverted")
 
     LOGGER.info(f"Qdrant revert complete: {total_reverted} points reverted")
 

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -7,8 +7,8 @@ Create Date: 2026-04-27
 """
 
 import logging
-from typing import Sequence, Union
-from uuid import uuid4
+from typing import Callable, Sequence, Union
+from uuid import NAMESPACE_DNS, uuid4, uuid5
 
 import httpx
 from alembic import op
@@ -37,7 +37,7 @@ if not LOGGER.handlers:
 UUID_REGEX = r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 MIGRATION_LOG_TABLE = "_chunk_id_migration_log"
 DB_BATCH_SIZE = 500
-QDRANT_SCROLL_BATCH = 256
+QDRANT_SCROLL_BATCH = 100
 
 
 def _batch_update_db(ingestion_conn, table_name: str, mapping: list[tuple[str, str, str]]):
@@ -63,13 +63,18 @@ def _batch_update_db(ingestion_conn, table_name: str, mapping: list[tuple[str, s
         LOGGER.info(f"  DB batch {i // DB_BATCH_SIZE + 1}: updated {len(batch)} rows")
 
 
-def _scroll_and_update_qdrant(
+def _legacy_point_id(source_id: str, chunk_id: str) -> str:
+    return str(uuid5(NAMESPACE_DNS, f"{source_id}:{chunk_id}"))
+
+
+def _scroll_and_replace_qdrant(
     client: httpx.Client,
     qdrant_url: str,
     headers: dict,
     collection_name: str,
     source_id: str,
     chunk_id_map: dict[str, str],
+    build_new_point_id: Callable[[str], str],
 ):
     offset = None
     updated = 0
@@ -79,8 +84,8 @@ def _scroll_and_update_qdrant(
     while True:
         scroll_body: dict = {
             "limit": QDRANT_SCROLL_BATCH,
-            "with_payload": ["chunk_id", "source_id"],
-            "with_vector": False,
+            "with_payload": True,
+            "with_vector": True,
             "filter": {"must": [{"key": "source_id", "match": {"value": source_id}}]},
         }
         if offset is not None:
@@ -99,33 +104,47 @@ def _scroll_and_update_qdrant(
             break
 
         page_num += 1
-        page_updated = 0
-        page_failed = 0
+        new_points = []
+        old_point_ids = []
 
         for point in points:
-            old_cid = point.get("payload", {}).get("chunk_id")
-            new_cid = chunk_id_map.get(old_cid)
+            cur_cid = point.get("payload", {}).get("chunk_id")
+            new_cid = chunk_id_map.get(cur_cid)
             if new_cid is None:
                 continue
+            new_payload = {**point.get("payload", {}), "chunk_id": new_cid}
+            new_points.append({
+                "id": build_new_point_id(new_cid),
+                "payload": new_payload,
+                "vector": point["vector"],
+            })
+            old_point_ids.append(point["id"])
+
+        page_replaced = 0
+        if new_points:
             try:
-                client.post(
-                    f"{qdrant_url}/collections/{collection_name}/points/payload",
+                client.put(
+                    f"{qdrant_url}/collections/{collection_name}/points",
                     headers=headers,
-                    json={"payload": {"chunk_id": new_cid}, "points": [point["id"]]},
+                    json={"points": new_points},
                 ).raise_for_status()
-                page_updated += 1
+                client.post(
+                    f"{qdrant_url}/collections/{collection_name}/points/delete",
+                    headers=headers,
+                    json={"points": old_point_ids},
+                ).raise_for_status()
+                page_replaced = len(new_points)
             except httpx.HTTPStatusError as exc:
                 LOGGER.warning(
-                    f"    Qdrant set_payload failed for point {point['id']} "
-                    f"(source {source_id}): {exc.response.status_code}"
+                    f"    Qdrant batch failed for source {source_id} page {page_num}: "
+                    f"{exc.response.status_code}"
                 )
-                failed_ids.append(str(point["id"]))
-                page_failed += 1
+                failed_ids.extend(str(pid) for pid in old_point_ids)
 
-        updated += page_updated
+        updated += page_replaced
         LOGGER.info(
             f"    Qdrant source {source_id} page {page_num}: "
-            f"{page_updated} updated, {page_failed} failed, {updated} total"
+            f"{page_replaced} replaced, {updated} total"
         )
 
         offset = result.get("next_page_offset")
@@ -250,7 +269,7 @@ def upgrade() -> None:
             LOGGER.info("No DB sources with Qdrant collections found. Skipping Qdrant update.")
             return
 
-        LOGGER.info("Phase 2: Updating Qdrant payloads...")
+        LOGGER.info("Phase 2: Replacing Qdrant points with new IDs...")
         qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
         headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
 
@@ -280,16 +299,17 @@ def upgrade() -> None:
                     continue
 
                 LOGGER.info(
-                    f"  Source {source_id}: scrolling collection '{collection_name}' "
-                    f"({len(chunk_id_map)} chunks to update)"
+                    f"  Source {source_id}: replacing points in collection '{collection_name}' "
+                    f"({len(chunk_id_map)} chunks to migrate)"
                 )
-                updated = _scroll_and_update_qdrant(
-                    qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map
+                updated = _scroll_and_replace_qdrant(
+                    qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map,
+                    build_new_point_id=lambda cid: cid,
                 )
                 total_updated += updated
-                LOGGER.info(f"  Source {source_id}: {updated} Qdrant points updated")
+                LOGGER.info(f"  Source {source_id}: {updated} Qdrant points replaced")
 
-        LOGGER.info(f"Qdrant update complete: {total_updated} updated, {total_skipped} skipped")
+        LOGGER.info(f"Qdrant update complete: {total_updated} replaced, {total_skipped} skipped")
 
     except Exception as e:
         LOGGER.error(f"Error during chunk_id UUID migration: {e}", exc_info=True)
@@ -341,7 +361,7 @@ def downgrade() -> None:
         if not settings.QDRANT_CLUSTER_URL or not settings.QDRANT_API_KEY:
             LOGGER.info("QDRANT_CLUSTER_URL or QDRANT_API_KEY not set. Skipping Qdrant revert.")
         else:
-            LOGGER.info("Phase 2: Reverting Qdrant payloads...")
+            LOGGER.info("Phase 2: Reverting Qdrant points to legacy IDs...")
             qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
             headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
 
@@ -372,10 +392,12 @@ def downgrade() -> None:
                         continue
 
                     LOGGER.info(
-                        f"  Source {source_id}: reverting {len(chunk_id_map)} chunks in collection '{collection_name}'"
+                        f"  Source {source_id}: reverting {len(chunk_id_map)} points "
+                        f"in collection '{collection_name}'"
                     )
-                    updated = _scroll_and_update_qdrant(
-                        qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map
+                    updated = _scroll_and_replace_qdrant(
+                        qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map,
+                        build_new_point_id=lambda cid, _sid=source_id: _legacy_point_id(_sid, cid),
                     )
                     total_updated += updated
                     LOGGER.info(f"  Source {source_id}: {updated} Qdrant points reverted")

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -77,6 +77,7 @@ async def _scroll_and_replace_qdrant_points(
     build_point_id=None,
 ):
     if build_point_id is None:
+
         def build_point_id(cid):
             return cid
 
@@ -107,10 +108,7 @@ async def _scroll_and_replace_qdrant_points(
 
         page_num += 1
         sample_cids = [p.get("payload", {}).get("chunk_id") for p in points[:5]]
-        LOGGER.info(
-            f"    Qdrant scroll page {page_num}: {len(points)} points. "
-            f"Sample chunk_ids: {sample_cids}"
-        )
+        LOGGER.info(f"    Qdrant scroll page {page_num}: {len(points)} points. Sample chunk_ids: {sample_cids}")
 
         new_points = []
         old_ids = []
@@ -171,35 +169,39 @@ async def _run_qdrant_upgrade(source_to_collection, ingestion_conn):
         col = source_to_collection.get(sid)
         if col:
             collection_chunk_maps.setdefault(col, {})[old_cid] = new_uuid
-    LOGGER.info(
-        f"Migration log: {len(log_rows)} entries, "
-        f"{len(collection_chunk_maps)} collections to update"
-    )
+    LOGGER.info(f"Migration log: {len(log_rows)} entries, {len(collection_chunk_maps)} collections to update")
     for col, cmap in collection_chunk_maps.items():
         sample = list(cmap.items())[:3]
         LOGGER.info(f"  collection {col}: {len(cmap)} mappings, sample: {sample}")
+
+    if log_rows and not collection_chunk_maps:
+        raise RuntimeError("Qdrant update cannot run: migration log has entries but none map to Qdrant collections")
 
     existing_collections = set(await qdrant_service.list_collection_names_async())
     LOGGER.info(f"Qdrant has {len(existing_collections)} collections: {existing_collections}")
 
     total_replaced = 0
+    expected_replacements = 0
     for collection_name, chunk_id_map in collection_chunk_maps.items():
         if collection_name not in existing_collections:
-            LOGGER.info(
-                f"  Collection '{collection_name}' not found in Qdrant, "
-                f"skipping {len(chunk_id_map)} chunks"
+            raise RuntimeError(
+                f"Qdrant collection '{collection_name}' not found; cannot migrate {len(chunk_id_map)} chunks"
             )
-            continue
 
-        LOGGER.info(
-            f"  Collection '{collection_name}': replacing points "
-            f"({len(chunk_id_map)} chunks to migrate)"
-        )
+        expected_replacements += len(chunk_id_map)
+        LOGGER.info(f"  Collection '{collection_name}': replacing points ({len(chunk_id_map)} chunks to migrate)")
         replaced = await _scroll_and_replace_qdrant_points(
-            qdrant_service, collection_name, chunk_id_map,
+            qdrant_service,
+            collection_name,
+            chunk_id_map,
         )
         total_replaced += replaced
         LOGGER.info(f"  Collection '{collection_name}': {replaced} Qdrant points replaced")
+
+    if expected_replacements and total_replaced == 0:
+        raise RuntimeError(
+            f"Qdrant update replaced 0 points, but DB migration has {expected_replacements} mapped chunk IDs"
+        )
 
     LOGGER.info(f"Qdrant update complete: {total_replaced} replaced")
 
@@ -231,7 +233,9 @@ async def _run_qdrant_downgrade(source_to_collection, all_mappings):
 
         LOGGER.info(f"  Collection '{collection_name}': reverting {len(chunk_id_map)} points")
         reverted = await _scroll_and_replace_qdrant_points(
-            qdrant_service, collection_name, chunk_id_map,
+            qdrant_service,
+            collection_name,
+            chunk_id_map,
             build_point_id=_legacy_build_point_id,
         )
         total_reverted += reverted
@@ -308,6 +312,24 @@ def upgrade() -> None:
             LOGGER.info(f"Table {table_name}: {len(table_mapping)} chunk_ids to migrate")
 
         if not all_mappings:
+            log_exists = ingestion_conn.execute(
+                text(
+                    "SELECT 1 FROM information_schema.tables "
+                    f"WHERE table_schema = 'public' AND table_name = '{MIGRATION_LOG_TABLE}'"
+                )
+            ).fetchone()
+            if log_exists and source_to_collection:
+                log_count = ingestion_conn.execute(
+                    text(f"SELECT COUNT(*) FROM public.{MIGRATION_LOG_TABLE}")
+                ).scalar_one()
+                if log_count:
+                    LOGGER.info(
+                        "No non-UUID chunk_ids found in DB, but migration log has "
+                        f"{log_count} entries. Running Qdrant update from saved DB mapping."
+                    )
+                    asyncio.run(_run_qdrant_upgrade(source_to_collection, ingestion_conn))
+                    return
+
             LOGGER.info("No non-UUID chunk_ids found across any table. Migration complete.")
             return
 

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -1,7 +1,7 @@
 """migrate_db_source_chunk_ids_to_uuid
 
 Revision ID: c7d8e9f0a1b2
-Revises: 88538199bc7b
+Revises: a3b4c5d6e7f9
 Create Date: 2026-04-27
 
 """
@@ -17,7 +17,7 @@ from sqlalchemy import create_engine, text
 from settings import settings
 
 revision: str = "c7d8e9f0a1b2"
-down_revision: Union[str, None] = "88538199bc7b"
+down_revision: Union[str, None] = "a3b4c5d6e7f9"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -7,8 +7,8 @@ Create Date: 2026-04-27
 """
 
 import logging
-from typing import Callable, Sequence, Union
-from uuid import NAMESPACE_DNS, uuid4, uuid5
+from typing import Sequence, Union
+from uuid import uuid4
 
 import httpx
 from alembic import op
@@ -63,29 +63,24 @@ def _batch_update_db(ingestion_conn, table_name: str, mapping: list[tuple[str, s
         LOGGER.info(f"  DB batch {i // DB_BATCH_SIZE + 1}: updated {len(batch)} rows")
 
 
-def _legacy_point_id(source_id: str, chunk_id: str) -> str:
-    return str(uuid5(NAMESPACE_DNS, f"{source_id}:{chunk_id}"))
-
-
-def _scroll_and_replace_qdrant(
+def _scroll_and_update_qdrant_payload(
     client: httpx.Client,
     qdrant_url: str,
     headers: dict,
     collection_name: str,
     source_id: str,
     chunk_id_map: dict[str, str],
-    build_new_point_id: Callable[[str], str],
 ):
     offset = None
     updated = 0
-    failed_ids: list[str] = []
+    failed = 0
     page_num = 0
 
     while True:
         scroll_body: dict = {
             "limit": QDRANT_SCROLL_BATCH,
-            "with_payload": True,
-            "with_vector": True,
+            "with_payload": ["chunk_id"],
+            "with_vector": False,
             "filter": {"must": [{"key": "source_id", "match": {"value": source_id}}]},
         }
         if offset is not None:
@@ -101,58 +96,52 @@ def _scroll_and_replace_qdrant(
         points = result.get("points", [])
 
         if not points:
+            if page_num == 0:
+                LOGGER.warning(
+                    f"    Qdrant scroll returned 0 points for source_id={source_id} "
+                    f"in collection={collection_name}"
+                )
             break
 
         page_num += 1
-        new_points = []
-        old_point_ids = []
+        sample_cids = [p.get("payload", {}).get("chunk_id") for p in points[:5]]
+        LOGGER.info(
+            f"    Qdrant scroll page {page_num}: {len(points)} points. "
+            f"Sample chunk_ids: {sample_cids}"
+        )
 
+        page_updated = 0
         for point in points:
             cur_cid = point.get("payload", {}).get("chunk_id")
             new_cid = chunk_id_map.get(cur_cid)
             if new_cid is None:
                 continue
-            new_payload = {**point.get("payload", {}), "chunk_id": new_cid}
-            new_points.append({
-                "id": build_new_point_id(new_cid),
-                "payload": new_payload,
-                "vector": point["vector"],
-            })
-            old_point_ids.append(point["id"])
-
-        page_replaced = 0
-        if new_points:
             try:
-                client.put(
-                    f"{qdrant_url}/collections/{collection_name}/points",
-                    headers=headers,
-                    json={"points": new_points},
-                ).raise_for_status()
                 client.post(
-                    f"{qdrant_url}/collections/{collection_name}/points/delete",
+                    f"{qdrant_url}/collections/{collection_name}/points/payload",
                     headers=headers,
-                    json={"points": old_point_ids},
+                    json={"payload": {"chunk_id": new_cid}, "points": [point["id"]]},
                 ).raise_for_status()
-                page_replaced = len(new_points)
+                page_updated += 1
             except httpx.HTTPStatusError as exc:
                 LOGGER.warning(
-                    f"    Qdrant batch failed for source {source_id} page {page_num}: "
-                    f"{exc.response.status_code}"
+                    f"    set_payload failed for point {point['id']}: "
+                    f"HTTP {exc.response.status_code} — {exc.response.text[:300]}"
                 )
-                failed_ids.extend(str(pid) for pid in old_point_ids)
+                failed += 1
 
-        updated += page_replaced
+        updated += page_updated
         LOGGER.info(
             f"    Qdrant source {source_id} page {page_num}: "
-            f"{page_replaced} replaced, {updated} total"
+            f"{page_updated}/{len(points)} updated, {updated} total"
         )
 
         offset = result.get("next_page_offset")
         if offset is None:
             break
 
-    if failed_ids:
-        LOGGER.warning(f"    Qdrant source {source_id}: {len(failed_ids)} points failed: {failed_ids[:20]}")
+    if failed:
+        LOGGER.warning(f"    Qdrant source {source_id}: {failed} points failed")
 
     return updated
 
@@ -174,6 +163,9 @@ def upgrade() -> None:
         return
 
     LOGGER.info(f"Found {len(db_source_ids)} database-type sources")
+    for sid, col in db_source_rows:
+        LOGGER.info(f"  source {sid} -> qdrant_collection_name={col!r}")
+    LOGGER.info(f"Sources with non-null collection name: {len(source_to_collection)}")
 
     ingestion_engine = create_engine(settings.INGESTION_DB_URL, isolation_level="AUTOCOMMIT")
     ingestion_conn = ingestion_engine.connect()
@@ -279,11 +271,16 @@ def upgrade() -> None:
         ).fetchall()
         for old_cid, sid, new_uuid in log_rows:
             source_chunk_maps.setdefault(sid, {})[old_cid] = new_uuid
+        LOGGER.info(f"Migration log: {len(log_rows)} entries across {len(source_chunk_maps)} sources")
+        for sid, cmap in source_chunk_maps.items():
+            sample = list(cmap.items())[:3]
+            LOGGER.info(f"  source {sid}: {len(cmap)} mappings, sample: {sample}")
 
         with httpx.Client(timeout=60) as qdrant_client:
             resp = qdrant_client.get(f"{qdrant_url}/collections", headers=headers)
             resp.raise_for_status()
             existing_collections = {c["name"] for c in resp.json().get("result", {}).get("collections", [])}
+            LOGGER.info(f"Qdrant has {len(existing_collections)} collections: {existing_collections}")
 
             total_updated = 0
             total_skipped = 0
@@ -302,9 +299,8 @@ def upgrade() -> None:
                     f"  Source {source_id}: replacing points in collection '{collection_name}' "
                     f"({len(chunk_id_map)} chunks to migrate)"
                 )
-                updated = _scroll_and_replace_qdrant(
+                updated = _scroll_and_update_qdrant_payload(
                     qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map,
-                    build_new_point_id=lambda cid: cid,
                 )
                 total_updated += updated
                 LOGGER.info(f"  Source {source_id}: {updated} Qdrant points replaced")
@@ -395,9 +391,8 @@ def downgrade() -> None:
                         f"  Source {source_id}: reverting {len(chunk_id_map)} points "
                         f"in collection '{collection_name}'"
                     )
-                    updated = _scroll_and_replace_qdrant(
+                    updated = _scroll_and_update_qdrant_payload(
                         qdrant_client, qdrant_url, headers, collection_name, source_id, chunk_id_map,
-                        build_new_point_id=lambda cid, _sid=source_id: _legacy_point_id(_sid, cid),
                     )
                     total_updated += updated
                     LOGGER.info(f"  Source {source_id}: {updated} Qdrant points reverted")

--- a/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
+++ b/ada_backend/database/alembic/versions/c7d8e9f0a1b2_migrate_db_source_chunk_ids_to_uuid.py
@@ -6,15 +6,16 @@ Create Date: 2026-04-27
 
 """
 
+import asyncio
 import logging
 import uuid
 from typing import Sequence, Union
 from uuid import uuid4
 
-import httpx
 from alembic import op
 from sqlalchemy import create_engine, text
 
+from engine.qdrant_service import QdrantService
 from settings import settings
 
 revision: str = "c7d8e9f0a1b2"
@@ -65,34 +66,12 @@ def _batch_update_db(ingestion_conn, table_name: str, mapping: list[tuple[str, s
         LOGGER.info(f"  DB batch {i // DB_BATCH_SIZE + 1}: updated {len(batch)} rows")
 
 
-def _upsert_points(client: httpx.Client, qdrant_url: str, headers: dict, collection_name: str, points: list[dict]):
-    for i in range(0, len(points), QDRANT_UPSERT_BATCH):
-        batch = points[i : i + QDRANT_UPSERT_BATCH]
-        client.put(
-            f"{qdrant_url}/collections/{collection_name}/points?wait=true",
-            headers=headers,
-            json={"points": batch},
-        ).raise_for_status()
-
-
-def _delete_points(client: httpx.Client, qdrant_url: str, headers: dict, collection_name: str, point_ids: list):
-    for i in range(0, len(point_ids), QDRANT_UPSERT_BATCH):
-        batch = point_ids[i : i + QDRANT_UPSERT_BATCH]
-        client.post(
-            f"{qdrant_url}/collections/{collection_name}/points/delete?wait=true",
-            headers=headers,
-            json={"points": batch},
-        ).raise_for_status()
-
-
 def _legacy_point_id(source_id: str, chunk_id: str) -> str:
     return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{source_id}:{chunk_id}"))
 
 
-def _scroll_and_replace_qdrant_points(
-    client: httpx.Client,
-    qdrant_url: str,
-    headers: dict,
+async def _scroll_and_replace_qdrant_points(
+    qdrant_service: QdrantService,
     collection_name: str,
     chunk_id_map: dict[str, str],
     build_point_id=None,
@@ -114,14 +93,12 @@ def _scroll_and_replace_qdrant_points(
         if offset is not None:
             scroll_body["offset"] = offset
 
-        resp = client.post(
-            f"{qdrant_url}/collections/{collection_name}/points/scroll",
-            headers=headers,
-            json=scroll_body,
+        result = await qdrant_service._send_request_async(
+            method="POST",
+            endpoint=f"collections/{collection_name}/points/scroll",
+            payload=scroll_body,
         )
-        resp.raise_for_status()
-        result = resp.json().get("result", {})
-        points = result.get("points", [])
+        points = result.get("result", {}).get("points", [])
 
         if not points:
             if page_num == 0:
@@ -153,8 +130,21 @@ def _scroll_and_replace_qdrant_points(
             old_ids.append(point["id"])
 
         if new_points:
-            _upsert_points(client, qdrant_url, headers, collection_name, new_points)
-            _delete_points(client, qdrant_url, headers, collection_name, old_ids)
+            for i in range(0, len(new_points), QDRANT_UPSERT_BATCH):
+                batch = new_points[i : i + QDRANT_UPSERT_BATCH]
+                await qdrant_service._send_request_async(
+                    method="PUT",
+                    endpoint=f"collections/{collection_name}/points?wait=true",
+                    payload={"points": batch},
+                )
+
+            for i in range(0, len(old_ids), QDRANT_UPSERT_BATCH):
+                batch = old_ids[i : i + QDRANT_UPSERT_BATCH]
+                await qdrant_service._send_request_async(
+                    method="POST",
+                    endpoint=f"collections/{collection_name}/points/delete?wait=true",
+                    payload={"points": batch},
+                )
 
         replaced += len(new_points)
         LOGGER.info(
@@ -162,11 +152,92 @@ def _scroll_and_replace_qdrant_points(
             f"{len(new_points)}/{len(points)} replaced, {replaced} total"
         )
 
-        offset = result.get("next_page_offset")
+        offset = result.get("result", {}).get("next_page_offset")
         if offset is None:
             break
 
     return replaced
+
+
+async def _run_qdrant_upgrade(source_to_collection, ingestion_conn):
+    qdrant_service = QdrantService.from_defaults()
+
+    log_rows = ingestion_conn.execute(
+        text(f"SELECT old_chunk_id, source_id, new_chunk_id FROM public.{MIGRATION_LOG_TABLE}")
+    ).fetchall()
+
+    collection_chunk_maps: dict[str, dict[str, str]] = {}
+    for old_cid, sid, new_uuid in log_rows:
+        col = source_to_collection.get(sid)
+        if col:
+            collection_chunk_maps.setdefault(col, {})[old_cid] = new_uuid
+    LOGGER.info(
+        f"Migration log: {len(log_rows)} entries, "
+        f"{len(collection_chunk_maps)} collections to update"
+    )
+    for col, cmap in collection_chunk_maps.items():
+        sample = list(cmap.items())[:3]
+        LOGGER.info(f"  collection {col}: {len(cmap)} mappings, sample: {sample}")
+
+    existing_collections = set(await qdrant_service.list_collection_names_async())
+    LOGGER.info(f"Qdrant has {len(existing_collections)} collections: {existing_collections}")
+
+    total_replaced = 0
+    for collection_name, chunk_id_map in collection_chunk_maps.items():
+        if collection_name not in existing_collections:
+            LOGGER.info(
+                f"  Collection '{collection_name}' not found in Qdrant, "
+                f"skipping {len(chunk_id_map)} chunks"
+            )
+            continue
+
+        LOGGER.info(
+            f"  Collection '{collection_name}': replacing points "
+            f"({len(chunk_id_map)} chunks to migrate)"
+        )
+        replaced = await _scroll_and_replace_qdrant_points(
+            qdrant_service, collection_name, chunk_id_map,
+        )
+        total_replaced += replaced
+        LOGGER.info(f"  Collection '{collection_name}': {replaced} Qdrant points replaced")
+
+    LOGGER.info(f"Qdrant update complete: {total_replaced} replaced")
+
+
+async def _run_qdrant_downgrade(source_to_collection, all_mappings):
+    qdrant_service = QdrantService.from_defaults()
+
+    collection_chunk_maps: dict[str, dict[str, str]] = {}
+    old_cid_to_source: dict[str, str] = {}
+    for mapping in all_mappings.values():
+        for new_uuid, sid, old_cid in mapping:
+            col = source_to_collection.get(sid)
+            if col:
+                collection_chunk_maps.setdefault(col, {})[new_uuid] = old_cid
+                old_cid_to_source[old_cid] = sid
+
+    def _legacy_build_point_id(cid):
+        sid = old_cid_to_source.get(cid)
+        if sid:
+            return _legacy_point_id(sid, cid)
+        return cid
+
+    existing_collections = set(await qdrant_service.list_collection_names_async())
+
+    total_reverted = 0
+    for collection_name, chunk_id_map in collection_chunk_maps.items():
+        if collection_name not in existing_collections:
+            continue
+
+        LOGGER.info(f"  Collection '{collection_name}': reverting {len(chunk_id_map)} points")
+        reverted = await _scroll_and_replace_qdrant_points(
+            qdrant_service, collection_name, chunk_id_map,
+            build_point_id=_legacy_build_point_id,
+        )
+        total_reverted += reverted
+        LOGGER.info(f"  Collection '{collection_name}': {reverted} Qdrant points reverted")
+
+    LOGGER.info(f"Qdrant revert complete: {total_reverted} points reverted")
 
 
 def upgrade() -> None:
@@ -276,62 +347,12 @@ def upgrade() -> None:
             _batch_update_db(ingestion_conn, table_name, mapping)
             LOGGER.info(f"Finished DB update for {table_name} ({len(mapping)} rows)")
 
-        if not settings.QDRANT_CLUSTER_URL or not settings.QDRANT_API_KEY:
-            LOGGER.info("QDRANT_CLUSTER_URL or QDRANT_API_KEY not set. Skipping Qdrant payload update.")
-            return
-
         if not source_to_collection:
             LOGGER.info("No DB sources with Qdrant collections found. Skipping Qdrant update.")
             return
 
         LOGGER.info("Phase 2: Replacing Qdrant points with new IDs...")
-        qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
-        headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
-
-        log_rows = ingestion_conn.execute(
-            text(f"SELECT old_chunk_id, source_id, new_chunk_id FROM public.{MIGRATION_LOG_TABLE}")
-        ).fetchall()
-
-        collection_chunk_maps: dict[str, dict[str, str]] = {}
-        for old_cid, sid, new_uuid in log_rows:
-            col = source_to_collection.get(sid)
-            if col:
-                collection_chunk_maps.setdefault(col, {})[old_cid] = new_uuid
-        LOGGER.info(
-            f"Migration log: {len(log_rows)} entries, "
-            f"{len(collection_chunk_maps)} collections to update"
-        )
-        for col, cmap in collection_chunk_maps.items():
-            sample = list(cmap.items())[:3]
-            LOGGER.info(f"  collection {col}: {len(cmap)} mappings, sample: {sample}")
-
-        with httpx.Client(timeout=60) as qdrant_client:
-            resp = qdrant_client.get(f"{qdrant_url}/collections", headers=headers)
-            resp.raise_for_status()
-            existing_collections = {c["name"] for c in resp.json().get("result", {}).get("collections", [])}
-            LOGGER.info(f"Qdrant has {len(existing_collections)} collections: {existing_collections}")
-
-            total_replaced = 0
-
-            for collection_name, chunk_id_map in collection_chunk_maps.items():
-                if collection_name not in existing_collections:
-                    LOGGER.info(
-                        f"  Collection '{collection_name}' not found in Qdrant, "
-                        f"skipping {len(chunk_id_map)} chunks"
-                    )
-                    continue
-
-                LOGGER.info(
-                    f"  Collection '{collection_name}': replacing points "
-                    f"({len(chunk_id_map)} chunks to migrate)"
-                )
-                replaced = _scroll_and_replace_qdrant_points(
-                    qdrant_client, qdrant_url, headers, collection_name, chunk_id_map,
-                )
-                total_replaced += replaced
-                LOGGER.info(f"  Collection '{collection_name}': {replaced} Qdrant points replaced")
-
-        LOGGER.info(f"Qdrant update complete: {total_replaced} replaced")
+        asyncio.run(_run_qdrant_upgrade(source_to_collection, ingestion_conn))
 
     except Exception as e:
         LOGGER.error(f"Error during chunk_id UUID migration: {e}", exc_info=True)
@@ -380,59 +401,18 @@ def downgrade() -> None:
             _batch_update_db(ingestion_conn, table_name, mapping)
             LOGGER.info(f"Finished DB revert for {table_name} ({len(mapping)} rows)")
 
-        if not settings.QDRANT_CLUSTER_URL or not settings.QDRANT_API_KEY:
-            LOGGER.info("QDRANT_CLUSTER_URL or QDRANT_API_KEY not set. Skipping Qdrant revert.")
-        else:
+        backend_conn = op.get_bind()
+        db_sources = backend_conn.execute(
+            text(
+                "SELECT id::text, qdrant_collection_name FROM data_sources "
+                "WHERE type = 'database' AND qdrant_collection_name IS NOT NULL"
+            )
+        ).fetchall()
+        source_to_collection = {sid: col for sid, col in db_sources}
+
+        if source_to_collection:
             LOGGER.info("Phase 2: Reverting Qdrant points to legacy IDs...")
-            qdrant_url = settings.QDRANT_CLUSTER_URL.rstrip("/")
-            headers = {"api-key": settings.QDRANT_API_KEY, "Content-Type": "application/json"}
-
-            backend_conn = op.get_bind()
-            db_sources = backend_conn.execute(
-                text(
-                    "SELECT id::text, qdrant_collection_name FROM data_sources "
-                    "WHERE type = 'database' AND qdrant_collection_name IS NOT NULL"
-                )
-            ).fetchall()
-
-            source_to_collection = {sid: col for sid, col in db_sources}
-
-            collection_chunk_maps: dict[str, dict[str, str]] = {}
-            old_cid_to_source: dict[str, str] = {}
-            for mapping in all_mappings.values():
-                for new_uuid, sid, old_cid in mapping:
-                    col = source_to_collection.get(sid)
-                    if col:
-                        collection_chunk_maps.setdefault(col, {})[new_uuid] = old_cid
-                        old_cid_to_source[old_cid] = sid
-
-            def _legacy_build_point_id(cid):
-                sid = old_cid_to_source.get(cid)
-                if sid:
-                    return _legacy_point_id(sid, cid)
-                return cid
-
-            with httpx.Client(timeout=60) as qdrant_client:
-                resp = qdrant_client.get(f"{qdrant_url}/collections", headers=headers)
-                resp.raise_for_status()
-                existing_collections = {c["name"] for c in resp.json().get("result", {}).get("collections", [])}
-
-                total_reverted = 0
-                for collection_name, chunk_id_map in collection_chunk_maps.items():
-                    if collection_name not in existing_collections:
-                        continue
-
-                    LOGGER.info(
-                        f"  Collection '{collection_name}': reverting {len(chunk_id_map)} points"
-                    )
-                    reverted = _scroll_and_replace_qdrant_points(
-                        qdrant_client, qdrant_url, headers, collection_name, chunk_id_map,
-                        build_point_id=_legacy_build_point_id,
-                    )
-                    total_reverted += reverted
-                    LOGGER.info(f"  Collection '{collection_name}': {reverted} Qdrant points reverted")
-
-            LOGGER.info(f"Qdrant revert complete: {total_reverted} points reverted")
+            asyncio.run(_run_qdrant_downgrade(source_to_collection, all_mappings))
 
         ingestion_conn.execute(text(f"DROP TABLE IF EXISTS public.{MIGRATION_LOG_TABLE}"))
         LOGGER.info(f"Dropped migration log table {MIGRATION_LOG_TABLE}")

--- a/engine/qdrant_service.py
+++ b/engine/qdrant_service.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import re
-import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -760,7 +759,7 @@ class QdrantService:
                     "sparse": {"text": chunk[schema.content_field], "model": BM25_MODEL},
                 }
                 point = {
-                    "id": self.get_uuid(self._build_point_id_seed(chunk, schema)),
+                    "id": chunk[schema.chunk_id_field],
                     "payload": {field: chunk[field] for field in chunk.keys()},
                     "vector": point_vector,
                 }
@@ -809,22 +808,6 @@ class QdrantService:
             collection_name=collection_name,
             point_ids=[point["id"] for point in points],
         )
-
-    @staticmethod
-    def get_uuid(string_id: str) -> str:
-        """Generate a UUID."""
-        namespace = uuid.NAMESPACE_DNS
-        return str(uuid.uuid5(namespace, string_id))
-
-    @staticmethod
-    def _build_point_id_seed(chunk: dict[str, Any], schema: QdrantCollectionSchema) -> str:
-        # TODO: Remove this workaround once chunk_id will be unique uuid
-        seed = chunk[schema.chunk_id_field]
-        if schema.source_id_field:
-            source_id = chunk.get(schema.source_id_field)
-            if source_id:
-                seed = f"{source_id}:{seed}"
-        return seed
 
     def _build_timestamp_filter(
         self,

--- a/ingestion_script/ingest_db_source.py
+++ b/ingestion_script/ingest_db_source.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from functools import partial
 from typing import Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from llama_index.core.node_parser import SentenceSplitter
 
@@ -144,7 +144,7 @@ def fetch_db_source_chunks(
         timestamp_value = source_row.get(timestamp_column_name) if timestamp_column_name else None
 
         for chunk_index, chunk_text in enumerate(chunks, start=1):
-            chunk_id = f"{row_id}_{chunk_index}"
+            chunk_id = str(uuid4())
 
             if url_pattern:
                 null_safe_row = {k: ("" if v is None else v) for k, v in source_row.items()}

--- a/tests/qdrant/test_qdrant_service.py
+++ b/tests/qdrant/test_qdrant_service.py
@@ -9,6 +9,12 @@ from engine.llm_services.llm_service import EmbeddingService
 from engine.qdrant_service import BM25_MODEL, FieldSchema, QdrantCollectionSchema, QdrantService, SearchMode
 from tests.mocks.trace_manager import MockTraceManager
 
+CID_1 = "00000000-0000-4000-8000-000000000001"
+CID_2 = "00000000-0000-4000-8000-000000000002"
+CID_3 = "00000000-0000-4000-8000-000000000003"
+CID_4 = "00000000-0000-4000-8000-000000000004"
+CID_5 = "00000000-0000-4000-8000-000000000005"
+
 
 def _sync_batched(qdrant_service: QdrantService, rows: list[dict], collection_name: str) -> bool:
     rows_by_id = {row["chunk_id"]: row for row in rows}
@@ -42,14 +48,14 @@ def test_qdrant_service():
     )
     chunks = [
         {
-            "chunk_id": "1",
+            "chunk_id": CID_1,
             "content": "chunk1",
             "file_id": "file_id1",
             "url": "https//www.dummy1.com",
             "last_edited_ts": "2024-11-26 10:40:40",
         },
         {
-            "chunk_id": "2",
+            "chunk_id": CID_2,
             "content": "chunk2",
             "file_id": "file_id2",
             "url": "https//www.dummy2.com",
@@ -76,7 +82,7 @@ def test_qdrant_service():
     )
     assert qdrant_agentic_service.count_points(TEST_COLLECTION_NAME) == 2
     assert qdrant_agentic_service.delete_chunks(
-        point_ids=["1"],
+        point_ids=[CID_1],
         id_field="chunk_id",
         collection_name=TEST_COLLECTION_NAME,
     )
@@ -86,7 +92,7 @@ def test_qdrant_service():
         collection_name=TEST_COLLECTION_NAME,
     )
     correct_chunk = SourceChunk(
-        name="2",
+        name=CID_2,
         content="chunk2",
         document_name="file_id2",
         url="https//www.dummy2.com",
@@ -96,14 +102,14 @@ def test_qdrant_service():
 
     new_rows_1 = [
         {
-            "chunk_id": "1",
+            "chunk_id": CID_1,
             "content": "chunk1",
             "file_id": "file_id1",
             "url": "https//www.dummy1.com",
             "last_edited_ts": "2025-01-2 10:40:40",
         },
         {
-            "chunk_id": "2",
+            "chunk_id": CID_2,
             "content": "chunk2",
             "url": "https//www.dummy2.com",
             "file_id": "file_id2",
@@ -122,14 +128,14 @@ def test_qdrant_service():
 
     new_rows_2 = [
         {
-            "chunk_id": "1",
+            "chunk_id": CID_1,
             "content": "chunk1",
             "file_id": "file_id1",
             "url": "https//www.dummy1.com",
             "last_edited_ts": "2025-01-2 10:40:40",
         },
         {
-            "chunk_id": "3",
+            "chunk_id": CID_3,
             "content": "chunk3",
             "file_id": "file_id3",
             "url": "https//www.dummy3.com",
@@ -212,7 +218,7 @@ def test_multiple_metadata_fields_index_creation():
     # Add a chunk so collection has data
     chunks = [
         {
-            "chunk_id": "1",
+            "chunk_id": CID_1,
             "content": "test content",
             "file_id": "file_1",
             "url": "https://test.com",
@@ -298,13 +304,13 @@ def test_custom_embedding_size_collection_creation():
 
     chunks = [
         {
-            "chunk_id": "1",
+            "chunk_id": CID_1,
             "content": "test content 1",
             "file_id": "file_1",
             "url": "https://test1.com",
         },
         {
-            "chunk_id": "2",
+            "chunk_id": CID_2,
             "content": "test content 2",
             "file_id": "file_2",
             "url": "https://test2.com",
@@ -359,7 +365,7 @@ def test_merge_qdrant_filters():
 
     chunks = [
         {
-            "chunk_id": "1",
+            "chunk_id": CID_1,
             "content": "chunk1",
             "file_id": "file_1",
             "url": "https://test1.com",
@@ -367,7 +373,7 @@ def test_merge_qdrant_filters():
             "field_2": None,
         },
         {
-            "chunk_id": "2",
+            "chunk_id": CID_2,
             "content": "chunk2",
             "file_id": "file_2",
             "url": "https://test2.com",
@@ -375,7 +381,7 @@ def test_merge_qdrant_filters():
             "field_2": None,
         },
         {
-            "chunk_id": "3",
+            "chunk_id": CID_3,
             "content": "chunk3",
             "file_id": "file_3",
             "url": "https://test3.com",
@@ -383,7 +389,7 @@ def test_merge_qdrant_filters():
             "field_2": "value_2",
         },
         {
-            "chunk_id": "4",
+            "chunk_id": CID_4,
             "content": "chunk4",
             "file_id": "file_4",
             "url": "https://test4.com",
@@ -391,7 +397,7 @@ def test_merge_qdrant_filters():
             "field_2": "value_2",
         },
         {
-            "chunk_id": "5",
+            "chunk_id": CID_5,
             "content": "chunk5",
             "file_id": "file_5",
             "url": "https://test5.com",
@@ -414,7 +420,7 @@ def test_merge_qdrant_filters():
         limit=10,
     )
     assert len(results_filter_1) == 3
-    assert set(chunk.name for chunk in results_filter_1) == {"1", "2", "5"}
+    assert set(chunk.name for chunk in results_filter_1) == {CID_1, CID_2, CID_5}
 
     results_filter_2 = qdrant_service.retrieve_similar_chunks(
         query_text="chunk",
@@ -423,7 +429,7 @@ def test_merge_qdrant_filters():
         limit=10,
     )
     assert len(results_filter_2) == 3
-    assert set(chunk.name for chunk in results_filter_2) == {"3", "4", "5"}
+    assert set(chunk.name for chunk in results_filter_2) == {CID_3, CID_4, CID_5}
 
     merged_filter = merge_qdrant_filters_with_and_conditions(filter_1, filter_2)
     results_merged = qdrant_service.retrieve_similar_chunks(
@@ -433,7 +439,7 @@ def test_merge_qdrant_filters():
         limit=10,
     )
     assert len(results_merged) == 1
-    assert results_merged[0].name == "5"
+    assert results_merged[0].name == CID_5
 
     qdrant_service.delete_collection(TEST_COLLECTION_NAME_MERGE)
 
@@ -469,13 +475,13 @@ def test_search_vectors():
 
     chunks = [
         {
-            "chunk_id": "1",
+            "chunk_id": CID_1,
             "content": "test content 1",
             "file_id": "file_1",
             "url": "https://test1.com",
         },
         {
-            "chunk_id": "2",
+            "chunk_id": CID_2,
             "content": "test content 2",
             "file_id": "file_2",
             "url": "https://test2.com",
@@ -484,10 +490,8 @@ def test_search_vectors():
 
     qdrant_service.add_chunks(list_chunks=chunks, collection_name=TEST_COLLECTION_NAME_SEARCH)
 
-    # Create a query vector (using embedding service)
     query_vector = qdrant_service._build_vectors("test content 1")[0]
 
-    # Search without filter
     results = qdrant_service.search_vectors(
         query_vector=query_vector,
         collection_name=TEST_COLLECTION_NAME_SEARCH,
@@ -496,10 +500,9 @@ def test_search_vectors():
 
     assert len(results) >= 1
     assert isinstance(results[0], tuple)
-    assert len(results[0]) == 3  # (id, score, payload)
+    assert len(results[0]) == 3
 
-    # Search with filter
-    filter_dict = {"must": [{"key": "chunk_id", "match": {"value": "1"}}]}
+    filter_dict = {"must": [{"key": "chunk_id", "match": {"value": CID_1}}]}
     filtered_results = qdrant_service.search_vectors(
         query_vector=query_vector,
         collection_name=TEST_COLLECTION_NAME_SEARCH,
@@ -508,7 +511,7 @@ def test_search_vectors():
     )
 
     assert len(filtered_results) >= 1
-    assert filtered_results[0][0] == "1"
+    assert filtered_results[0][0] == CID_1
 
     qdrant_service.delete_collection(TEST_COLLECTION_NAME_SEARCH)
 
@@ -544,13 +547,13 @@ def test_get_chunk_data_by_id():
 
     chunks = [
         {
-            "chunk_id": "1",
+            "chunk_id": CID_1,
             "content": "test content 1",
             "file_id": "file_1",
             "url": "https://test1.com",
         },
         {
-            "chunk_id": "2",
+            "chunk_id": CID_2,
             "content": "test content 2",
             "file_id": "file_2",
             "url": "https://test2.com",
@@ -559,24 +562,22 @@ def test_get_chunk_data_by_id():
 
     qdrant_service.add_chunks(list_chunks=chunks, collection_name=TEST_COLLECTION_NAME_GET)
 
-    # Get chunk data by IDs
     results = qdrant_service.get_chunk_data_by_id(
-        vector_ids=["1", "2"],
+        vector_ids=[CID_1, CID_2],
         collection_name=TEST_COLLECTION_NAME_GET,
     )
 
     assert len(results) == 2
-    assert any(result.get("payload", {}).get("chunk_id") == "1" for result in results)
-    assert any(result.get("payload", {}).get("chunk_id") == "2" for result in results)
+    assert any(result.get("payload", {}).get("chunk_id") == CID_1 for result in results)
+    assert any(result.get("payload", {}).get("chunk_id") == CID_2 for result in results)
 
-    # Test with single ID
     single_result = qdrant_service.get_chunk_data_by_id(
-        vector_ids=["1"],
+        vector_ids=[CID_1],
         collection_name=TEST_COLLECTION_NAME_GET,
     )
 
     assert len(single_result) == 1
-    assert single_result[0].get("payload", {}).get("chunk_id") == "1"
+    assert single_result[0].get("payload", {}).get("chunk_id") == CID_1
 
     qdrant_service.delete_collection(TEST_COLLECTION_NAME_GET)
 
@@ -612,13 +613,13 @@ def test_get_points():
 
     chunks = [
         {
-            "chunk_id": "1",
+            "chunk_id": CID_1,
             "content": "test content 1",
             "file_id": "file_1",
             "url": "https://test1.com",
         },
         {
-            "chunk_id": "2",
+            "chunk_id": CID_2,
             "content": "test content 2",
             "file_id": "file_2",
             "url": "https://test2.com",
@@ -627,22 +628,20 @@ def test_get_points():
 
     qdrant_service.add_chunks(list_chunks=chunks, collection_name=TEST_COLLECTION_NAME_POINTS)
 
-    # Get all points
     all_points = qdrant_service.get_points(
         collection_name=TEST_COLLECTION_NAME_POINTS,
     )
 
     assert len(all_points) == 2
 
-    # Get points with filter
-    filter_dict = {"must": [{"key": "chunk_id", "match": {"value": "1"}}]}
+    filter_dict = {"must": [{"key": "chunk_id", "match": {"value": CID_1}}]}
     filtered_points = qdrant_service.get_points(
         collection_name=TEST_COLLECTION_NAME_POINTS,
         filter=filter_dict,
     )
 
     assert len(filtered_points) == 1
-    assert filtered_points[0].get("payload", {}).get("chunk_id") == "1"
+    assert filtered_points[0].get("payload", {}).get("chunk_id") == CID_1
 
     qdrant_service.delete_collection(TEST_COLLECTION_NAME_POINTS)
 
@@ -678,13 +677,13 @@ def test_delete_points():
 
     chunks = [
         {
-            "chunk_id": "1",
+            "chunk_id": CID_1,
             "content": "test content 1",
             "file_id": "file_1",
             "url": "https://test1.com",
         },
         {
-            "chunk_id": "2",
+            "chunk_id": CID_2,
             "content": "test content 2",
             "file_id": "file_2",
             "url": "https://test2.com",
@@ -746,9 +745,9 @@ def test_insert_points_in_collection():
 
     points = [
         {
-            "id": "1",
+            "id": CID_1,
             "payload": {
-                "chunk_id": "1",
+                "chunk_id": CID_1,
                 "content": "test content 1",
                 "file_id": "file_1",
                 "url": "https://test1.com",
@@ -759,9 +758,9 @@ def test_insert_points_in_collection():
             },
         },
         {
-            "id": "2",
+            "id": CID_2,
             "payload": {
-                "chunk_id": "2",
+                "chunk_id": CID_2,
                 "content": "test content 2",
                 "file_id": "file_2",
                 "url": "https://test2.com",

--- a/tests/qdrant/test_qdrant_service.py
+++ b/tests/qdrant/test_qdrant_service.py
@@ -508,7 +508,7 @@ def test_search_vectors():
     )
 
     assert len(filtered_results) >= 1
-    assert filtered_results[0][0] == qdrant_service.get_uuid("1")
+    assert filtered_results[0][0] == "1"
 
     qdrant_service.delete_collection(TEST_COLLECTION_NAME_SEARCH)
 
@@ -560,11 +560,8 @@ def test_get_chunk_data_by_id():
     qdrant_service.add_chunks(list_chunks=chunks, collection_name=TEST_COLLECTION_NAME_GET)
 
     # Get chunk data by IDs
-    chunk_1_uuid = qdrant_service.get_uuid("1")
-    chunk_2_uuid = qdrant_service.get_uuid("2")
-
     results = qdrant_service.get_chunk_data_by_id(
-        vector_ids=[chunk_1_uuid, chunk_2_uuid],
+        vector_ids=["1", "2"],
         collection_name=TEST_COLLECTION_NAME_GET,
     )
 
@@ -574,7 +571,7 @@ def test_get_chunk_data_by_id():
 
     # Test with single ID
     single_result = qdrant_service.get_chunk_data_by_id(
-        vector_ids=[chunk_1_uuid],
+        vector_ids=["1"],
         collection_name=TEST_COLLECTION_NAME_GET,
     )
 
@@ -749,7 +746,7 @@ def test_insert_points_in_collection():
 
     points = [
         {
-            "id": qdrant_service.get_uuid("1"),
+            "id": "1",
             "payload": {
                 "chunk_id": "1",
                 "content": "test content 1",
@@ -762,7 +759,7 @@ def test_insert_points_in_collection():
             },
         },
         {
-            "id": qdrant_service.get_uuid("2"),
+            "id": "2",
             "payload": {
                 "chunk_id": "2",
                 "content": "test content 2",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Converted legacy chunk identifiers to UUIDs in the database and updated vector storage payloads, with migration logging and rollback support.
  * New ingests now assign fresh UUIDs to chunks.
  * Simplified identifier handling in the vector storage service so stored point IDs match source chunk IDs.

* **Tests**
  * Updated tests to use the new raw chunk ID values and validate the revised identifier behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->