### PR TITLE
Unified Mail Sender component — DRA-1279 

### DIFF
--- a/ada_backend/database/alembic/versions/88538199bc7b_add_exclusive_oauth_connection_ui_component.py
+++ b/ada_backend/database/alembic/versions/88538199bc7b_add_exclusive_oauth_connection_ui_component.py
@@ -1,0 +1,26 @@
+"""add exclusive oauth connection ui component enum value
+
+Revision ID: 88538199bc7b
+Revises: 93189a98fdf2
+Create Date: 2026-04-29 17:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "88538199bc7b"
+down_revision: Union[str, None] = "93189a98fdf2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy: Union[str, None] = "migrate-first"
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE ui_component ADD VALUE IF NOT EXISTS 'ExclusiveOAuthConnection'")
+
+
+def downgrade() -> None:
+    pass

--- a/ada_backend/database/alembic/versions/88538199bc7b_add_exclusive_oauth_connection_ui_component.py
+++ b/ada_backend/database/alembic/versions/88538199bc7b_add_exclusive_oauth_connection_ui_component.py
@@ -1,7 +1,7 @@
 """add exclusive oauth connection ui component enum value
 
 Revision ID: 88538199bc7b
-Revises: 93189a98fdf2
+Revises: l3m4n5o6p7q8
 Create Date: 2026-04-29 17:00:00.000000
 
 """
@@ -11,7 +11,7 @@ from typing import Sequence, Union
 from alembic import op
 
 revision: str = "88538199bc7b"
-down_revision: Union[str, None] = "93189a98fdf2"
+down_revision: Union[str, None] = "l3m4n5o6p7q8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/ada_backend/database/alembic/versions/88538199bc7b_add_exclusive_oauth_connection_ui_component.py
+++ b/ada_backend/database/alembic/versions/88538199bc7b_add_exclusive_oauth_connection_ui_component.py
@@ -1,7 +1,7 @@
 """add exclusive oauth connection ui component enum value
 
 Revision ID: 88538199bc7b
-Revises: l3m4n5o6p7q8
+Revises: 03a252d28d9f
 Create Date: 2026-04-29 17:00:00.000000
 
 """
@@ -11,7 +11,7 @@ from typing import Sequence, Union
 from alembic import op
 
 revision: str = "88538199bc7b"
-down_revision: Union[str, None] = "l3m4n5o6p7q8"
+down_revision: Union[str, None] = "03a252d28d9f"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -172,6 +172,7 @@ class UIComponent(StrEnum):
     #       not OAuthConnection.id. Rename the parameter to "oauth_definition_id" in all
     #       seed files + a DB migration to update component_parameter_definitions.name.
     OAUTH_CONNECTION = "OAuthConnection"
+    EXCLUSIVE_OAUTH_CONNECTION = "ExclusiveOAuthConnection"
     CODE = "Code"
     ROUTE_BUILDER = "RouteBuilder"
     CATEGORIES_BUILDER = "CategoriesBuilder"

--- a/ada_backend/database/seed/integrations/seed_mail_sender.py
+++ b/ada_backend/database/seed/integrations/seed_mail_sender.py
@@ -33,6 +33,7 @@ from engine.integrations.gmail.gmail_sender import (
 from engine.integrations.providers import OAuthProvider
 
 MAIL_SENDER_PARAMETER_GROUP_UUIDS: dict[str, UUID] = {
+    "connection": UUID("1afcebb8-c315-4638-8717-959319efd81e"),
     "email_content": GMAIL_GROUP_EMAIL_CONTENT_ID,
     "recipients": GMAIL_GROUP_RECIPIENTS_ID,
     "attachments": GMAIL_GROUP_ATTACHMENTS_ID,
@@ -68,11 +69,12 @@ def seed_mail_sender_components(session: Session):
             type=ParameterType.STRING,
             nullable=True,
             display_order=0,
+            parameter_group_id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["connection"],
             parameter_order_within_group=0,
             ui_component=UIComponent.OAUTH_CONNECTION,
             ui_component_properties={
                 "label": "Gmail Connection",
-                "description": "Connect Gmail (leave Outlook disconnected if you use Gmail)",
+                "description": "Select a Gmail connection.",
                 "provider": OAuthProvider.GMAIL.value,
                 "icon": "logos-google-gmail",
             },
@@ -84,11 +86,12 @@ def seed_mail_sender_components(session: Session):
             type=ParameterType.STRING,
             nullable=True,
             display_order=1,
+            parameter_group_id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["connection"],
             parameter_order_within_group=1,
             ui_component=UIComponent.OAUTH_CONNECTION,
             ui_component_properties={
                 "label": "Outlook Connection",
-                "description": "Connect Outlook (leave Gmail disconnected if you use Outlook)",
+                "description": "Select an Outlook connection.",
                 "provider": OAuthProvider.OUTLOOK.value,
                 "icon": "custom-microsoft-outlook",
             },
@@ -127,6 +130,10 @@ def seed_mail_sender_components(session: Session):
 def seed_mail_sender_parameter_groups(session: Session):
     parameter_groups = [
         db.ParameterGroup(
+            id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["connection"],
+            name="Connection (use exactly one)",
+        ),
+        db.ParameterGroup(
             id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["email_content"],
             name="Email Content",
         ),
@@ -142,6 +149,11 @@ def seed_mail_sender_parameter_groups(session: Session):
     build_parameters_group(session, parameter_groups)
 
     component_parameter_groups = [
+        db.ComponentParameterGroup(
+            component_version_id=COMPONENT_VERSION_UUIDS["mail_sender"],
+            parameter_group_id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["connection"],
+            group_order_within_component=0,
+        ),
         db.ComponentParameterGroup(
             component_version_id=COMPONENT_VERSION_UUIDS["mail_sender"],
             parameter_group_id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["email_content"],

--- a/ada_backend/database/seed/integrations/seed_mail_sender.py
+++ b/ada_backend/database/seed/integrations/seed_mail_sender.py
@@ -148,6 +148,8 @@ def seed_mail_sender_parameter_groups(session: Session):
     ]
     build_parameters_group(session, parameter_groups)
 
+
+def seed_mail_sender_component_parameter_groups(session: Session):
     component_parameter_groups = [
         db.ComponentParameterGroup(
             component_version_id=COMPONENT_VERSION_UUIDS["mail_sender"],

--- a/ada_backend/database/seed/integrations/seed_mail_sender.py
+++ b/ada_backend/database/seed/integrations/seed_mail_sender.py
@@ -71,7 +71,7 @@ def seed_mail_sender_components(session: Session):
             display_order=0,
             parameter_group_id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["connection"],
             parameter_order_within_group=0,
-            ui_component=UIComponent.OAUTH_CONNECTION,
+            ui_component=UIComponent.EXCLUSIVE_OAUTH_CONNECTION,
             ui_component_properties={
                 "label": "Gmail Connection",
                 "description": "Select a Gmail connection.",
@@ -88,7 +88,7 @@ def seed_mail_sender_components(session: Session):
             display_order=1,
             parameter_group_id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["connection"],
             parameter_order_within_group=1,
-            ui_component=UIComponent.OAUTH_CONNECTION,
+            ui_component=UIComponent.EXCLUSIVE_OAUTH_CONNECTION,
             ui_component_properties={
                 "label": "Outlook Connection",
                 "description": "Select an Outlook connection.",
@@ -131,7 +131,7 @@ def seed_mail_sender_parameter_groups(session: Session):
     parameter_groups = [
         db.ParameterGroup(
             id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["connection"],
-            name="Connection (use exactly one)",
+            name="Connection",
         ),
         db.ParameterGroup(
             id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["email_content"],

--- a/ada_backend/database/seed/integrations/seed_mail_sender.py
+++ b/ada_backend/database/seed/integrations/seed_mail_sender.py
@@ -1,0 +1,161 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ada_backend.database import models as db
+from ada_backend.database.component_definition_seeding import (
+    upsert_component_categories,
+    upsert_component_versions,
+    upsert_components,
+    upsert_components_parameter_definitions,
+    upsert_release_stage_to_current_version_mapping,
+)
+from ada_backend.database.models import (
+    Component,
+    ComponentParameterDefinition,
+    ParameterType,
+    UIComponent,
+    UIComponentProperties,
+)
+from ada_backend.database.seed.seed_categories import CATEGORY_UUIDS
+from ada_backend.database.seed.seed_tool_description import TOOL_DESCRIPTION_UUIDS
+from ada_backend.database.seed.utils import (
+    COMPONENT_UUIDS,
+    COMPONENT_VERSION_UUIDS,
+    build_parameters_group,
+    build_parameters_group_definitions,
+)
+from engine.integrations.gmail.gmail_sender import (
+    GMAIL_GROUP_ATTACHMENTS_ID,
+    GMAIL_GROUP_EMAIL_CONTENT_ID,
+    GMAIL_GROUP_RECIPIENTS_ID,
+)
+from engine.integrations.providers import OAuthProvider
+
+MAIL_SENDER_PARAMETER_GROUP_UUIDS: dict[str, UUID] = {
+    "email_content": GMAIL_GROUP_EMAIL_CONTENT_ID,
+    "recipients": GMAIL_GROUP_RECIPIENTS_ID,
+    "attachments": GMAIL_GROUP_ATTACHMENTS_ID,
+}
+
+
+def seed_mail_sender_components(session: Session):
+    mail_sender_component = Component(
+        id=COMPONENT_UUIDS["mail_sender"],
+        name="Mail Sender",
+        is_agent=True,
+        function_callable=True,
+        can_use_function_calling=False,
+        icon="tabler-mail",
+    )
+    upsert_components(session, [mail_sender_component])
+
+    mail_sender_version = db.ComponentVersion(
+        id=COMPONENT_VERSION_UUIDS["mail_sender"],
+        component_id=COMPONENT_UUIDS["mail_sender"],
+        version_tag="0.0.1",
+        release_stage=db.ReleaseStage.INTERNAL,
+        description="Send email via Gmail or Outlook by connecting one provider.",
+        default_tool_description_id=TOOL_DESCRIPTION_UUIDS["mail_sender_tool_description"],
+    )
+    upsert_component_versions(session, [mail_sender_version])
+
+    mail_sender_parameter_definitions = [
+        ComponentParameterDefinition(
+            id=UUID("90cedcdf-2bcb-4f12-a2c2-2fcaedd2b365"),
+            component_version_id=mail_sender_version.id,
+            name="gmail_oauth_connection_id",
+            type=ParameterType.STRING,
+            nullable=True,
+            display_order=0,
+            parameter_order_within_group=0,
+            ui_component=UIComponent.OAUTH_CONNECTION,
+            ui_component_properties={
+                "label": "Gmail Connection",
+                "description": "Connect Gmail (leave Outlook disconnected if you use Gmail)",
+                "provider": OAuthProvider.GMAIL.value,
+                "icon": "logos-google-gmail",
+            },
+        ),
+        ComponentParameterDefinition(
+            id=UUID("eedfb8be-388e-444a-bebd-84599493661d"),
+            component_version_id=mail_sender_version.id,
+            name="outlook_oauth_connection_id",
+            type=ParameterType.STRING,
+            nullable=True,
+            display_order=1,
+            parameter_order_within_group=1,
+            ui_component=UIComponent.OAUTH_CONNECTION,
+            ui_component_properties={
+                "label": "Outlook Connection",
+                "description": "Connect Outlook (leave Gmail disconnected if you use Outlook)",
+                "provider": OAuthProvider.OUTLOOK.value,
+                "icon": "custom-microsoft-outlook",
+            },
+        ),
+        ComponentParameterDefinition(
+            id=UUID("70a74f93-0756-45be-aea6-8de3216a28b6"),
+            component_version_id=mail_sender_version.id,
+            name="save_as_draft",
+            type=ParameterType.BOOLEAN,
+            nullable=False,
+            default=True,
+            ui_component=UIComponent.CHECKBOX,
+            ui_component_properties=UIComponentProperties(
+                type="checkbox",
+                label="Save as Draft",
+                description="If checked, the email will be saved as a draft instead of being sent immediately.",
+            ).model_dump(exclude_unset=True, exclude_none=True),
+        ),
+    ]
+    upsert_components_parameter_definitions(session, mail_sender_parameter_definitions)
+
+    upsert_release_stage_to_current_version_mapping(
+        session=session,
+        component_id=mail_sender_version.component_id,
+        release_stage=mail_sender_version.release_stage,
+        component_version_id=mail_sender_version.id,
+    )
+
+    upsert_component_categories(
+        session=session,
+        component_id=mail_sender_component.id,
+        category_ids=[CATEGORY_UUIDS["messaging"], CATEGORY_UUIDS["integrations"]],
+    )
+
+
+def seed_mail_sender_parameter_groups(session: Session):
+    parameter_groups = [
+        db.ParameterGroup(
+            id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["email_content"],
+            name="Email Content",
+        ),
+        db.ParameterGroup(
+            id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["recipients"],
+            name="Recipients",
+        ),
+        db.ParameterGroup(
+            id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["attachments"],
+            name="Attachments",
+        ),
+    ]
+    build_parameters_group(session, parameter_groups)
+
+    component_parameter_groups = [
+        db.ComponentParameterGroup(
+            component_version_id=COMPONENT_VERSION_UUIDS["mail_sender"],
+            parameter_group_id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["email_content"],
+            group_order_within_component=1,
+        ),
+        db.ComponentParameterGroup(
+            component_version_id=COMPONENT_VERSION_UUIDS["mail_sender"],
+            parameter_group_id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["recipients"],
+            group_order_within_component=2,
+        ),
+        db.ComponentParameterGroup(
+            component_version_id=COMPONENT_VERSION_UUIDS["mail_sender"],
+            parameter_group_id=MAIL_SENDER_PARAMETER_GROUP_UUIDS["attachments"],
+            group_order_within_component=3,
+        ),
+    ]
+    build_parameters_group_definitions(session, component_parameter_groups)

--- a/ada_backend/database/seed/integrations/seed_mail_sender.py
+++ b/ada_backend/database/seed/integrations/seed_mail_sender.py
@@ -43,7 +43,7 @@ MAIL_SENDER_PARAMETER_GROUP_UUIDS: dict[str, UUID] = {
 def seed_mail_sender_components(session: Session):
     mail_sender_component = Component(
         id=COMPONENT_UUIDS["mail_sender"],
-        name="Mail Sender",
+        name="Email Sender",
         is_agent=True,
         function_callable=True,
         can_use_function_calling=False,

--- a/ada_backend/database/seed/seed_tool_description.py
+++ b/ada_backend/database/seed/seed_tool_description.py
@@ -27,6 +27,7 @@ from engine.components.tools.tavily_search_tool import TAVILY_TOOL_DESCRIPTION
 from engine.components.tools.terminal_command_runner import TERMINAL_COMMAND_RUNNER_TOOL_DESCRIPTION
 from engine.components.web_search_tool_openai import DEFAULT_WEB_SEARCH_OPENAI_TOOL_DESCRIPTION
 from engine.integrations.gmail.gmail_sender import GMAIL_SENDER_TOOL_DESCRIPTION
+from engine.integrations.mail_sender import MAIL_SENDER_TOOL_DESCRIPTION
 from engine.integrations.outlook.outlook_sender import OUTLOOK_SENDER_TOOL_DESCRIPTION
 from engine.integrations.slack.slack_sender import SLACK_SENDER_TOOL_DESCRIPTION
 
@@ -57,6 +58,7 @@ TOOL_DESCRIPTION_UUIDS = {
     "hubspot_neverdrop_mcp_tool_description": UUID("a1e7f624-6c98-4546-b769-3607819ebad2"),
     "google_calendar_mcp_tool_description": UUID("d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a"),
     "outlook_sender_tool_description": UUID("31344b0e-4949-42b6-98a8-6b1dcec98f3c"),
+    "mail_sender_tool_description": UUID("7fe2178e-36c6-4195-aa5b-9a9178be70e8"),
     "default_sql_tool_description": UUID("7a2b3c4d-5e6f-4a8b-9c0d-1e2f3a4b5c6d"),
     "scorer_tool_description": UUID("8f9d4c3e-7a2b-4e1d-9c8f-5b6a3d2e1f0b"),
 }
@@ -161,6 +163,10 @@ def seed_tool_description(session: Session):
         id=TOOL_DESCRIPTION_UUIDS["outlook_sender_tool_description"],
         **OUTLOOK_SENDER_TOOL_DESCRIPTION.model_dump(),
     )
+    mail_sender_tool_description = db.ToolDescription(
+        id=TOOL_DESCRIPTION_UUIDS["mail_sender_tool_description"],
+        **MAIL_SENDER_TOOL_DESCRIPTION.model_dump(),
+    )
     default_sql_tool_description = db.ToolDescription(
         id=TOOL_DESCRIPTION_UUIDS["default_sql_tool_description"],
         **DEFAULT_SQL_TOOL_DESCRIPTION.model_dump(),
@@ -198,6 +204,7 @@ def seed_tool_description(session: Session):
             hubspot_neverdrop_mcp_tool_description,
             google_calendar_mcp_tool_description,
             outlook_sender_tool_description,
+            mail_sender_tool_description,
             default_sql_tool_description,
             scorer_tool_description,
         ],

--- a/ada_backend/database/seed/utils.py
+++ b/ada_backend/database/seed/utils.py
@@ -65,6 +65,7 @@ COMPONENT_UUIDS: dict[str, UUID] = {
     "router": UUID("8c9d0e1f-2a3b-4c5d-6e7f-8a9b0c1d2e3f"),
     "categorizer": UUID("1962862d-bbd5-4bc5-bb4a-d267feadc6f8"),
     "outlook_sender": UUID("62979492-b4ef-4cfe-96f1-67a960a1e8d4"),
+    "mail_sender": UUID("83c061db-1506-4636-95d1-9254ee23283e"),
     "scorer": UUID("f1a2b3c4-d5e6-7890-abcd-ef1234567891"),
 }
 COMPONENT_VERSION_UUIDS: dict[str, UUID] = {
@@ -120,6 +121,7 @@ COMPONENT_VERSION_UUIDS: dict[str, UUID] = {
     "router": UUID("9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a"),
     "categorizer": UUID("c4a1e2f3-5d6b-4c7a-8e9f-1a2b3c4d5e6f"),
     "outlook_sender": UUID("6e3b9e9b-ab98-4189-88b7-41b8bf2aa07c"),
+    "mail_sender": UUID("ced15521-e358-4b57-a9ac-47672dd1657b"),
     "scorer": UUID("f1a2b3c4-d5e6-7890-abcd-ef1234567892"),
 }
 

--- a/ada_backend/database/seed_db.py
+++ b/ada_backend/database/seed_db.py
@@ -13,14 +13,14 @@ from sqlalchemy.orm import Session
 from ada_backend.database import models as db
 from ada_backend.database.seed.integrations.seed_gmail import seed_gmail_components, seed_gmail_parameter_groups
 from ada_backend.database.seed.integrations.seed_integration import seed_integrations
-from ada_backend.database.seed.integrations.seed_mcp_google_calendar import seed_mcp_google_calendar_components
-from ada_backend.database.seed.integrations.seed_mcp_hubspot import seed_mcp_hubspot_components
-from ada_backend.database.seed.integrations.seed_mcp_hubspot_neverdrop import seed_mcp_hubspot_neverdrop_components
 from ada_backend.database.seed.integrations.seed_mail_sender import (
     seed_mail_sender_component_parameter_groups,
     seed_mail_sender_components,
     seed_mail_sender_parameter_groups,
 )
+from ada_backend.database.seed.integrations.seed_mcp_google_calendar import seed_mcp_google_calendar_components
+from ada_backend.database.seed.integrations.seed_mcp_hubspot import seed_mcp_hubspot_components
+from ada_backend.database.seed.integrations.seed_mcp_hubspot_neverdrop import seed_mcp_hubspot_neverdrop_components
 from ada_backend.database.seed.integrations.seed_outlook import seed_outlook_components, seed_outlook_parameter_groups
 from ada_backend.database.seed.integrations.seed_slack import seed_slack_components
 from ada_backend.database.seed.seed_ai_agent import seed_ai_agent_components, seed_ai_agent_parameter_groups

--- a/ada_backend/database/seed_db.py
+++ b/ada_backend/database/seed_db.py
@@ -17,6 +17,7 @@ from ada_backend.database.seed.integrations.seed_mcp_google_calendar import seed
 from ada_backend.database.seed.integrations.seed_mcp_hubspot import seed_mcp_hubspot_components
 from ada_backend.database.seed.integrations.seed_mcp_hubspot_neverdrop import seed_mcp_hubspot_neverdrop_components
 from ada_backend.database.seed.integrations.seed_mail_sender import (
+    seed_mail_sender_component_parameter_groups,
     seed_mail_sender_components,
     seed_mail_sender_parameter_groups,
 )
@@ -149,8 +150,9 @@ def seed_db(session: Session):
         seed_outlook_parameter_groups(session)
         session.commit()
 
-        seed_mail_sender_components(session)
         seed_mail_sender_parameter_groups(session)
+        seed_mail_sender_components(session)
+        seed_mail_sender_component_parameter_groups(session)
         session.commit()
 
         seed_project_reference_components(session)

--- a/ada_backend/database/seed_db.py
+++ b/ada_backend/database/seed_db.py
@@ -16,6 +16,10 @@ from ada_backend.database.seed.integrations.seed_integration import seed_integra
 from ada_backend.database.seed.integrations.seed_mcp_google_calendar import seed_mcp_google_calendar_components
 from ada_backend.database.seed.integrations.seed_mcp_hubspot import seed_mcp_hubspot_components
 from ada_backend.database.seed.integrations.seed_mcp_hubspot_neverdrop import seed_mcp_hubspot_neverdrop_components
+from ada_backend.database.seed.integrations.seed_mail_sender import (
+    seed_mail_sender_components,
+    seed_mail_sender_parameter_groups,
+)
 from ada_backend.database.seed.integrations.seed_outlook import seed_outlook_components, seed_outlook_parameter_groups
 from ada_backend.database.seed.integrations.seed_slack import seed_slack_components
 from ada_backend.database.seed.seed_ai_agent import seed_ai_agent_components, seed_ai_agent_parameter_groups
@@ -143,6 +147,10 @@ def seed_db(session: Session):
 
         seed_outlook_components(session)
         seed_outlook_parameter_groups(session)
+        session.commit()
+
+        seed_mail_sender_components(session)
+        seed_mail_sender_parameter_groups(session)
         session.commit()
 
         seed_project_reference_components(session)

--- a/ada_backend/services/entity_factory.py
+++ b/ada_backend/services/entity_factory.py
@@ -264,9 +264,7 @@ class OAuthComponentFactory:
     def __init__(
         self,
         entity_class: Type,
-        provider_config_key: str | None = None,
-        target_param_name: str = "access_token",
-        oauth_bindings: list[tuple[str, str, str]] | None = None,
+        oauth_bindings: list[tuple[str, str, str]],
         parameter_processors: list[ParameterProcessor] | None = None,
         constructor_method: str = "__init__",
     ):
@@ -275,29 +273,17 @@ class OAuthComponentFactory:
 
         Args:
             entity_class: The component class to instantiate
-            provider_config_key: OAuth provider key (e.g., "slack", "gmail").
-                Shortcut for the common single-OAuth configuration.
-            target_param_name: Parameter name for the resolved token (default: "access_token")
-                used with the single-OAuth shortcut.
-            oauth_bindings: Optional list of (param_name, provider_config_key, target_kwarg_name).
-                When provided, the factory resolves one token per binding.
+            oauth_bindings: List of (param_name, provider_config_key, target_kwarg_name).
+                The factory resolves one token per binding.
             parameter_processors: Additional parameter processors to apply after token resolution
             constructor_method: Method to use for instantiation (default: "__init__")
         """
         self.entity_class = entity_class
         self.parameter_processors = parameter_processors or []
         self.constructor_method = constructor_method
-        self.provider_config_key = provider_config_key
-        self.target_param_name = target_param_name
-
-        if oauth_bindings is not None:
-            if provider_config_key is not None:
-                raise ValueError("Provide either provider_config_key or oauth_bindings, not both.")
-            self.oauth_bindings = oauth_bindings
-        else:
-            if provider_config_key is None:
-                raise ValueError("provider_config_key is required when oauth_bindings is not provided.")
-            self.oauth_bindings = [("oauth_connection_id", provider_config_key, target_param_name)]
+        if not oauth_bindings:
+            raise ValueError("oauth_bindings is required.")
+        self.oauth_bindings = oauth_bindings
 
         if constructor_method == "__init__":
             self.constructor_params = signature(entity_class.__init__).parameters

--- a/ada_backend/services/entity_factory.py
+++ b/ada_backend/services/entity_factory.py
@@ -309,7 +309,7 @@ class OAuthComponentFactory:
             #       after migration d4e5f6a7b8c9 — rename column to oauth_definition_id
             definition_id = kwargs.pop(param_name, None)
             if isinstance(definition_id, list):
-                definition_id = definition_id[0]
+                definition_id = definition_id[0] if definition_id else None
             access_token = await resolve_oauth_access_token(definition_id, provider_config_key)
             # may be None; component raises at run if required
             kwargs[resolved_param_name] = SecretStr(access_token) if access_token is not None else None

--- a/ada_backend/services/entity_factory.py
+++ b/ada_backend/services/entity_factory.py
@@ -259,9 +259,6 @@ async def resolve_oauth_access_token(
 class OAuthComponentFactory:
     """
     Generic async factory for components that require OAuth access tokens via Nango.
-
-    Backward-compatible with the original single-OAuth API and can also resolve
-    multiple OAuth bindings for components that expose more than one connection input.
     """
 
     def __init__(

--- a/ada_backend/services/entity_factory.py
+++ b/ada_backend/services/entity_factory.py
@@ -260,14 +260,16 @@ class OAuthComponentFactory:
     """
     Generic async factory for components that require OAuth access tokens via Nango.
 
-    Resolves oauth_connection_id to access_token asynchronously before instantiating the component.
+    Backward-compatible with the original single-OAuth API and can also resolve
+    multiple OAuth bindings for components that expose more than one connection input.
     """
 
     def __init__(
         self,
         entity_class: Type,
-        provider_config_key: str,
+        provider_config_key: str | None = None,
         target_param_name: str = "access_token",
+        oauth_bindings: list[tuple[str, str, str]] | None = None,
         parameter_processors: list[ParameterProcessor] | None = None,
         constructor_method: str = "__init__",
     ):
@@ -276,16 +278,29 @@ class OAuthComponentFactory:
 
         Args:
             entity_class: The component class to instantiate
-            provider_config_key: OAuth provider key (e.g., "slack", "gmail")
+            provider_config_key: OAuth provider key (e.g., "slack", "gmail") for the
+                backward-compatible single-OAuth mode.
             target_param_name: Parameter name for the resolved token (default: "access_token")
+                for the backward-compatible single-OAuth mode.
+            oauth_bindings: Optional list of (param_name, provider_config_key, target_kwarg_name).
+                When provided, the factory resolves one token per binding.
             parameter_processors: Additional parameter processors to apply after token resolution
             constructor_method: Method to use for instantiation (default: "__init__")
         """
         self.entity_class = entity_class
-        self.provider_config_key = provider_config_key
-        self.target_param_name = target_param_name
         self.parameter_processors = parameter_processors or []
         self.constructor_method = constructor_method
+        self.provider_config_key = provider_config_key
+        self.target_param_name = target_param_name
+
+        if oauth_bindings is not None:
+            if provider_config_key is not None:
+                raise ValueError("Provide either provider_config_key or oauth_bindings, not both.")
+            self.oauth_bindings = oauth_bindings
+        else:
+            if provider_config_key is None:
+                raise ValueError("provider_config_key is required when oauth_bindings is not provided.")
+            self.oauth_bindings = [("oauth_connection_id", provider_config_key, target_param_name)]
 
         if constructor_method == "__init__":
             self.constructor_params = signature(entity_class.__init__).parameters
@@ -306,14 +321,15 @@ class OAuthComponentFactory:
             Instantiated component with resolved OAuth token (access_token may be None;
             component raises at run time if a connection is required but not configured).
         """
-        # TODO: DB column is still named "oauth_connection_id" but stores OrgVariableDefinition.id
-        #       after migration d4e5f6a7b8c9 — rename column to oauth_definition_id
-        definition_id = kwargs.pop("oauth_connection_id", None)
-        if isinstance(definition_id, list):
-            definition_id = definition_id[0]
-        access_token = await resolve_oauth_access_token(definition_id, self.provider_config_key)
-        # may be None; component raises at run if required
-        kwargs[self.target_param_name] = SecretStr(access_token) if access_token is not None else None
+        for param_name, provider_config_key, resolved_param_name in self.oauth_bindings:
+            # TODO: DB column is still named "oauth_connection_id" but stores OrgVariableDefinition.id
+            #       after migration d4e5f6a7b8c9 — rename column to oauth_definition_id
+            definition_id = kwargs.pop(param_name, None)
+            if isinstance(definition_id, list):
+                definition_id = definition_id[0]
+            access_token = await resolve_oauth_access_token(definition_id, provider_config_key)
+            # may be None; component raises at run if required
+            kwargs[resolved_param_name] = SecretStr(access_token) if access_token is not None else None
 
         for processor in self.parameter_processors:
             kwargs = processor(kwargs, self.constructor_params)

--- a/ada_backend/services/entity_factory.py
+++ b/ada_backend/services/entity_factory.py
@@ -275,10 +275,10 @@ class OAuthComponentFactory:
 
         Args:
             entity_class: The component class to instantiate
-            provider_config_key: OAuth provider key (e.g., "slack", "gmail") for the
-                backward-compatible single-OAuth mode.
+            provider_config_key: OAuth provider key (e.g., "slack", "gmail").
+                Shortcut for the common single-OAuth configuration.
             target_param_name: Parameter name for the resolved token (default: "access_token")
-                for the backward-compatible single-OAuth mode.
+                used with the single-OAuth shortcut.
             oauth_bindings: Optional list of (param_name, provider_config_key, target_kwarg_name).
                 When provided, the factory resolves one token per binding.
             parameter_processors: Additional parameter processors to apply after token resolution

--- a/ada_backend/services/entity_factory.py
+++ b/ada_backend/services/entity_factory.py
@@ -35,6 +35,7 @@ from engine.components.rag.vocabulary_search import VocabularySearch
 from engine.components.synthesizer import Synthesizer
 from engine.components.tools.mcp.remote_mcp_tool import RemoteMCPTool
 from engine.components.types import ToolDescription
+from engine.integrations.providers import OAuthProvider
 from engine.llm_services.llm_service import CompletionService, EmbeddingService, OCRService, WebSearchService
 from engine.qdrant_service import QdrantCollectionSchema, QdrantService
 from engine.secret_utils import unwrap_secret, unwrap_secrets
@@ -256,6 +257,14 @@ async def resolve_oauth_access_token(
         )
 
 
+class OAuthBinding(BaseModel):
+    """Maps a component OAuth parameter to a provider key and constructor kwarg."""
+
+    param_name: str = "oauth_connection_id"
+    provider_config_key: OAuthProvider
+    target_param_name: str = "access_token"
+
+
 class OAuthComponentFactory:
     """
     Generic async factory for components that require OAuth access tokens via Nango.
@@ -264,7 +273,7 @@ class OAuthComponentFactory:
     def __init__(
         self,
         entity_class: Type,
-        oauth_bindings: list[tuple[str, str, str]],
+        oauth_bindings: list[OAuthBinding],
         parameter_processors: list[ParameterProcessor] | None = None,
         constructor_method: str = "__init__",
     ):
@@ -273,7 +282,7 @@ class OAuthComponentFactory:
 
         Args:
             entity_class: The component class to instantiate
-            oauth_bindings: List of (param_name, provider_config_key, target_kwarg_name).
+            oauth_bindings: List of OAuth bindings.
                 The factory resolves one token per binding.
             parameter_processors: Additional parameter processors to apply after token resolution
             constructor_method: Method to use for instantiation (default: "__init__")
@@ -304,15 +313,15 @@ class OAuthComponentFactory:
             Instantiated component with resolved OAuth token (access_token may be None;
             component raises at run time if a connection is required but not configured).
         """
-        for param_name, provider_config_key, resolved_param_name in self.oauth_bindings:
+        for binding in self.oauth_bindings:
             # TODO: DB column is still named "oauth_connection_id" but stores OrgVariableDefinition.id
             #       after migration d4e5f6a7b8c9 — rename column to oauth_definition_id
-            definition_id = kwargs.pop(param_name, None)
+            definition_id = kwargs.pop(binding.param_name, None)
             if isinstance(definition_id, list):
                 definition_id = definition_id[0] if definition_id else None
-            access_token = await resolve_oauth_access_token(definition_id, provider_config_key)
+            access_token = await resolve_oauth_access_token(definition_id, str(binding.provider_config_key))
             # may be None; component raises at run if required
-            kwargs[resolved_param_name] = SecretStr(access_token) if access_token is not None else None
+            kwargs[binding.target_param_name] = SecretStr(access_token) if access_token is not None else None
 
         for processor in self.parameter_processors:
             kwargs = processor(kwargs, self.constructor_params)

--- a/ada_backend/services/registry.py
+++ b/ada_backend/services/registry.py
@@ -71,6 +71,7 @@ from engine.components.tools.terminal_command_runner import TerminalCommandRunne
 from engine.components.web_search_tool_openai import WebSearchOpenAITool
 from engine.integrations.gmail.gmail_sender import GmailSender
 from engine.integrations.gmail.gmail_sender_v2 import GmailSenderV2
+from engine.integrations.mail_sender import MailSender
 from engine.integrations.outlook.outlook_sender import OutlookSender
 from engine.integrations.providers import OAuthProvider
 from engine.integrations.slack.slack_sender import SlackSender
@@ -570,6 +571,17 @@ def create_factory_registry() -> FactoryRegistry:
         factory=OAuthComponentFactory(
             entity_class=OutlookSender,
             provider_config_key=OAuthProvider.OUTLOOK,
+        ),
+    )
+
+    registry.register(
+        component_version_id=COMPONENT_VERSION_UUIDS["mail_sender"],
+        factory=OAuthComponentFactory(
+            entity_class=MailSender,
+            oauth_bindings=[
+                ("gmail_oauth_connection_id", OAuthProvider.GMAIL, "gmail_access_token"),
+                ("outlook_oauth_connection_id", OAuthProvider.OUTLOOK, "outlook_access_token"),
+            ],
         ),
     )
 

--- a/ada_backend/services/registry.py
+++ b/ada_backend/services/registry.py
@@ -554,7 +554,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["gmail_sender_v2"],
         factory=OAuthComponentFactory(
             entity_class=GmailSenderV2,
-            provider_config_key=OAuthProvider.GMAIL,
+            oauth_bindings=[("oauth_connection_id", OAuthProvider.GMAIL, "access_token")],
         ),
     )
 
@@ -562,7 +562,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["gmail_sender_v3"],
         factory=OAuthComponentFactory(
             entity_class=GmailSenderV2,
-            provider_config_key=OAuthProvider.GMAIL,
+            oauth_bindings=[("oauth_connection_id", OAuthProvider.GMAIL, "access_token")],
         ),
     )
 
@@ -570,7 +570,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["outlook_sender"],
         factory=OAuthComponentFactory(
             entity_class=OutlookSender,
-            provider_config_key=OAuthProvider.OUTLOOK,
+            oauth_bindings=[("oauth_connection_id", OAuthProvider.OUTLOOK, "access_token")],
         ),
     )
 
@@ -589,7 +589,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["slack_sender"],
         factory=OAuthComponentFactory(
             entity_class=SlackSender,
-            provider_config_key=OAuthProvider.SLACK,
+            oauth_bindings=[("oauth_connection_id", OAuthProvider.SLACK, "access_token")],
         ),
     )
 
@@ -597,7 +597,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["hubspot_mcp_tool"],
         factory=OAuthComponentFactory(
             entity_class=HubSpotMCPTool,
-            provider_config_key=OAuthProvider.HUBSPOT,
+            oauth_bindings=[("oauth_connection_id", OAuthProvider.HUBSPOT, "access_token")],
             constructor_method="from_access_token",
             parameter_processors=[build_ignore_tool_description_processor()],
         ),
@@ -607,7 +607,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["hubspot_neverdrop_mcp_tool"],
         factory=OAuthComponentFactory(
             entity_class=HubSpotMCPTool,
-            provider_config_key=OAuthProvider.HUBSPOT_NEVERDROP,
+            oauth_bindings=[("oauth_connection_id", OAuthProvider.HUBSPOT_NEVERDROP, "access_token")],
             constructor_method="from_access_token",
             parameter_processors=[build_ignore_tool_description_processor()],
         ),
@@ -617,7 +617,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["google_calendar_mcp_tool"],
         factory=OAuthComponentFactory(
             entity_class=GoogleCalendarMCPTool,
-            provider_config_key=OAuthProvider.GOOGLE_CALENDAR,
+            oauth_bindings=[("oauth_connection_id", OAuthProvider.GOOGLE_CALENDAR, "access_token")],
             constructor_method="from_access_token",
             parameter_processors=[build_ignore_tool_description_processor()],
         ),

--- a/ada_backend/services/registry.py
+++ b/ada_backend/services/registry.py
@@ -13,6 +13,7 @@ from ada_backend.services.entity_factory import (
     AgentFactory,
     EntityFactory,
     NonToolCallableBlockFactory,
+    OAuthBinding,
     OAuthComponentFactory,
     RemoteMCPToolFactory,
     build_completion_service_processor,
@@ -554,7 +555,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["gmail_sender_v2"],
         factory=OAuthComponentFactory(
             entity_class=GmailSenderV2,
-            oauth_bindings=[("oauth_connection_id", OAuthProvider.GMAIL, "access_token")],
+            oauth_bindings=[OAuthBinding(provider_config_key=OAuthProvider.GMAIL)],
         ),
     )
 
@@ -562,7 +563,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["gmail_sender_v3"],
         factory=OAuthComponentFactory(
             entity_class=GmailSenderV2,
-            oauth_bindings=[("oauth_connection_id", OAuthProvider.GMAIL, "access_token")],
+            oauth_bindings=[OAuthBinding(provider_config_key=OAuthProvider.GMAIL)],
         ),
     )
 
@@ -570,7 +571,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["outlook_sender"],
         factory=OAuthComponentFactory(
             entity_class=OutlookSender,
-            oauth_bindings=[("oauth_connection_id", OAuthProvider.OUTLOOK, "access_token")],
+            oauth_bindings=[OAuthBinding(provider_config_key=OAuthProvider.OUTLOOK)],
         ),
     )
 
@@ -579,8 +580,16 @@ def create_factory_registry() -> FactoryRegistry:
         factory=OAuthComponentFactory(
             entity_class=MailSender,
             oauth_bindings=[
-                ("gmail_oauth_connection_id", OAuthProvider.GMAIL, "gmail_access_token"),
-                ("outlook_oauth_connection_id", OAuthProvider.OUTLOOK, "outlook_access_token"),
+                OAuthBinding(
+                    param_name="gmail_oauth_connection_id",
+                    provider_config_key=OAuthProvider.GMAIL,
+                    target_param_name="gmail_access_token",
+                ),
+                OAuthBinding(
+                    param_name="outlook_oauth_connection_id",
+                    provider_config_key=OAuthProvider.OUTLOOK,
+                    target_param_name="outlook_access_token",
+                ),
             ],
         ),
     )
@@ -589,7 +598,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["slack_sender"],
         factory=OAuthComponentFactory(
             entity_class=SlackSender,
-            oauth_bindings=[("oauth_connection_id", OAuthProvider.SLACK, "access_token")],
+            oauth_bindings=[OAuthBinding(provider_config_key=OAuthProvider.SLACK)],
         ),
     )
 
@@ -597,7 +606,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["hubspot_mcp_tool"],
         factory=OAuthComponentFactory(
             entity_class=HubSpotMCPTool,
-            oauth_bindings=[("oauth_connection_id", OAuthProvider.HUBSPOT, "access_token")],
+            oauth_bindings=[OAuthBinding(provider_config_key=OAuthProvider.HUBSPOT)],
             constructor_method="from_access_token",
             parameter_processors=[build_ignore_tool_description_processor()],
         ),
@@ -607,7 +616,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["hubspot_neverdrop_mcp_tool"],
         factory=OAuthComponentFactory(
             entity_class=HubSpotMCPTool,
-            oauth_bindings=[("oauth_connection_id", OAuthProvider.HUBSPOT_NEVERDROP, "access_token")],
+            oauth_bindings=[OAuthBinding(provider_config_key=OAuthProvider.HUBSPOT_NEVERDROP)],
             constructor_method="from_access_token",
             parameter_processors=[build_ignore_tool_description_processor()],
         ),
@@ -617,7 +626,7 @@ def create_factory_registry() -> FactoryRegistry:
         component_version_id=COMPONENT_VERSION_UUIDS["google_calendar_mcp_tool"],
         factory=OAuthComponentFactory(
             entity_class=GoogleCalendarMCPTool,
-            oauth_bindings=[("oauth_connection_id", OAuthProvider.GOOGLE_CALENDAR, "access_token")],
+            oauth_bindings=[OAuthBinding(provider_config_key=OAuthProvider.GOOGLE_CALENDAR)],
             constructor_method="from_access_token",
             parameter_processors=[build_ignore_tool_description_processor()],
         ),

--- a/engine/integrations/mail_sender.py
+++ b/engine/integrations/mail_sender.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 
 from engine.components.component import Component
 from engine.components.types import ComponentAttributes, ToolDescription
+from engine.errors import EngineError
 from engine.integrations.gmail.gmail_sender import GmailSenderInputs
 from engine.integrations.gmail.gmail_sender_v2 import GmailSenderV2
 from engine.integrations.outlook.outlook_sender import OutlookSender, OutlookSenderInputs
@@ -72,6 +73,10 @@ class MailSenderOutputs(BaseModel):
     )
 
 
+class MailSenderConfigurationError(EngineError):
+    """Raised when Mail Sender has an invalid provider configuration."""
+
+
 class MailSender(Component):
     """Unified mail sender: delegates to Gmail or Outlook based on OAuth configuration."""
 
@@ -109,25 +114,22 @@ class MailSender(Component):
         return {"input": "mail_body", "output": "status"}
 
     def is_available(self) -> bool:
-        g = bool(self._gmail_access_token)
-        o = bool(self._outlook_access_token)
-        return g ^ o
+        has_gmail_connection = bool(self._gmail_access_token)
+        has_outlook_connection = bool(self._outlook_access_token)
+        return has_gmail_connection ^ has_outlook_connection
 
     async def _run_without_io_trace(self, inputs: BaseModel, ctx: dict) -> MailSenderOutputs:
-        gi = GmailSenderInputs.model_validate(inputs.model_dump())
-        g = bool(self._gmail_access_token)
-        o = bool(self._outlook_access_token)
-        if g and o:
-            raise ValueError(
+        gmail_inputs = GmailSenderInputs.model_validate(inputs.model_dump())
+        has_gmail_connection = bool(self._gmail_access_token)
+        has_outlook_connection = bool(self._outlook_access_token)
+
+        if has_gmail_connection and has_outlook_connection:
+            raise MailSenderConfigurationError(
                 "Mail Sender allows only one provider: disconnect either Gmail or Outlook "
                 "and keep a single connection."
             )
-        if not g and not o:
-            raise ValueError(
-                "Mail Sender requires a Gmail or Outlook connection. "
-                "Please connect one provider in the component settings."
-            )
-        if g:
+
+        if has_gmail_connection:
             gmail_inner = GmailSenderV2(
                 trace_manager=self.trace_manager,
                 component_attributes=self.component_attributes,
@@ -135,15 +137,22 @@ class MailSender(Component):
                 save_as_draft=self.save_as_draft,
                 tool_description=self.tool_description,
             )
-            out = await gmail_inner._run_without_io_trace(gi, ctx)
+            out = await gmail_inner._run_without_io_trace(gmail_inputs, ctx)
             return MailSenderOutputs(status=out.status, message_id=out.message_id)
-        outlook_inner = OutlookSender(
-            trace_manager=self.trace_manager,
-            component_attributes=self.component_attributes,
-            access_token=self._outlook_access_token,
-            save_as_draft=self.save_as_draft,
-            tool_description=self.tool_description,
+
+        if has_outlook_connection:
+            outlook_inner = OutlookSender(
+                trace_manager=self.trace_manager,
+                component_attributes=self.component_attributes,
+                access_token=self._outlook_access_token,
+                save_as_draft=self.save_as_draft,
+                tool_description=self.tool_description,
+            )
+            outlook_inputs = OutlookSenderInputs.model_validate(gmail_inputs.model_dump())
+            out = await outlook_inner._run_without_io_trace(outlook_inputs, ctx)
+            return MailSenderOutputs(status=out.status, message_id=out.message_id)
+
+        raise MailSenderConfigurationError(
+            "Mail Sender requires a Gmail or Outlook connection. "
+            "Please connect one provider in the component settings."
         )
-        outlook_inputs = OutlookSenderInputs.model_validate(gi.model_dump())
-        out = await outlook_inner._run_without_io_trace(outlook_inputs, ctx)
-        return MailSenderOutputs(status=out.status, message_id=out.message_id)

--- a/engine/integrations/mail_sender.py
+++ b/engine/integrations/mail_sender.py
@@ -114,9 +114,7 @@ class MailSender(Component):
         return {"input": "mail_body", "output": "status"}
 
     def is_available(self) -> bool:
-        has_gmail_connection = bool(self._gmail_access_token)
-        has_outlook_connection = bool(self._outlook_access_token)
-        return has_gmail_connection ^ has_outlook_connection
+        return bool(self._gmail_access_token) or bool(self._outlook_access_token)
 
     async def _run_without_io_trace(self, inputs: BaseModel, ctx: dict) -> MailSenderOutputs:
         gmail_inputs = GmailSenderInputs.model_validate(inputs.model_dump())

--- a/engine/integrations/mail_sender.py
+++ b/engine/integrations/mail_sender.py
@@ -1,0 +1,149 @@
+from typing import Optional, Type
+
+from openinference.semconv.trace import OpenInferenceSpanKindValues
+from pydantic import BaseModel, Field
+
+from engine.components.component import Component
+from engine.components.types import ComponentAttributes, ToolDescription
+from engine.integrations.gmail.gmail_sender import GmailSenderInputs
+from engine.integrations.gmail.gmail_sender_v2 import GmailSenderV2
+from engine.integrations.outlook.outlook_sender import OutlookSender, OutlookSenderInputs
+from engine.trace.trace_manager import TraceManager
+
+MAIL_SENDER_TOOL_DESCRIPTION = ToolDescription(
+    name="Mail Sender",
+    description=(
+        "Send email using Gmail or Microsoft Outlook. "
+        "Connect exactly one provider (Gmail or Outlook) in the component settings."
+    ),
+    tool_properties={
+        "from_email": {
+            "type": "string",
+            "description": (
+                "Optional sender alias (Gmail only). Must be a verified 'Send mail as' alias "
+                "on the connected account. Ignored when using Outlook."
+            ),
+        },
+        "mail_subject": {
+            "type": "string",
+            "description": "The subject of the email to be sent.",
+        },
+        "mail_body": {
+            "type": "string",
+            "description": "The body of the email to be sent.",
+        },
+        "mail_html_body": {
+            "type": "string",
+            "description": "Optional HTML body of the email. When provided, used instead of mail_body.",
+        },
+        "email_recipients": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "List of email addresses to send the email to. "
+                "If not provided, the email will be saved as a draft without recipients."
+            ),
+        },
+        "cc": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of CC email addresses.",
+        },
+        "bcc": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of BCC email addresses.",
+        },
+        "email_attachments": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of file paths to attach to the email.",
+        },
+    },
+    required_tool_properties=["mail_subject"],
+)
+
+
+class MailSenderOutputs(BaseModel):
+    status: str = Field(description="The status of the email operation.")
+    message_id: Optional[str] = Field(
+        default=None,
+        description="The provider message or draft ID when available.",
+    )
+
+
+class MailSender(Component):
+    """Unified mail sender: delegates to Gmail or Outlook based on OAuth configuration."""
+
+    TRACE_SPAN_KIND = OpenInferenceSpanKindValues.TOOL.value
+    migrated = True
+
+    def __init__(
+        self,
+        trace_manager: TraceManager,
+        component_attributes: ComponentAttributes,
+        gmail_access_token: Optional[str] = None,
+        outlook_access_token: Optional[str] = None,
+        save_as_draft: bool = True,
+        tool_description: ToolDescription = MAIL_SENDER_TOOL_DESCRIPTION,
+    ):
+        super().__init__(
+            trace_manager,
+            tool_description=tool_description,
+            component_attributes=component_attributes,
+        )
+        self._gmail_access_token = gmail_access_token
+        self._outlook_access_token = outlook_access_token
+        self.save_as_draft = save_as_draft
+
+    @classmethod
+    def get_inputs_schema(cls) -> Type[BaseModel]:
+        return GmailSenderInputs
+
+    @classmethod
+    def get_outputs_schema(cls) -> Type[BaseModel]:
+        return MailSenderOutputs
+
+    @classmethod
+    def get_canonical_ports(cls) -> dict[str, str | None]:
+        return {"input": "mail_body", "output": "status"}
+
+    def is_available(self) -> bool:
+        g = bool(self._gmail_access_token)
+        o = bool(self._outlook_access_token)
+        return g ^ o
+
+    async def _run_without_io_trace(self, inputs: BaseModel, ctx: dict) -> MailSenderOutputs:
+        gi = GmailSenderInputs.model_validate(inputs.model_dump())
+        g = bool(self._gmail_access_token)
+        o = bool(self._outlook_access_token)
+        if g and o:
+            raise ValueError(
+                "Mail Sender allows only one provider: disconnect either Gmail or Outlook "
+                "and keep a single connection."
+            )
+        if not g and not o:
+            raise ValueError(
+                "Mail Sender requires a Gmail or Outlook connection. "
+                "Please connect one provider in the component settings."
+            )
+        if g:
+            gmail_inner = GmailSenderV2(
+                trace_manager=self.trace_manager,
+                component_attributes=self.component_attributes,
+                access_token=self._gmail_access_token,
+                save_as_draft=self.save_as_draft,
+                tool_description=self.tool_description,
+            )
+            out = await gmail_inner._run_without_io_trace(gi, ctx)
+            return MailSenderOutputs(status=out.status, message_id=out.message_id)
+        outlook_inner = OutlookSender(
+            trace_manager=self.trace_manager,
+            component_attributes=self.component_attributes,
+            access_token=self._outlook_access_token,
+            save_as_draft=self.save_as_draft,
+            tool_description=self.tool_description,
+        )
+        outlook_inputs = OutlookSenderInputs.model_validate(gi.model_dump())
+        out = await outlook_inner._run_without_io_trace(outlook_inputs, ctx)
+        return MailSenderOutputs(status=out.status, message_id=out.message_id)

--- a/frontend/src/components/studio/components/EditSidebar.vue
+++ b/frontend/src/components/studio/components/EditSidebar.vue
@@ -3,6 +3,7 @@ import { useAbility } from '@casl/vue'
 import { Icon } from '@iconify/vue'
 import { isProviderLogo } from '../utils/node-factory.utils'
 import EditSidebarParameterField from './EditSidebarParameterField.vue'
+import ExclusiveOAuthGroup from './ExclusiveOAuthGroup.vue'
 import EditSidebarGmail from './EditSidebarGmail.vue'
 import EditSidebarOptionalTools from './EditSidebarOptionalTools.vue'
 import EditSidebarConfigContent from './EditSidebarConfigContent.vue'
@@ -13,6 +14,7 @@ import { useEditSidebarSubmit } from '@/composables/useEditSidebarSubmit'
 import { useEditSidebarOAuth } from '@/composables/useEditSidebarOAuth'
 import { useEditSidebarComponentConfig } from '@/composables/useEditSidebarComponentConfig'
 import { getComponentDefinitionFromCache } from '@/composables/queries/useComponentDefinitionsQuery'
+import { normalizeUiComponent } from './edit-sidebar/types'
 import { logger } from '@/utils/logger'
 
 interface Props {
@@ -110,6 +112,9 @@ const getComponentIcon = computed(() => {
 })
 
 const color = computed(() => (isWorker.value ? 'secondary' : 'primary'))
+
+const isExclusiveOAuthGroup = (group: any): boolean =>
+  group.parameters.some((p: any) => normalizeUiComponent(p.ui_component) === 'EXCLUSIVEOAUTHCONNECTION')
 </script>
 
 <template>
@@ -206,17 +211,25 @@ const color = computed(() => (isWorker.value ? 'secondary' : 'primary'))
                   </div>
                   <VExpandTransition>
                     <div v-show="form.groupVisibility.value[group.group.id]">
-                      <EditSidebarParameterField
-                        v-for="param in group.parameters.filter((p: any) => !p.is_advanced || form.showAdvanced.value)"
-                        :key="param.name"
-                        v-model="form.formData.value.parameters[param.name]"
-                        :param="param"
-                        :component-config="componentConfig.getComponentConfig(param)"
-                        :color="color"
-                        :json-validation-state="form.jsonValidationState.value[param.name]"
-                        @file-update="form.onFileModelUpdate(param.name, $event)"
-                        @json-blur="form.handleJsonFieldBlur(param.name)"
+                      <ExclusiveOAuthGroup
+                        v-if="isExclusiveOAuthGroup(group)"
+                        :parameters="group.parameters"
+                        :form-data="form.formData.value.parameters"
+                        :readonly="isReadOnlyMode"
                       />
+                      <template v-else>
+                        <EditSidebarParameterField
+                          v-for="param in group.parameters.filter((p: any) => !p.is_advanced || form.showAdvanced.value)"
+                          :key="param.name"
+                          v-model="form.formData.value.parameters[param.name]"
+                          :param="param"
+                          :component-config="componentConfig.getComponentConfig(param)"
+                          :color="color"
+                          :json-validation-state="form.jsonValidationState.value[param.name]"
+                          @file-update="form.onFileModelUpdate(param.name, $event)"
+                          @json-blur="form.handleJsonFieldBlur(param.name)"
+                        />
+                      </template>
                     </div>
                   </VExpandTransition>
                 </VCard>

--- a/frontend/src/components/studio/components/EditSidebar.vue
+++ b/frontend/src/components/studio/components/EditSidebar.vue
@@ -113,8 +113,10 @@ const getComponentIcon = computed(() => {
 
 const color = computed(() => (isWorker.value ? 'secondary' : 'primary'))
 
+const EXCLUSIVE_OAUTH_GROUP_COMPONENTS = new Set(['EXCLUSIVE_OAUTH_CONNECTION', 'EXCLUSIVEOAUTHCONNECTION'])
+
 const isExclusiveOAuthGroup = (group: any): boolean =>
-  group.parameters.some((p: any) => normalizeUiComponent(p.ui_component) === 'EXCLUSIVEOAUTHCONNECTION')
+  group.parameters.some((p: any) => EXCLUSIVE_OAUTH_GROUP_COMPONENTS.has(normalizeUiComponent(p.ui_component)))
 </script>
 
 <template>
@@ -219,7 +221,9 @@ const isExclusiveOAuthGroup = (group: any): boolean =>
                       />
                       <template v-else>
                         <EditSidebarParameterField
-                          v-for="param in group.parameters.filter((p: any) => !p.is_advanced || form.showAdvanced.value)"
+                          v-for="param in group.parameters.filter(
+                            (p: any) => !p.is_advanced || form.showAdvanced.value
+                          )"
                           :key="param.name"
                           v-model="form.formData.value.parameters[param.name]"
                           :param="param"

--- a/frontend/src/components/studio/components/ExclusiveOAuthGroup.vue
+++ b/frontend/src/components/studio/components/ExclusiveOAuthGroup.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
 import { computed, ref, watch } from 'vue'
-import { VDivider } from 'vuetify/components/VDivider'
-import { VLabel } from 'vuetify/components/VLabel'
 import OAuthConnectionInput from '@/components/studio/inputs/OAuthConnectionInput.vue'
 import type { SidebarParameter } from './edit-sidebar/types'
 
@@ -33,8 +31,8 @@ watch(
 
 const selectedParam = computed(() => props.parameters.find(p => p.name === selectedParamName.value) ?? null)
 
-const handleProviderChange = (paramName: string | null) => {
-  if (!paramName) return
+const selectProvider = (paramName: string) => {
+  if (props.readonly) return
   if (selectedParamName.value && selectedParamName.value !== paramName) {
     props.formData[selectedParamName.value] = null
   }
@@ -50,40 +48,34 @@ const handleConnectionUpdate = (value: string | null) => {
 
 <template>
   <div class="exclusive-oauth-group">
-    <VRadioGroup
-      :model-value="selectedParamName"
-      hide-details
-      :disabled="readonly"
-      @update:model-value="handleProviderChange"
+    <div
+      v-for="param in parameters"
+      :key="param.name"
+      class="provider-option rounded-lg mb-2 pa-3 d-flex align-center"
+      :class="{ active: selectedParamName === param.name }"
+      role="radio"
+      :aria-checked="selectedParamName === param.name"
+      tabindex="0"
+      @click="selectProvider(param.name)"
+      @keydown.enter="selectProvider(param.name)"
+      @keydown.space.prevent="selectProvider(param.name)"
     >
-      <VLabel
-        v-for="param in parameters"
-        :key="param.name"
-        class="provider-radio-option rounded mb-2 pa-3 d-flex align-center"
-        :class="{ active: selectedParamName === param.name }"
-      >
-        <Icon
-          :icon="param.ui_component_properties?.icon || 'mdi-connection'"
-          width="24"
-          height="24"
-          class="me-3 flex-shrink-0"
-        />
-        <div class="flex-grow-1">
-          <div class="text-subtitle-2">{{ param.ui_component_properties?.label }}</div>
-          <div class="text-caption text-medium-emphasis">
-            {{ formData[param.name] ? 'Connection selected' : 'No connection selected' }}
-          </div>
+      <Icon
+        :icon="param.ui_component_properties?.icon || 'mdi-connection'"
+        width="24"
+        height="24"
+        class="me-3 flex-shrink-0"
+      />
+      <div class="flex-grow-1">
+        <div class="text-subtitle-2">{{ param.ui_component_properties?.label }}</div>
+        <div class="text-caption text-medium-emphasis">
+          {{ formData[param.name] ? 'Connection selected' : 'No connection selected' }}
         </div>
-        <VRadio :value="param.name" hide-details />
-      </VLabel>
-    </VRadioGroup>
-
-    <VDivider class="my-3" />
-
-    <div v-if="selectedParam">
-      <div class="text-overline text-medium-emphasis mb-2">
-        {{ selectedParam.ui_component_properties?.label }} — OAuth Connection
       </div>
+      <div class="radio-indicator" :class="{ selected: selectedParamName === param.name }" />
+    </div>
+
+    <div v-if="selectedParam" class="mt-4">
       <OAuthConnectionInput
         :model-value="formData[selectedParam.name]"
         :provider="selectedParam.ui_component_properties?.provider || 'unknown'"
@@ -102,10 +94,12 @@ const handleConnectionUpdate = (value: string | null) => {
   width: 100%;
 }
 
-.provider-radio-option {
+.provider-option {
   border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
   cursor: pointer;
-  transition: border-color 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
   user-select: none;
 
   &.active {
@@ -115,6 +109,27 @@ const handleConnectionUpdate = (value: string | null) => {
 
   &:not(.active):hover {
     background-color: rgba(var(--v-theme-on-surface), 0.04);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgb(var(--v-theme-primary));
+    outline-offset: 1px;
+  }
+}
+
+.radio-indicator {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border: 2px solid rgba(var(--v-border-color), var(--v-high-emphasis-opacity));
+  border-radius: 50%;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+
+  &.selected {
+    border-color: rgb(var(--v-theme-primary));
+    border-width: 6px;
   }
 }
 </style>

--- a/frontend/src/components/studio/components/ExclusiveOAuthGroup.vue
+++ b/frontend/src/components/studio/components/ExclusiveOAuthGroup.vue
@@ -3,7 +3,6 @@ import { Icon } from '@iconify/vue'
 import { computed, ref, watch } from 'vue'
 import { VDivider } from 'vuetify/components/VDivider'
 import { VLabel } from 'vuetify/components/VLabel'
-import { VRadio, VRadioGroup } from 'vuetify/components/VRadioGroup'
 import OAuthConnectionInput from '@/components/studio/inputs/OAuthConnectionInput.vue'
 import type { SidebarParameter } from './edit-sidebar/types'
 

--- a/frontend/src/components/studio/components/ExclusiveOAuthGroup.vue
+++ b/frontend/src/components/studio/components/ExclusiveOAuthGroup.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { computed, ref, watch } from 'vue'
+import { VDivider } from 'vuetify/components/VDivider'
+import { VLabel } from 'vuetify/components/VLabel'
+import { VRadio, VRadioGroup } from 'vuetify/components/VRadioGroup'
+import OAuthConnectionInput from '@/components/studio/inputs/OAuthConnectionInput.vue'
+import type { SidebarParameter } from './edit-sidebar/types'
+
+interface Props {
+  parameters: SidebarParameter[]
+  formData: Record<string, any>
+  readonly?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  readonly: false,
+})
+
+const initialSelected = (): string | null => {
+  const connected = props.parameters.find(p => props.formData[p.name])
+  return connected?.name ?? props.parameters[0]?.name ?? null
+}
+
+const selectedParamName = ref<string | null>(initialSelected())
+
+watch(
+  () => props.parameters.map(p => props.formData[p.name]),
+  () => {
+    const connected = props.parameters.find(p => props.formData[p.name])
+    if (connected) selectedParamName.value = connected.name
+  }
+)
+
+const selectedParam = computed(() => props.parameters.find(p => p.name === selectedParamName.value) ?? null)
+
+const handleProviderChange = (paramName: string | null) => {
+  if (!paramName) return
+  if (selectedParamName.value && selectedParamName.value !== paramName) {
+    props.formData[selectedParamName.value] = null
+  }
+  selectedParamName.value = paramName
+}
+
+const handleConnectionUpdate = (value: string | null) => {
+  if (selectedParamName.value) {
+    props.formData[selectedParamName.value] = value
+  }
+}
+</script>
+
+<template>
+  <div class="exclusive-oauth-group">
+    <VRadioGroup
+      :model-value="selectedParamName"
+      hide-details
+      :disabled="readonly"
+      @update:model-value="handleProviderChange"
+    >
+      <VLabel
+        v-for="param in parameters"
+        :key="param.name"
+        class="provider-radio-option rounded mb-2 pa-3 d-flex align-center"
+        :class="{ active: selectedParamName === param.name }"
+      >
+        <Icon
+          :icon="param.ui_component_properties?.icon || 'mdi-connection'"
+          width="24"
+          height="24"
+          class="me-3 flex-shrink-0"
+        />
+        <div class="flex-grow-1">
+          <div class="text-subtitle-2">{{ param.ui_component_properties?.label }}</div>
+          <div class="text-caption text-medium-emphasis">
+            {{ formData[param.name] ? 'Connection selected' : 'No connection selected' }}
+          </div>
+        </div>
+        <VRadio :value="param.name" hide-details />
+      </VLabel>
+    </VRadioGroup>
+
+    <VDivider class="my-3" />
+
+    <div v-if="selectedParam">
+      <div class="text-overline text-medium-emphasis mb-2">
+        {{ selectedParam.ui_component_properties?.label }} — OAuth Connection
+      </div>
+      <OAuthConnectionInput
+        :model-value="formData[selectedParam.name]"
+        :provider="selectedParam.ui_component_properties?.provider || 'unknown'"
+        :icon="selectedParam.ui_component_properties?.icon"
+        :label="selectedParam.ui_component_properties?.label || selectedParam.name"
+        :description="selectedParam.ui_component_properties?.description"
+        :readonly="readonly"
+        @update:model-value="handleConnectionUpdate"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.exclusive-oauth-group {
+  width: 100%;
+}
+
+.provider-radio-option {
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+  user-select: none;
+
+  &.active {
+    border-color: rgb(var(--v-theme-primary));
+    background-color: rgba(var(--v-theme-primary), 0.04);
+  }
+
+  &:not(.active):hover {
+    background-color: rgba(var(--v-theme-on-surface), 0.04);
+  }
+}
+</style>

--- a/frontend/src/components/studio/components/ExclusiveOAuthGroup.vue
+++ b/frontend/src/components/studio/components/ExclusiveOAuthGroup.vue
@@ -14,6 +14,8 @@ const props = withDefaults(defineProps<Props>(), {
   readonly: false,
 })
 
+const optionRefs = ref<Record<string, HTMLElement | null>>({})
+
 const initialSelected = (): string | null => {
   const connected = props.parameters.find(p => props.formData[p.name])
   return connected?.name ?? props.parameters[0]?.name ?? null
@@ -22,14 +24,40 @@ const initialSelected = (): string | null => {
 const selectedParamName = ref<string | null>(initialSelected())
 
 watch(
-  () => props.parameters.map(p => props.formData[p.name]),
+  () => ({
+    parameterNames: props.parameters.map(p => p.name),
+    connectionValues: props.parameters.map(p => props.formData[p.name]),
+  }),
   () => {
     const connected = props.parameters.find(p => props.formData[p.name])
-    if (connected) selectedParamName.value = connected.name
+    if (connected) {
+      selectedParamName.value = connected.name
+      return
+    }
+
+    if (selectedParamName.value && props.parameters.some(p => p.name === selectedParamName.value)) return
+
+    selectedParamName.value = props.parameters[0]?.name ?? null
+    optionRefs.value = Object.fromEntries(
+      props.parameters.map(param => [param.name, optionRefs.value[param.name] ?? null])
+    )
   }
 )
 
 const selectedParam = computed(() => props.parameters.find(p => p.name === selectedParamName.value) ?? null)
+
+const setOptionRef = (paramName: string, element: Element | null) => {
+  optionRefs.value[paramName] = element instanceof HTMLElement ? element : null
+}
+
+const focusProvider = (paramName: string) => {
+  optionRefs.value[paramName]?.focus()
+}
+
+const getTabIndex = (paramName: string, index: number) => {
+  if (selectedParamName.value) return selectedParamName.value === paramName ? 0 : -1
+  return index === 0 ? 0 : -1
+}
 
 const selectProvider = (paramName: string) => {
   if (props.readonly) return
@@ -37,6 +65,33 @@ const selectProvider = (paramName: string) => {
     props.formData[selectedParamName.value] = null
   }
   selectedParamName.value = paramName
+}
+
+const handleArrowNavigation = (event: KeyboardEvent, currentParamName: string) => {
+  if (props.readonly) return
+
+  const directionByKey: Record<string, number> = {
+    ArrowLeft: -1,
+    ArrowUp: -1,
+    ArrowRight: 1,
+    ArrowDown: 1,
+  }
+
+  const direction = directionByKey[event.key]
+  if (!direction) return
+
+  const currentIndex = props.parameters.findIndex(param => param.name === currentParamName)
+  if (currentIndex === -1 || props.parameters.length === 0) return
+
+  event.preventDefault()
+
+  const nextIndex = (currentIndex + direction + props.parameters.length) % props.parameters.length
+  const nextParamName = props.parameters[nextIndex]?.name
+  if (!nextParamName) return
+
+  selectProvider(nextParamName)
+
+  focusProvider(nextParamName)
 }
 
 const handleConnectionUpdate = (value: string | null) => {
@@ -47,18 +102,20 @@ const handleConnectionUpdate = (value: string | null) => {
 </script>
 
 <template>
-  <div class="exclusive-oauth-group">
+  <div class="exclusive-oauth-group" role="radiogroup" aria-label="OAuth provider selection">
     <div
-      v-for="param in parameters"
+      v-for="(param, index) in parameters"
       :key="param.name"
+      :ref="el => setOptionRef(param.name, el)"
       class="provider-option rounded-lg mb-2 pa-3 d-flex align-center"
       :class="{ active: selectedParamName === param.name }"
       role="radio"
       :aria-checked="selectedParamName === param.name"
-      tabindex="0"
+      :tabindex="getTabIndex(param.name, index)"
       @click="selectProvider(param.name)"
       @keydown.enter="selectProvider(param.name)"
       @keydown.space.prevent="selectProvider(param.name)"
+      @keydown="handleArrowNavigation($event, param.name)"
     >
       <Icon
         :icon="param.ui_component_properties?.icon || 'mdi-connection'"

--- a/frontend/src/composables/useEditSidebarComponentConfig.ts
+++ b/frontend/src/composables/useEditSidebarComponentConfig.ts
@@ -225,6 +225,18 @@ export function useEditSidebarComponentConfig(
             description: param.ui_component_properties?.description,
           },
         }
+      case 'EXCLUSIVE_OAUTH_CONNECTION':
+      case 'EXCLUSIVEOAUTHCONNECTION':
+        return {
+          component: OAuthConnectionInput,
+          props: {
+            readonly: isReadOnlyMode.value || !!param.ui_component_properties?.readonly,
+            provider: param.ui_component_properties?.provider || 'unknown',
+            icon: param.ui_component_properties?.icon,
+            label: param.ui_component_properties?.label || param.name,
+            description: param.ui_component_properties?.description,
+          },
+        }
       case 'ROUTEBUILDER':
         return {
           component: RouterConfigBuilder,

--- a/tests/ada_backend/services/test_registry.py
+++ b/tests/ada_backend/services/test_registry.py
@@ -7,6 +7,7 @@ from engine.components.synthesizer import Synthesizer
 from engine.components.tools.google_calendar_mcp_tool import GoogleCalendarMCPTool
 from engine.components.tools.mcp.remote_mcp_tool import RemoteMCPTool
 from engine.components.types import ComponentAttributes, ToolDescription
+from engine.integrations.mail_sender import MailSender
 from engine.integrations.providers import OAuthProvider
 from engine.llm_services.llm_service import CompletionService
 from engine.trace.trace_context import set_trace_manager
@@ -67,3 +68,14 @@ def test_google_calendar_mcp_tool_registered():
     assert factory.entity_class is GoogleCalendarMCPTool
     assert factory.provider_config_key == OAuthProvider.GOOGLE_CALENDAR
     assert factory.constructor_method == "from_access_token"
+
+
+def test_mail_sender_registered():
+    factory = FACTORY_REGISTRY.get(component_version_id=COMPONENT_VERSION_UUIDS["mail_sender"])
+    assert factory is not None
+    assert isinstance(factory, OAuthComponentFactory)
+    assert factory.entity_class is MailSender
+    assert factory.oauth_bindings == [
+        ("gmail_oauth_connection_id", OAuthProvider.GMAIL, "gmail_access_token"),
+        ("outlook_oauth_connection_id", OAuthProvider.OUTLOOK, "outlook_access_token"),
+    ]

--- a/tests/ada_backend/services/test_registry.py
+++ b/tests/ada_backend/services/test_registry.py
@@ -66,7 +66,9 @@ def test_google_calendar_mcp_tool_registered():
     assert factory is not None
     assert isinstance(factory, OAuthComponentFactory)
     assert factory.entity_class is GoogleCalendarMCPTool
-    assert factory.provider_config_key == OAuthProvider.GOOGLE_CALENDAR
+    assert factory.oauth_bindings == [
+        ("oauth_connection_id", OAuthProvider.GOOGLE_CALENDAR, "access_token"),
+    ]
     assert factory.constructor_method == "from_access_token"
 
 

--- a/tests/ada_backend/services/test_registry.py
+++ b/tests/ada_backend/services/test_registry.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ada_backend.database.seed.utils import COMPONENT_VERSION_UUIDS
-from ada_backend.services.entity_factory import OAuthComponentFactory
+from ada_backend.services.entity_factory import OAuthBinding, OAuthComponentFactory
 from ada_backend.services.registry import FACTORY_REGISTRY
 from engine.components.synthesizer import Synthesizer
 from engine.components.tools.google_calendar_mcp_tool import GoogleCalendarMCPTool
@@ -67,7 +67,11 @@ def test_google_calendar_mcp_tool_registered():
     assert isinstance(factory, OAuthComponentFactory)
     assert factory.entity_class is GoogleCalendarMCPTool
     assert factory.oauth_bindings == [
-        ("oauth_connection_id", OAuthProvider.GOOGLE_CALENDAR, "access_token"),
+        OAuthBinding(
+            param_name="oauth_connection_id",
+            provider_config_key=OAuthProvider.GOOGLE_CALENDAR,
+            target_param_name="access_token",
+        ),
     ]
     assert factory.constructor_method == "from_access_token"
 
@@ -78,8 +82,16 @@ def test_mail_sender_registered():
     assert isinstance(factory, OAuthComponentFactory)
     assert factory.entity_class is MailSender
     assert factory.oauth_bindings == [
-        ("gmail_oauth_connection_id", OAuthProvider.GMAIL, "gmail_access_token"),
-        ("outlook_oauth_connection_id", OAuthProvider.OUTLOOK, "outlook_access_token"),
+        OAuthBinding(
+            param_name="gmail_oauth_connection_id",
+            provider_config_key=OAuthProvider.GMAIL,
+            target_param_name="gmail_access_token",
+        ),
+        OAuthBinding(
+            param_name="outlook_oauth_connection_id",
+            provider_config_key=OAuthProvider.OUTLOOK,
+            target_param_name="outlook_access_token",
+        ),
     ]
 
 

--- a/tests/ada_backend/services/test_registry.py
+++ b/tests/ada_backend/services/test_registry.py
@@ -81,3 +81,38 @@ def test_mail_sender_registered():
         ("gmail_oauth_connection_id", OAuthProvider.GMAIL, "gmail_access_token"),
         ("outlook_oauth_connection_id", OAuthProvider.OUTLOOK, "outlook_access_token"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_mail_sender_factory_resolves_oauth_bindings(monkeypatch):
+    set_trace_manager(MockTraceManager(project_name="test_project"))
+
+    resolved_requests: list[tuple[str | None, str]] = []
+
+    async def fake_resolve_oauth_access_token(definition_id: str | None, provider_config_key: str) -> str | None:
+        resolved_requests.append((definition_id, provider_config_key))
+        tokens = {
+            OAuthProvider.GMAIL: "gmail-access-token",
+            OAuthProvider.OUTLOOK: "outlook-access-token",
+        }
+        return tokens[provider_config_key]
+
+    monkeypatch.setattr(
+        "ada_backend.services.entity_factory.resolve_oauth_access_token",
+        fake_resolve_oauth_access_token,
+    )
+
+    component = await FACTORY_REGISTRY.create(
+        component_version_id=COMPONENT_VERSION_UUIDS["mail_sender"],
+        component_attributes=ComponentAttributes(component_instance_name="mail_sender"),
+        gmail_oauth_connection_id="gmail-definition-id",
+        outlook_oauth_connection_id="outlook-definition-id",
+    )
+
+    assert isinstance(component, MailSender)
+    assert resolved_requests == [
+        ("gmail-definition-id", OAuthProvider.GMAIL),
+        ("outlook-definition-id", OAuthProvider.OUTLOOK),
+    ]
+    assert component._gmail_access_token == "gmail-access-token"
+    assert component._outlook_access_token == "outlook-access-token"

--- a/tests/engine/integrations/test_mail_sender.py
+++ b/tests/engine/integrations/test_mail_sender.py
@@ -4,7 +4,7 @@ import pytest
 
 from engine.components.types import ComponentAttributes
 from engine.integrations.gmail.gmail_sender import GmailSenderInputs
-from engine.integrations.mail_sender import MailSender, MailSenderOutputs
+from engine.integrations.mail_sender import MailSender, MailSenderConfigurationError, MailSenderOutputs
 
 
 @pytest.fixture
@@ -55,14 +55,14 @@ async def test_run_requires_exactly_one_provider(component_attrs: ComponentAttri
         gmail_access_token="g",
         outlook_access_token="o",
     )
-    with pytest.raises(ValueError, match="only one provider"):
+    with pytest.raises(MailSenderConfigurationError, match="only one provider"):
         await sender._run_without_io_trace(GmailSenderInputs(mail_subject="s"), {})
 
 
 @pytest.mark.asyncio
 async def test_run_requires_any_provider(component_attrs: ComponentAttributes):
     sender = MailSender(MagicMock(), component_attrs)
-    with pytest.raises(ValueError, match="Gmail or Outlook"):
+    with pytest.raises(MailSenderConfigurationError, match="Gmail or Outlook"):
         await sender._run_without_io_trace(GmailSenderInputs(mail_subject="s"), {})
 
 
@@ -70,9 +70,7 @@ async def test_run_requires_any_provider(component_attrs: ComponentAttributes):
 async def test_delegates_to_gmail(component_attrs: ComponentAttributes):
     with patch("engine.integrations.mail_sender.GmailSenderV2") as mock_cls:
         inner = mock_cls.return_value
-        inner._run_without_io_trace = AsyncMock(
-            return_value=MailSenderOutputs(status="sent", message_id="mid-g")
-        )
+        inner._run_without_io_trace = AsyncMock(return_value=MailSenderOutputs(status="sent", message_id="mid-g"))
         sender = MailSender(
             MagicMock(),
             component_attrs,
@@ -88,9 +86,7 @@ async def test_delegates_to_gmail(component_attrs: ComponentAttributes):
 async def test_delegates_to_outlook(component_attrs: ComponentAttributes):
     with patch("engine.integrations.mail_sender.OutlookSender") as mock_cls:
         inner = mock_cls.return_value
-        inner._run_without_io_trace = AsyncMock(
-            return_value=MailSenderOutputs(status="sent", message_id=None)
-        )
+        inner._run_without_io_trace = AsyncMock(return_value=MailSenderOutputs(status="sent", message_id=None))
         sender = MailSender(
             MagicMock(),
             component_attrs,

--- a/tests/engine/integrations/test_mail_sender.py
+++ b/tests/engine/integrations/test_mail_sender.py
@@ -1,0 +1,102 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from engine.components.types import ComponentAttributes
+from engine.integrations.gmail.gmail_sender import GmailSenderInputs
+from engine.integrations.mail_sender import MailSender, MailSenderOutputs
+
+
+@pytest.fixture
+def component_attrs() -> ComponentAttributes:
+    return ComponentAttributes(component_instance_name="mail_test", component_instance_id=None)
+
+
+def test_is_available_gmail_only(component_attrs: ComponentAttributes):
+    sender = MailSender(
+        MagicMock(),
+        component_attrs,
+        gmail_access_token="tok",
+        outlook_access_token=None,
+    )
+    assert sender.is_available()
+
+
+def test_is_available_outlook_only(component_attrs: ComponentAttributes):
+    sender = MailSender(
+        MagicMock(),
+        component_attrs,
+        gmail_access_token=None,
+        outlook_access_token="tok",
+    )
+    assert sender.is_available()
+
+
+def test_is_available_both_disconnected(component_attrs: ComponentAttributes):
+    sender = MailSender(MagicMock(), component_attrs)
+    assert not sender.is_available()
+
+
+def test_is_available_both_connected(component_attrs: ComponentAttributes):
+    sender = MailSender(
+        MagicMock(),
+        component_attrs,
+        gmail_access_token="g",
+        outlook_access_token="o",
+    )
+    assert not sender.is_available()
+
+
+@pytest.mark.asyncio
+async def test_run_requires_exactly_one_provider(component_attrs: ComponentAttributes):
+    sender = MailSender(
+        MagicMock(),
+        component_attrs,
+        gmail_access_token="g",
+        outlook_access_token="o",
+    )
+    with pytest.raises(ValueError, match="only one provider"):
+        await sender._run_without_io_trace(GmailSenderInputs(mail_subject="s"), {})
+
+
+@pytest.mark.asyncio
+async def test_run_requires_any_provider(component_attrs: ComponentAttributes):
+    sender = MailSender(MagicMock(), component_attrs)
+    with pytest.raises(ValueError, match="Gmail or Outlook"):
+        await sender._run_without_io_trace(GmailSenderInputs(mail_subject="s"), {})
+
+
+@pytest.mark.asyncio
+async def test_delegates_to_gmail(component_attrs: ComponentAttributes):
+    with patch("engine.integrations.mail_sender.GmailSenderV2") as mock_cls:
+        inner = mock_cls.return_value
+        inner._run_without_io_trace = AsyncMock(
+            return_value=MailSenderOutputs(status="sent", message_id="mid-g")
+        )
+        sender = MailSender(
+            MagicMock(),
+            component_attrs,
+            gmail_access_token="g",
+        )
+        out = await sender._run_without_io_trace(GmailSenderInputs(mail_subject="sub"), {})
+        assert out.status == "sent"
+        assert out.message_id == "mid-g"
+        mock_cls.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_delegates_to_outlook(component_attrs: ComponentAttributes):
+    with patch("engine.integrations.mail_sender.OutlookSender") as mock_cls:
+        inner = mock_cls.return_value
+        inner._run_without_io_trace = AsyncMock(
+            return_value=MailSenderOutputs(status="sent", message_id=None)
+        )
+        sender = MailSender(
+            MagicMock(),
+            component_attrs,
+            outlook_access_token="o",
+        )
+        out = await sender._run_without_io_trace(GmailSenderInputs(mail_subject="sub"), {})
+        assert out.status == "sent"
+        assert out.message_id is None
+        mock_cls.assert_called_once()

--- a/tests/engine/integrations/test_mail_sender.py
+++ b/tests/engine/integrations/test_mail_sender.py
@@ -44,7 +44,7 @@ def test_is_available_both_connected(component_attrs: ComponentAttributes):
         gmail_access_token="g",
         outlook_access_token="o",
     )
-    assert not sender.is_available()
+    assert sender.is_available()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- New **Mail Sender** engine component (`engine/integrations/mail_sender.py`): thin dispatcher over existing `GmailSenderV2` and `OutlookSender` (same input/output shape as the standalone senders). **Exactly one** provider must be connected; if both or neither are present, the run fails with `MailSenderConfigurationError` extending **`EngineError`** (engine code does not depend on `ServiceError`).
- **`OAuthComponentFactory`** now uses only `oauth_bindings` to wire `OAUTH_CONNECTION` parameters to Nango provider keys / constructor kwargs (single-provider components use a one-item list). Registry callsites were normalized to this shape, and list input handling now treats `[]` as unconfigured instead of indexing into an empty list.
- **Registry** registers `mail_sender` with bindings for Gmail and Outlook. **Seeds**: component, version, tool description, `COMPONENT_UUIDS` / `COMPONENT_VERSION_UUIDS`, parameter groups (Connection first, reusing shared Gmail group UUIDs for content/recipients/attachments). **Seed order** creates `parameter_groups` rows and the component, then `component_parameter_groups` links, so `component_parameter_definitions.parameter_group_id` FKs are valid.
- **Exclusive OAuth radio UI** (`frontend/src/components/studio/components/ExclusiveOAuthGroup.vue`): new `UIComponent.EXCLUSIVE_OAUTH_CONNECTION` enum value + Alembic migration (`migrate-first`). The Connection group now renders a radio-select showing one provider at a time instead of two parallel OAuth cards. Switching providers clears the previous selection.

## Out of scope (per ticket)

- **Send later** / scheduled delivery (follow-up; parity across providers was intentionally deferred).

## Testing

- **Automated:** `tests/engine/integrations/test_mail_sender.py`, `tests/ada_backend/services/test_registry.py` (`test_mail_sender_registered`).
- **Manual:** Send succeeded via **Gmail** and **Outlook**; configuration error messages look correct when invalid.

## Preview
<img width="1224" height="385" alt="image" src="https://github.com/user-attachments/assets/6dc7626a-9118-4cef-b677-f481931d6f39" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mail Sender integration component supporting Gmail and Outlook email delivery with a unified interface.
  * Exclusive OAuth Connection UI for intuitive provider selection via radio buttons.

* **Infrastructure**
  * Database migration to support exclusive OAuth connection UI component type.
  * Mail Sender component seeding and system registry configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->