### PR TITLE
feat(cron): Unwrap polled item fields into input_data dra-1282

### DIFF
--- a/ada_backend/services/cron/endpoint_polling_service.py
+++ b/ada_backend/services/cron/endpoint_polling_service.py
@@ -372,7 +372,7 @@ async def run_endpoint_polling(
                     body = {
                         "input_data": {
                             "messages": [{"role": "user", "content": input_message}],
-                            "item": item,
+                            **item,
                         },
                         "cron_id": str(cron_id),
                     }


### PR DESCRIPTION
# Unwrap polled item fields into input_data

## Summary
- Spread the polled endpoint item directly into `input_data` instead of nesting it under an "item" key, so its fields are available as top-level keys for field expression injection.

## Context
When endpoint polling triggers a workflow run, the polled item's data was nested as `input_data.item.<field>`. This made it impossible to reference item fields directly via injection (e.g. `{{input_data.name}}`). By unwrapping with `**item`, each field from the polled item becomes a top-level key in `input_data` alongside messages, enabling straightforward injection like `{{input_data.some_field}}`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal data structure handling for endpoint polling webhook requests to streamline payload configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->