### PR TITLE
feat(ingestion): switch source attribute reads to EAV DRA-1273

### DIFF
--- a/ada_backend/admin/admin.py
+++ b/ada_backend/admin/admin.py
@@ -552,7 +552,7 @@ class SourceAdmin(EnhancedModelView, model=db.DataSource):
     ]
 
 
-class SourceAttributesAdmin(EnhancedModelView, model=db.SourceAttributeEntry):
+class SourceAttributesAdmin(EnhancedModelView, model=db.SourceAttribute):
     category = AdminCategory.SOURCES
     icon = "fas fa-database"
     column_list = [

--- a/ada_backend/admin/admin.py
+++ b/ada_backend/admin/admin.py
@@ -552,12 +552,14 @@ class SourceAdmin(EnhancedModelView, model=db.DataSource):
     ]
 
 
-class SourceAttributesAdmin(EnhancedModelView, model=db.SourceAttributes):
+class SourceAttributesAdmin(EnhancedModelView, model=db.SourceAttributeEntry):
     category = AdminCategory.SOURCES
     icon = "fas fa-database"
     column_list = [
         "id",
         "source_id",
+        "attribute_name",
+        "value",
         "created_at",
         "updated_at",
     ]

--- a/ada_backend/database/alembic/versions/93189a98fdf2_drop_legacy_source_attributes_table.py
+++ b/ada_backend/database/alembic/versions/93189a98fdf2_drop_legacy_source_attributes_table.py
@@ -1,0 +1,84 @@
+"""drop legacy source_attributes table
+
+Revision ID: 93189a98fdf2
+Revises: k2l3m4n5o6p7
+Create Date: 2026-04-27 14:12:47.867361
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "93189a98fdf2"
+down_revision: Union[str, None] = "k2l3m4n5o6p7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy: Union[str, None] = "code-first"
+
+
+def upgrade() -> None:
+    op.drop_index(op.f("ix_source_attributes_id"), table_name="source_attributes")
+    op.drop_table("source_attributes")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "source_attributes",
+        sa.Column("id", sa.UUID(), autoincrement=False, nullable=False),
+        sa.Column("source_id", sa.UUID(), autoincrement=False, nullable=False),
+        sa.Column("access_token", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.Column("path", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.Column(
+            "list_of_files_from_local_folder",
+            postgresql.JSON(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.Column("folder_id", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.Column("source_db_url", sa.UUID(), autoincrement=False, nullable=True),
+        sa.Column("source_table_name", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.Column("id_column_name", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.Column("text_column_names", postgresql.JSON(astext_type=sa.Text()), autoincrement=False, nullable=True),
+        sa.Column("source_schema_name", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.Column("chunk_size", sa.INTEGER(), autoincrement=False, nullable=True),
+        sa.Column("chunk_overlap", sa.INTEGER(), autoincrement=False, nullable=True),
+        sa.Column("metadata_column_names", postgresql.JSON(astext_type=sa.Text()), autoincrement=False, nullable=True),
+        sa.Column("timestamp_column_name", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.Column("url_pattern", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.Column("update_existing", sa.BOOLEAN(), autoincrement=False, nullable=False),
+        sa.Column("query_filter", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.Column("timestamp_filter", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.Column(
+            "created_at",
+            postgresql.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            postgresql.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_db_url"],
+            ["organization_secrets.id"],
+            name=op.f("source_attributes_source_db_url_fkey"),
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_id"],
+            ["data_sources.id"],
+            name=op.f("source_attributes_source_id_fkey"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("source_attributes_pkey")),
+    )
+    op.create_index(op.f("ix_source_attributes_id"), "source_attributes", ["id"], unique=False)

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -1576,11 +1576,6 @@ class OrganizationSecret(Base):
         back_populates="organization_secret",
         cascade="all, delete-orphan",
     )
-    source_attributes = relationship(
-        "SourceAttributes",
-        back_populates="source_db_url_secret",
-        passive_deletes=True,
-    )
 
     def __str__(self):
         return f"OrganizationSecret(organization_id={self.organization_id}, key={self.key})"
@@ -1701,12 +1696,6 @@ class DataSource(Base):
     last_ingestion_time = mapped_column(DateTime(timezone=True), nullable=True)
 
     ingestion_tasks = relationship("IngestionTask", back_populates="source")
-    # TODO(DRA-1273): Remove once reads no longer depend on the legacy wide table.
-    attributes = relationship(
-        "SourceAttributes",
-        back_populates="source",
-        cascade="all, delete-orphan",
-    )
     attribute_entries = relationship(
         "SourceAttributeEntry",
         back_populates="source",
@@ -1715,49 +1704,6 @@ class DataSource(Base):
 
     def __str__(self):
         return f"DataSource({self.name})"
-
-
-class SourceAttributes(Base):
-    """
-    Represents attributes for a data source.
-    """
-    # TODO(DRA-1273): Delete after switching reads to EAV and dropping the legacy table.
-
-    __tablename__ = "source_attributes"
-
-    id = mapped_column(UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4)
-    source_id = mapped_column(
-        UUID(as_uuid=True),
-        ForeignKey("data_sources.id", ondelete="CASCADE"),
-        nullable=False,
-    )
-    access_token = mapped_column(String, nullable=True)
-    path = mapped_column(String, nullable=True)
-    list_of_files_from_local_folder = mapped_column(JSON, nullable=True)
-    folder_id = mapped_column(String, nullable=True)
-    source_db_url = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organization_secrets.id", ondelete="SET NULL"), nullable=True
-    )
-    source_table_name = mapped_column(String, nullable=True)
-    id_column_name = mapped_column(String, nullable=True)
-    text_column_names = mapped_column(JSON, nullable=True)
-    source_schema_name = mapped_column(String, nullable=True)
-    chunk_size = mapped_column(Integer, nullable=True)
-    chunk_overlap = mapped_column(Integer, nullable=True)
-    metadata_column_names = mapped_column(JSON, nullable=True)
-    timestamp_column_name = mapped_column(String, nullable=True)
-    url_pattern = mapped_column(String, nullable=True)
-    update_existing = mapped_column(Boolean, nullable=False, default=False)
-    query_filter = mapped_column(String, nullable=True)
-    timestamp_filter = mapped_column(String, nullable=True)
-    created_at = mapped_column(DateTime(timezone=True), server_default=func.now())
-    updated_at = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
-
-    source = relationship("DataSource", back_populates="attributes")
-    source_db_url_secret = relationship("OrganizationSecret", back_populates="source_attributes")
-
-    def __str__(self):
-        return f"SourceAttributes(source_id={self.source_id})"
 
 
 class SourceAttributeEntry(Base):

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -1696,8 +1696,8 @@ class DataSource(Base):
     last_ingestion_time = mapped_column(DateTime(timezone=True), nullable=True)
 
     ingestion_tasks = relationship("IngestionTask", back_populates="source")
-    attribute_entries = relationship(
-        "SourceAttributeEntry",
+    attributes = relationship(
+        "SourceAttribute",
         back_populates="source",
         cascade="all, delete-orphan",
     )
@@ -1706,9 +1706,10 @@ class DataSource(Base):
         return f"DataSource({self.name})"
 
 
-class SourceAttributeEntry(Base):
+class SourceAttribute(Base):
     """Represents a single persisted source attribute in the EAV transition table."""
 
+    # TODO: rename to source_attributes (index too) for consistency.
     __tablename__ = "source_attribute_entries"
     __table_args__ = (
         UniqueConstraint(
@@ -1730,7 +1731,7 @@ class SourceAttributeEntry(Base):
     created_at = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
-    source = relationship("DataSource", back_populates="attribute_entries")
+    source = relationship("DataSource", back_populates="attributes")
 
     @validates("attribute_name")
     def validate_attribute_name(self, _, attribute_name: str) -> str:
@@ -1739,7 +1740,7 @@ class SourceAttributeEntry(Base):
         return attribute_name
 
     def __str__(self):
-        return f"SourceAttributeEntry(source_id={self.source_id}, attribute_name={self.attribute_name})"
+        return f"SourceAttribute(source_id={self.source_id}, attribute_name={self.attribute_name})"
 
 
 class CronJob(Base):
@@ -1883,9 +1884,7 @@ class DatasetProject(Base):
     project = relationship("Project", back_populates="datasets")
     input_groundtruths = relationship("InputGroundtruth", back_populates="dataset", cascade="all, delete-orphan")
     qa_metadata = relationship("QADatasetMetadata", back_populates="dataset", cascade="all, delete-orphan")
-    project_associations = relationship(
-        "DatasetProjectAssociation", cascade="all, delete-orphan", lazy="selectin"
-    )
+    project_associations = relationship("DatasetProjectAssociation", cascade="all, delete-orphan", lazy="selectin")
 
     def __str__(self):
         return f"DatasetProject(id={self.id}, name={self.dataset_name})"
@@ -2028,9 +2027,7 @@ class LLMJudge(Base):
 
     project = relationship("Project")
     evaluations = relationship("JudgeEvaluation", back_populates="judge", cascade="all, delete-orphan")
-    project_associations = relationship(
-        "LLMJudgeProjectAssociation", cascade="all, delete-orphan", lazy="selectin"
-    )
+    project_associations = relationship("LLMJudgeProjectAssociation", cascade="all, delete-orphan", lazy="selectin")
 
     def __str__(self):
         return f"LLMJudge(id={self.id}, name={self.name}, evaluation_type={self.evaluation_type})"

--- a/ada_backend/repositories/source_repository.py
+++ b/ada_backend/repositories/source_repository.py
@@ -15,9 +15,9 @@ from ada_backend.schemas.ingestion_task_schema import SourceAttributes
 LOGGER = logging.getLogger(__name__)
 
 
-def _build_source_attribute_entries(source_id: UUID, attributes: dict[str, Any]) -> list[db.SourceAttributeEntry]:
+def _build_source_attribute_entries(source_id: UUID, attributes: dict[str, Any]) -> list[db.SourceAttribute]:
     return [
-        db.SourceAttributeEntry(
+        db.SourceAttribute(
             source_id=source_id,
             attribute_name=attribute_name,
             value=value,
@@ -167,9 +167,7 @@ def get_source_attributes(
 ) -> SourceAttributes:
     """Get source attributes including decrypted database URL from the SourceAttributes table."""
 
-    rows = (
-        session_sql_alchemy.query(db.SourceAttributeEntry).filter(db.SourceAttributeEntry.source_id == source_id).all()
-    )
+    rows = session_sql_alchemy.query(db.SourceAttribute).filter(db.SourceAttribute.source_id == source_id).all()
 
     if not rows:
         raise ValueError(f"Source attributes not found for source_id={source_id}")

--- a/ada_backend/repositories/source_repository.py
+++ b/ada_backend/repositories/source_repository.py
@@ -174,8 +174,9 @@ def get_source_attributes(
 
     attr_dict = {row.attribute_name: row.value for row in rows}
 
-    if "source_db_url" in attr_dict:
-        secret_id = UUID(attr_dict["source_db_url"])
+    source_db_url_key = db.SourceAttributeKey.SOURCE_DB_URL.value
+    if source_db_url_key in attr_dict:
+        secret_id = UUID(attr_dict[source_db_url_key])
         org_secret = (
             session_sql_alchemy.query(db.OrganizationSecret)
             .filter(
@@ -184,7 +185,7 @@ def get_source_attributes(
             )
             .first()
         )
-        attr_dict["source_db_url"] = org_secret.get_secret() if org_secret else None
+        attr_dict[source_db_url_key] = org_secret.get_secret() if org_secret else None
 
     return SourceAttributes(**attr_dict)
 

--- a/ada_backend/repositories/source_repository.py
+++ b/ada_backend/repositories/source_repository.py
@@ -167,7 +167,15 @@ def get_source_attributes(
 ) -> SourceAttributes:
     """Get source attributes including decrypted database URL from the SourceAttributes table."""
 
-    rows = session_sql_alchemy.query(db.SourceAttribute).filter(db.SourceAttribute.source_id == source_id).all()
+    rows = (
+        session_sql_alchemy.query(db.SourceAttribute)
+        .join(db.DataSource, db.SourceAttribute.source_id == db.DataSource.id)
+        .filter(
+            db.SourceAttribute.source_id == source_id,
+            db.DataSource.organization_id == organization_id,
+        )
+        .all()
+    )
 
     if not rows:
         raise ValueError(f"Source attributes not found for source_id={source_id}")

--- a/ada_backend/repositories/source_repository.py
+++ b/ada_backend/repositories/source_repository.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Any, Optional
 from uuid import UUID
 
-from sqlalchemy import and_, exists, func, select
+from sqlalchemy import exists, func, select
 from sqlalchemy.orm import Session
 
 from ada_backend.database import models as db
@@ -114,28 +114,6 @@ def create_source(
             secret_type=db.OrgSecretType.PASSWORD,
         )
 
-        # TODO(DRA-1273): Remove this legacy wide-table write after the read path switches to EAV.
-        source_attributes = db.SourceAttributes(
-            source_id=source_data_create.id,
-            access_token=attributes.access_token,
-            path=attributes.path,
-            list_of_files_from_local_folder=attributes.list_of_files_from_local_folder,
-            folder_id=attributes.folder_id,
-            source_db_url=org_secret.id,
-            source_table_name=attributes.source_table_name,
-            id_column_name=attributes.id_column_name,
-            text_column_names=attributes.text_column_names,
-            source_schema_name=attributes.source_schema_name,
-            chunk_size=attributes.chunk_size,
-            chunk_overlap=attributes.chunk_overlap,
-            metadata_column_names=attributes.metadata_column_names,
-            timestamp_column_name=attributes.timestamp_column_name,
-            url_pattern=attributes.url_pattern,
-            update_existing=attributes.update_existing,
-            query_filter=attributes.query_filter,
-            timestamp_filter=attributes.timestamp_filter,
-        )
-
         eav_attributes = {
             key: value
             for key, value in attributes.model_dump(mode="json", exclude_none=True).items()
@@ -145,7 +123,6 @@ def create_source(
 
         source_attribute_entries = _build_source_attribute_entries(source_data_create.id, eav_attributes)
 
-        session.add(source_attributes)
         session.add_all(source_attribute_entries)
         session.commit()
     return source_data_create.id
@@ -190,47 +167,28 @@ def get_source_attributes(
 ) -> SourceAttributes:
     """Get source attributes including decrypted database URL from the SourceAttributes table."""
 
-    result = (
-        session_sql_alchemy.query(db.SourceAttributes, db.OrganizationSecret)
-        .outerjoin(
-            db.OrganizationSecret,
-            and_(
-                db.SourceAttributes.source_db_url == db.OrganizationSecret.id,
-                db.OrganizationSecret.organization_id == organization_id,
-            ),
-        )
-        .filter(db.SourceAttributes.source_id == source_id)
-        .first()
+    rows = (
+        session_sql_alchemy.query(db.SourceAttributeEntry).filter(db.SourceAttributeEntry.source_id == source_id).all()
     )
 
-    if not result:
+    if not rows:
         raise ValueError(f"Source attributes not found for source_id={source_id}")
 
-    source_attributes, org_secret = result
+    attr_dict = {row.attribute_name: row.value for row in rows}
 
-    attributes = SourceAttributes(
-        access_token=source_attributes.access_token,
-        path=source_attributes.path,
-        list_of_files_from_local_folder=source_attributes.list_of_files_from_local_folder,
-        folder_id=source_attributes.folder_id,
-        source_table_name=source_attributes.source_table_name,
-        id_column_name=source_attributes.id_column_name,
-        text_column_names=source_attributes.text_column_names,
-        source_schema_name=source_attributes.source_schema_name,
-        chunk_size=source_attributes.chunk_size,
-        chunk_overlap=source_attributes.chunk_overlap,
-        metadata_column_names=source_attributes.metadata_column_names,
-        timestamp_column_name=source_attributes.timestamp_column_name,
-        url_pattern=source_attributes.url_pattern,
-        update_existing=source_attributes.update_existing,
-        query_filter=source_attributes.query_filter,
-        timestamp_filter=source_attributes.timestamp_filter,
-    )
+    if "source_db_url" in attr_dict:
+        secret_id = UUID(attr_dict["source_db_url"])
+        org_secret = (
+            session_sql_alchemy.query(db.OrganizationSecret)
+            .filter(
+                db.OrganizationSecret.id == secret_id,
+                db.OrganizationSecret.organization_id == organization_id,
+            )
+            .first()
+        )
+        attr_dict["source_db_url"] = org_secret.get_secret() if org_secret else None
 
-    if org_secret:
-        attributes.source_db_url = org_secret.get_secret()
-
-    return attributes
+    return SourceAttributes(**attr_dict)
 
 
 def get_projects_using_source(


### PR DESCRIPTION
## What changed

This PR completes the read-side switch from the legacy wide `source_attributes` table to the EAV `source_attribute_entries` table introduced in DRA-1272.

On the backend side, the legacy `SourceAttributes` ORM model and its related relationships are removed, source creation stops dual-writing to the legacy table, and `get_source_attributes()` now reconstructs the Pydantic schema from EAV rows while still resolving `source_db_url` through `OrganizationSecret`. The coexistence model is also renamed from `SourceAttributeEntry` to `SourceAttribute` to match its long-term role.

The admin view is updated to display the EAV shape (`attribute_name`, `value`) instead of the legacy wide-table shape.

## Why

DRA-1272 created and backfilled the EAV table but deliberately kept reads on the legacy schema. This PR removes that transitional dependency so the application no longer relies on the wide `source_attributes` table at runtime.

For the migration strategy, we intentionally keep the physical EAV table name as `source_attribute_entries` for now and only drop the legacy `source_attributes` table. Renaming the EAV table in the same PR would create a code-first deployment mismatch, because the new code would point at the new name before the migration had run.

## Migration

A new Alembic migration drops the legacy `source_attributes` table with `deploy_strategy = "code-first"`. The downgrade recreates the old table shape so rollback remains possible.

## Out of scope

- Renaming `source_attribute_entries` to `source_attributes` table (because that would require a `breaking` migration)
- Renaming the EAV index/constraint names to match the final table name
- Expanding persisted source attributes beyond the current database-source path

## Validation

- `make db-upgrade` moved Alembic from `k2l3m4n5o6p7` to `93189a98fdf2`
- confirmed `source_attributes` was dropped while `source_attribute_entries` and its indexes/unique constraint remained intact
- `make db-downgrade` restored `source_attributes` and returned Alembic to `k2l3m4n5o6p7`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal source attribute data handling for improved system efficiency. Enhanced the admin panel to display attribute names and values more clearly alongside existing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->