### PR TITLE
feat(ports): Backfill and populate port_definition_id on input port instances dra-1290

### DIFF
--- a/ada_backend/database/alembic/versions/b4c5d6e7f8b0_backfill_port_definition_id_on_input_port_instances.py
+++ b/ada_backend/database/alembic/versions/b4c5d6e7f8b0_backfill_port_definition_id_on_input_port_instances.py
@@ -1,0 +1,40 @@
+"""Backfill port_definition_id on input_port_instances where it is NULL.
+
+Joins through component_instances → port_definitions to resolve the
+catalogue port definition for each named input port.
+
+Revision ID: b4c5d6e7f8b0
+Revises: a3b4c5d6e7f9
+Create Date: 2026-05-06
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b4c5d6e7f8b0"
+down_revision: Union[str, None] = "a3b4c5d6e7f9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy = "migrate-first"
+
+
+def upgrade() -> None:
+    op.execute("""
+        UPDATE port_instances pi
+        SET port_definition_id = pd.id
+        FROM input_port_instances ipi,
+             component_instances ci,
+             port_definitions pd
+        WHERE ipi.id = pi.id
+          AND ci.id = pi.component_instance_id
+          AND pd.component_version_id = ci.component_version_id
+          AND pd.name = pi.name
+          AND pd.port_type = 'INPUT'
+          AND pi.port_definition_id IS NULL
+    """)
+
+
+def downgrade() -> None:
+    pass

--- a/ada_backend/services/graph/component_instance_v2_service.py
+++ b/ada_backend/services/graph/component_instance_v2_service.py
@@ -187,6 +187,7 @@ def _sync_input_port_field_expressions(
                 component_instance_id=instance_id,
                 name=port_data.name,
                 field_expression_id=expr.id,
+                port_definition_id=port_data.port_definition_id,
                 prompt_version_id=port_data.prompt_version_id,
             )
 

--- a/ada_backend/services/graph/deploy_graph_service.py
+++ b/ada_backend/services/graph/deploy_graph_service.py
@@ -243,6 +243,7 @@ def clone_graph_runner(
                     component_instance_id=target_instance_id,
                     name=remapped_expr.field_name,
                     field_expression_id=field_expr.id,
+                    port_definition_id=source_port.port_definition_id if source_port else None,
                     prompt_version_id=source_port.prompt_version_id if source_port else None,
                 )
                 if source_port:

--- a/ada_backend/services/graph/update_graph_service.py
+++ b/ada_backend/services/graph/update_graph_service.py
@@ -345,6 +345,11 @@ async def update_graph_service(
         session, graph_runner_id, graph_project, input_params_by_instance
     )
 
+    instance_to_cv: dict[UUID, UUID] = {}
+    for inst in graph_project.component_instances:
+        if inst.id and inst.component_version_id:
+            instance_to_cv[inst.id] = inst.component_version_id
+
     db_port_instances_by_instance: dict[UUID, dict[str, UUID]] = defaultdict(dict)
     db_field_expr_port_names: dict[UUID, set[str]] = defaultdict(set)
     for instance_id in instance_ids:
@@ -353,6 +358,10 @@ async def update_graph_service(
             db_port_instances_by_instance[instance_id][port.name] = port.id
             if port.field_expression_id:
                 db_field_expr_port_names[instance_id].add(port.name)
+            if not port.port_definition_id and instance_id in instance_to_cv:
+                port_def_id = get_input_port_definition_id(session, instance_to_cv[instance_id], port.name)
+                if port_def_id:
+                    update_input_port_instance(session, port.id, port_definition_id=port_def_id)
 
     # Create/update auto-generated canonical field expressions so the user can
     # see canonical wiring in the UI.  Must run before field-expression processing
@@ -371,12 +380,16 @@ async def update_graph_service(
                 expr = create_field_expression(session, expression_json)
                 update_input_port_instance(session, existing_port_id, field_expression_id=expr.id)
         else:
+            port_def_id = get_input_port_definition_id(
+                session, instance_to_cv[target_id], field_name
+            ) if target_id in instance_to_cv else None
             expr = create_field_expression(session, expression_json)
             input_port_instance = create_input_port_instance(
                 session=session,
                 component_instance_id=target_id,
                 name=field_name,
                 field_expression_id=expr.id,
+                port_definition_id=port_def_id,
             )
             db_port_instances_by_instance[target_id][field_name] = input_port_instance.id
 
@@ -406,12 +419,16 @@ async def update_graph_service(
                             expr = create_field_expression(session, port_instance.field_expression.expression_json)
                             update_input_port_instance(session, existing_port_id, field_expression_id=expr.id)
                     else:
+                        port_def_id = get_input_port_definition_id(
+                            session, instance.component_version_id, field_name
+                        ) if instance.component_version_id else None
                         expr = create_field_expression(session, port_instance.field_expression.expression_json)
                         create_input_port_instance(
                             session=session,
                             component_instance_id=instance.id,
                             name=field_name,
                             field_expression_id=expr.id,
+                            port_definition_id=port_def_id,
                         )
 
         # Convert Inputs from parameters[kind="input"] to field expressions.
@@ -472,6 +489,9 @@ async def update_graph_service(
                 if prompt_version_id is not None:
                     update_input_port_instance(session, existing_port_id, prompt_version_id=prompt_version_id)
             else:
+                port_def_id = get_input_port_definition_id(
+                    session, instance.component_version_id, field_name
+                ) if instance.component_version_id else None
                 expr = create_field_expression(session, expression_json)
                 create_input_port_instance(
                     session=session,
@@ -479,6 +499,7 @@ async def update_graph_service(
                     name=field_name,
                     field_expression_id=expr.id,
                     prompt_version_id=prompt_version_id,
+                    port_definition_id=port_def_id,
                 )
             sync_output_port_instances_from_schema(
                 session=session,

--- a/tests/ada_backend/services/graph/test_component_instance_v2_service.py
+++ b/tests/ada_backend/services/graph/test_component_instance_v2_service.py
@@ -397,6 +397,7 @@ class TestSyncInputPortFieldExpressionsPromptPin:
             component_instance_id=instance_id,
             name="system_prompt",
             field_expression_id=expr_mock.id,
+            port_definition_id=None,
             prompt_version_id=version_id,
         )
 
@@ -455,5 +456,6 @@ class TestSyncInputPortFieldExpressionsPromptPin:
             component_instance_id=instance_id,
             name="query",
             field_expression_id=expr_mock.id,
+            port_definition_id=None,
             prompt_version_id=None,
         )

--- a/tests/ada_backend/test_prompt_service.py
+++ b/tests/ada_backend/test_prompt_service.py
@@ -10,6 +10,7 @@ from ada_backend.services.errors import (
     GraphNotBoundToProjectError,
     GraphNotFound,
     NotFoundError,
+    PortNotPromptEligibleError,
     PromptStillReferencedError,
 )
 from ada_backend.services.prompt_service import (
@@ -371,3 +372,17 @@ class TestPinOwnershipValidation:
 
             with pytest.raises(GraphNotBoundToProjectError):
                 unpin_prompt_from_port_service(session, ci.id, "system_prompt", gr.id, uuid.uuid4())
+
+    def test_pin_fails_when_port_definition_id_is_null(self):
+        """port_definition_id must be set for prompt eligibility check to pass."""
+        with get_db_session() as session:
+            ci, gr, ipi, project = _setup_graph_with_component(session)
+            ipi.port_definition_id = None
+            session.flush()
+
+            prompt = _create_prompt(session, name=f"Pin-{uuid.uuid4().hex[:8]}")
+            detail = get_prompt_detail_service(session, prompt.id, organization_id=ORG_ID)
+            version_id = detail.versions[0].id
+
+            with pytest.raises(PortNotPromptEligibleError):
+                pin_prompt_to_port_service(session, ci.id, "system_prompt", version_id, gr.id, project.id)


### PR DESCRIPTION
# feat(ports): Backfill and populate port_definition_id on input port instances (DRA-1290)

## Summary
- Fix missing `port_definition_id` on `InputPortInstance` rows: several code paths (V1 graph update, graph `clone/deploy`, V2 component sync) were creating input port instances without setting `port_definition_id`, which broke downstream features like prompt pinning that rely on port definition metadata (e.g. `is_prompt` eligibility check).
- Alembic migration backfills all existing `NULL` `port_definition_id` values by joining through `component_instances` → `port_definitions` to resolve the correct catalogue entry.
- Regression test verifying that `pin_prompt_to_port_service` raises `PortNotPromptEligibleError` when `port_definition_id` is `NULL`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backfilled missing port-definition IDs for input ports and ensured newly created, cloned, or remapped input ports inherit or are assigned the correct port-definition for consistent wiring and prompt eligibility.
  * Ensured canonical wiring and auto-wiring logic account for input parameters so existing incoming connections are recognized.

* **Tests**
  * Added a test confirming pinning a prompt to a port without a port-definition now fails as expected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Scopeo/draftnrun/pull/712)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->