### PR TITLE
feat(ingestion): Fix internal metadatas DRA-1169

### DIFF
--- a/.cursor/rules/engine.mdc
+++ b/.cursor/rules/engine.mdc
@@ -19,6 +19,7 @@ globs:
 - Legacy system: some components still use `AgentPayload` pattern (`migrated = False`). New components MUST use the multi-port `NodeData` system (`migrated = True`).
 - `SQLLocalService` engine pools are cached per `engine_url` (process-level). Avoid patterns that instantiate many services for the same URL expecting independent pools.
 - In ingestion code paths, reuse one `SQLLocalService` per job when possible, and ensure `await close()` is called in a `finally` block.
+- Internal source metadata keys must be underscore-prefixed (`_source_url`, `_supabase_url`, `_reranked_score`, retrieval/reranker ranks) and excluded from LLM context. Keep public source display on top-level chunk `url` / `SourceChunk.url`.
 - `IS_CLOUD_S3` controls folder-source ingestion URL strategy: keep it `False` in local/dev and custom `S3_ENDPOINT_URL` setups (direct file reads; presigned URL getter returns `None`), set it `True` in cloud AWS S3 prod to require presigned URL generation and fail fast on missing URLs.
 - For DB-source ingestion worker flow (`ingestion_script/ingest_db_source.py`), keep a single source `SQLLocalService` per run and share it across validation and fetch helpers.
 - Adding a new component: create class in `engine/components/`, register in `ada_backend/services/registry.py`, add DB seed data (Component, ComponentVersion, PortDefinition, ComponentParameterDefinition rows). Always set `migrated = True`, define Pydantic I/O schemas, define canonical ports.

--- a/ada_backend/database/alembic/versions/d1e2f3a4b5c6_prefix_internal_metadata_keys.py
+++ b/ada_backend/database/alembic/versions/d1e2f3a4b5c6_prefix_internal_metadata_keys.py
@@ -1,0 +1,232 @@
+"""prefix_internal_metadata_keys
+
+Revision ID: d1e2f3a4b5c6
+Revises: a3b4c5d6e7f9
+Create Date: 2026-05-07 17:17:00.000000
+
+"""
+
+import asyncio
+import logging
+from typing import Any, Sequence, Union
+
+import psycopg2
+from alembic import op
+from psycopg2 import sql
+from sqlalchemy import text
+
+from engine.qdrant_service import QdrantService
+from settings import settings
+
+# revision identifiers, used by Alembic.
+revision: str = "d1e2f3a4b5c6"
+down_revision: Union[str, None] = "a3b4c5d6e7f9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deploy_strategy: Union[str, None] = "breaking"
+
+LOGGER = logging.getLogger(__name__)
+
+BATCH_SIZE = 500
+UPGRADE_KEY_RENAMES = {
+    "source_url": "_source_url",
+    "supabase_url": "_supabase_url",
+}
+DOWNGRADE_KEY_RENAMES = {value: key for key, value in UPGRADE_KEY_RENAMES.items()}
+
+
+def _get_data_sources():
+    connection = op.get_bind()
+    result = connection.execute(
+        text(
+            """
+            SELECT DISTINCT database_schema, database_table_name, qdrant_collection_name
+            FROM data_sources
+            WHERE database_table_name IS NOT NULL
+               OR qdrant_collection_name IS NOT NULL
+            """
+        )
+    )
+    return result.fetchall()
+
+
+def _table_has_metadata_column(cursor, schema_name: str, table_name: str) -> bool:
+    cursor.execute(
+        """
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = %s
+          AND table_name = %s
+          AND column_name = 'metadata'
+        """,
+        (schema_name, table_name),
+    )
+    return cursor.fetchone() is not None
+
+
+def _rename_metadata_keys_in_ingestion_db(data_sources, key_renames: dict[str, str]) -> None:
+    if not settings.INGESTION_DB_URL:
+        LOGGER.warning("INGESTION_DB_URL is not set. Skipping ingestion metadata key migration.")
+        return
+
+    tables = {
+        (source.database_schema, source.database_table_name)
+        for source in data_sources
+        if source.database_schema and source.database_table_name
+    }
+    if not tables:
+        LOGGER.info("No ingestion tables found for metadata key migration.")
+        return
+
+    try:
+        ingestion_conn = psycopg2.connect(settings.INGESTION_DB_URL)
+        ingestion_conn.autocommit = True
+        cursor = ingestion_conn.cursor()
+
+        for schema_name, table_name in tables:
+            if not _table_has_metadata_column(cursor, schema_name, table_name):
+                LOGGER.warning("Skipping %s.%s because it has no metadata column.", schema_name, table_name)
+                continue
+
+            keys_to_remove = sql.SQL(" - ").join(sql.Literal(key) for key in key_renames)
+            set_fragments = [
+                sql.SQL(
+                    "CASE WHEN COALESCE(metadata, '{}'::jsonb) ? {old_key} "
+                    "THEN jsonb_build_object({new_key}, metadata -> {old_key}) "
+                    "ELSE '{}'::jsonb END"
+                ).format(old_key=sql.Literal(old_key), new_key=sql.Literal(new_key))
+                for old_key, new_key in key_renames.items()
+            ]
+            set_expression = sql.SQL(" || ").join([
+                sql.SQL("(COALESCE(metadata, '{}'::jsonb) - {keys_to_remove})").format(
+                    keys_to_remove=keys_to_remove
+                ),
+                *set_fragments,
+            ])
+            where_expression = sql.SQL(" OR ").join(
+                sql.SQL("COALESCE(metadata, '{}'::jsonb) ? {old_key}").format(old_key=sql.Literal(old_key))
+                for old_key in key_renames
+            )
+            query = sql.SQL(
+                """
+                UPDATE {schema_name}.{table_name}
+                SET metadata = jsonb_strip_nulls({set_expression})
+                WHERE {where_expression}
+                """
+            ).format(
+                schema_name=sql.Identifier(schema_name),
+                table_name=sql.Identifier(table_name),
+                set_expression=set_expression,
+                where_expression=where_expression,
+            )
+            cursor.execute(query)
+            LOGGER.info("Migrated %s metadata rows in %s.%s.", cursor.rowcount, schema_name, table_name)
+    except psycopg2.Error as e:
+        LOGGER.error("Failed to migrate ingestion DB metadata keys: %s", e, exc_info=True)
+        raise
+    finally:
+        if "cursor" in locals():
+            cursor.close()
+        if "ingestion_conn" in locals():
+            ingestion_conn.close()
+
+
+async def _scroll_qdrant_batch(
+    qdrant_service: QdrantService,
+    collection_name: str,
+    offset: Any = None,
+) -> tuple[list[dict], Any]:
+    payload: dict[str, Any] = {"limit": BATCH_SIZE, "with_payload": True, "with_vector": False}
+    if offset is not None:
+        payload["offset"] = offset
+    response = await qdrant_service._send_request_async(
+        method="POST",
+        endpoint=f"collections/{collection_name}/points/scroll?wait=true",
+        payload=payload,
+    )
+    result = response.get("result", {})
+    return result.get("points", []), result.get("next_page_offset")
+
+
+async def _rename_qdrant_payload_keys_for_collection(
+    qdrant_service: QdrantService,
+    collection_name: str,
+    key_renames: dict[str, str],
+) -> int:
+    if not await qdrant_service.collection_exists_async(collection_name):
+        LOGGER.warning("Qdrant collection %s does not exist. Skipping.", collection_name)
+        return 0
+
+    updated_points = 0
+    offset = None
+    while True:
+        points, offset = await _scroll_qdrant_batch(qdrant_service, collection_name, offset)
+        if not points:
+            break
+
+        for point in points:
+            point_payload = point.get("payload") or {}
+            renamed_payload = {
+                new_key: point_payload[old_key]
+                for old_key, new_key in key_renames.items()
+                if old_key in point_payload
+            }
+            if not renamed_payload:
+                continue
+
+            point_id = point["id"]
+            await qdrant_service._send_request_async(
+                method="POST",
+                endpoint=f"collections/{collection_name}/points/payload?wait=true",
+                payload={"points": [point_id], "payload": renamed_payload},
+            )
+            await qdrant_service._send_request_async(
+                method="POST",
+                endpoint=f"collections/{collection_name}/points/payload/delete?wait=true",
+                payload={"points": [point_id], "keys": list(key_renames.keys())},
+            )
+            updated_points += 1
+
+        if offset is None:
+            break
+
+    LOGGER.info("Migrated %s Qdrant points in collection %s.", updated_points, collection_name)
+    return updated_points
+
+
+async def _rename_qdrant_payload_keys(data_sources, key_renames: dict[str, str]) -> None:
+    collection_names = sorted({
+        source.qdrant_collection_name for source in data_sources if source.qdrant_collection_name
+    })
+    if not collection_names:
+        LOGGER.info("No Qdrant collections found for metadata key migration.")
+        return
+
+    qdrant_service = QdrantService.from_defaults(timeout=120)
+    total_updated = 0
+    for collection_name in collection_names:
+        total_updated += await _rename_qdrant_payload_keys_for_collection(
+            qdrant_service,
+            collection_name,
+            key_renames,
+        )
+    LOGGER.info("Migrated %s total Qdrant points.", total_updated)
+
+
+def _rename_internal_metadata_keys(key_renames: dict[str, str]) -> None:
+    data_sources = _get_data_sources()
+    if not data_sources:
+        LOGGER.info("No data sources found for metadata key migration.")
+        return
+
+    _rename_metadata_keys_in_ingestion_db(data_sources, key_renames)
+    asyncio.run(_rename_qdrant_payload_keys(data_sources, key_renames))
+
+
+def upgrade() -> None:
+    _rename_internal_metadata_keys(UPGRADE_KEY_RENAMES)
+
+
+def downgrade() -> None:
+    _rename_internal_metadata_keys(DOWNGRADE_KEY_RENAMES)

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -146,6 +146,16 @@ In ingestion flows, prefer reusing an existing `SQLLocalService` instance inside
 In ingestion workers, `ingestion_script.ingest_db_source.upload_db_source()` should create one source
 `SQLLocalService` per ingestion run and reuse it across the run before closing it in `finally`.
 
+## Internal Source Metadata
+
+Metadata keys used for internal retrieval, storage, or ranking state are underscore-prefixed and excluded from LLM
+context formatting. This includes `_source_url`, `_supabase_url`, `_retrieval_rank`, `_reranker_rank`, and
+`_reranked_score`. User-facing source links should continue to flow through the top-level `url` field on chunks and
+`SourceChunk.url`; the underscore-prefixed metadata keys are not part of the frontend source display contract.
+
+Ingestion stores source-specific metadata in the ingestion DB `metadata` JSONB column. Qdrant receives that metadata
+flattened into top-level payload fields, and retrieval maps non-standard payload fields back into `SourceChunk.metadata`.
+
 ## Tracing Context to Sentry Tags
 
 **File**: `engine/trace/span_context.py`

--- a/data_ingestion/document/folder_management/folder_management.py
+++ b/data_ingestion/document/folder_management/folder_management.py
@@ -66,7 +66,7 @@ class BaseDocument(BaseModel):
 
     @property
     def url(self) -> str | None:
-        return self.metadata.get("supabase_url") or self.metadata.get("source_url", None)
+        return self.metadata.get("_supabase_url") or self.metadata.get("_source_url", None)
 
 
 class FileDocument(BaseDocument):

--- a/data_ingestion/document/folder_management/google_drive_folder_management.py
+++ b/data_ingestion/document/folder_management/google_drive_folder_management.py
@@ -143,7 +143,7 @@ class GoogleDriveFolderManager(FolderManager):
             file_name=file["name"],
             folder_name="/".join(reversed(folder_names)),
             metadata={
-                "source_url": file.get("webViewLink", None),
+                "_source_url": file.get("webViewLink", None),
             },
         )
 

--- a/data_ingestion/document/supabase_file_uploader.py
+++ b/data_ingestion/document/supabase_file_uploader.py
@@ -46,10 +46,10 @@ def sync_files_to_supabase(
     supabase_client = create_client(settings.SUPABASE_PROJECT_URL, settings.SUPABASE_SERVICE_ROLE_SECRET_KEY)
 
     for doc in list_of_documents:
-        doc.metadata["supabase_url"] = get_supabase_url_for_file(
+        doc.metadata["_supabase_url"] = get_supabase_url_for_file(
             f"{doc.folder_name}/{doc.file_name}",
             organization_id=organization_id,
             source_name=source_name,
         )
-        upload_file_to_supabase(get_file_content_func(doc.id), supabase_client, doc.metadata["supabase_url"])
+        upload_file_to_supabase(get_file_content_func(doc.id), supabase_client, doc.metadata["_supabase_url"])
     return list_of_documents

--- a/engine/components/build_context.py
+++ b/engine/components/build_context.py
@@ -43,14 +43,14 @@ def format_source_chunk_metadata(
         'Metadata:\\nauthor: Jane Doe\\nyear: 2021\\n'
     """
     metadata = source.metadata or {}
-    # TODO: add _ prefix for metadata keys that we want to exclude from the context
-    _excluded_keys = {"reranked_score", "_retrieval_rank", "_reranker_rank"}
     if llm_metadata_keys:
-        metadata = {key: metadata[key] for key in llm_metadata_keys if key in metadata and key not in _excluded_keys}
-    else:
         metadata = {
-            key: value for key, value in metadata.items() if not key.startswith("_") and key not in _excluded_keys
+            key: metadata[key]
+            for key in llm_metadata_keys
+            if key in metadata and not key.startswith("_")
         }
+    else:
+        metadata = {key: value for key, value in metadata.items() if not key.startswith("_")}
 
     if not metadata:
         LOGGER.info("No metadata available for source: %s", source.name)

--- a/engine/components/rag/cohere_reranker.py
+++ b/engine/components/rag/cohere_reranker.py
@@ -46,6 +46,6 @@ class CohereReranker(Reranker):
             chunks[result.index] for result in response.results if result.relevance_score >= self._score_threshold
         ]
         for chunk, result in zip(reranked_chunks, response.results, strict=False):
-            chunk.metadata["reranked_score"] = result.relevance_score
+            chunk.metadata["_reranked_score"] = result.relevance_score
         LOGGER.info(f"Reranked {len(reranked_chunks)} chunks")
         return reranked_chunks

--- a/engine/components/rag/reranker.py
+++ b/engine/components/rag/reranker.py
@@ -67,7 +67,7 @@ class Reranker(CloseMixin, ABC):
                 span.set_attributes({
                     f"{output_prefix}.content": reranker_chunk.content,
                     f"{output_prefix}.id": reranker_chunk.name,
-                    f"{output_prefix}.score": reranker_chunk.metadata["reranked_score"],
+                    f"{output_prefix}.score": reranker_chunk.metadata["_reranked_score"],
                     f"{output_prefix}.metadata": metadata_str,
                     f"{output_prefix}.metadata.retrieval_rank": retrieval_rank,
                     f"{output_prefix}.metadata.reranker_rank": i + 1,

--- a/ingestion_script/ingest_website_source.py
+++ b/ingestion_script/ingest_website_source.py
@@ -205,7 +205,7 @@ async def upload_website_source(
             folder_name=page_data.url,
             metadata={
                 "title": page_data.title,
-                "source_url": page_data.url,
+                "_source_url": page_data.url,
             },
         )
 

--- a/tests/components/rag/test_build_context.py
+++ b/tests/components/rag/test_build_context.py
@@ -1,4 +1,5 @@
 from engine.components.build_context import build_context_from_source_chunks
+from engine.components.types import SourceChunk
 
 
 # 1. Test Basic SourceChunk Formatting
@@ -54,6 +55,42 @@ def test_source_chunk_filter_metadata(mock_source_chunk_many_metadata):
         "keywords: AI, Python, Programming"
     )
     assert result == expected
+
+
+def test_source_chunk_excludes_internal_metadata_keys():
+    source = SourceChunk(
+        name="internal_metadata",
+        document_name="internal_metadata",
+        url="url",
+        content="Content",
+        metadata={
+            "author": "Jane Doe",
+            "_source_url": "https://example.com",
+            "_supabase_url": "org/source/file.pdf",
+            "_reranked_score": 0.9,
+        },
+    )
+
+    result = build_context_from_source_chunks([source])
+
+    assert result == "**Source 1:**\nContent\nMetadata:\nauthor: Jane Doe"
+
+
+def test_source_chunk_allowlist_cannot_include_internal_metadata_keys():
+    source = SourceChunk(
+        name="internal_metadata",
+        document_name="internal_metadata",
+        url="url",
+        content="Content",
+        metadata={
+            "author": "Jane Doe",
+            "_source_url": "https://example.com",
+        },
+    )
+
+    result = build_context_from_source_chunks([source], llm_metadata_keys=["author", "_source_url"])
+
+    assert result == "**Source 1:**\nContent\nMetadata:\nauthor: Jane Doe"
 
 
 # 7. Test Custom Template and Content Formatting

--- a/tests/data_ingestion/test_ingest_folder.py
+++ b/tests/data_ingestion/test_ingest_folder.py
@@ -83,3 +83,25 @@ def test_get_chunks_dataframe_from_docs(mock_file_document, mock_file_chunk):
     assert result_df["bounding_boxes"].iloc[0] == '[{"xmin": 1, "ymin": 2, "xmax": 3, "ymax": 4, "page": 1}]'
     assert result_df["url"].iloc[0] == "None"
     assert result_df["order"].iloc[0] == 0
+
+
+def test_file_document_url_uses_internal_metadata_keys():
+    source_document = FileDocument(
+        id="source-id",
+        last_edited_ts="2023-01-01T00:00:00Z",
+        type=FileDocumentType.PDF,
+        file_name="source.pdf",
+        folder_name="folder",
+        metadata={"_source_url": "https://example.com/source.pdf"},
+    )
+    supabase_document = FileDocument(
+        id="supabase-id",
+        last_edited_ts="2023-01-01T00:00:00Z",
+        type=FileDocumentType.PDF,
+        file_name="supabase.pdf",
+        folder_name="folder",
+        metadata={"_supabase_url": "org/source/supabase.pdf", "_source_url": "https://example.com/source.pdf"},
+    )
+
+    assert source_document.url == "https://example.com/source.pdf"
+    assert supabase_document.url == "org/source/supabase.pdf"

--- a/tests/ingestion_script/test_ingest_website_source.py
+++ b/tests/ingestion_script/test_ingest_website_source.py
@@ -151,7 +151,7 @@ async def test_upload_website_source_syncs_scraped_pages(monkeypatch):
     assert mapping_kwargs["document_reading_mode"] == DocumentReadingMode.STANDARD
 
     document_arg = chunks_mock.await_args.args[0]
-    assert document_arg.metadata["source_url"] == "https://example.com/page"
+    assert document_arg.metadata["_source_url"] == "https://example.com/page"
     assert document_arg.metadata["title"] == "Example page"
 
     assert chunks_mock.await_args.kwargs["document_chunk_mapping"] is mapping_sentinel


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal metadata keys are now prefixed with underscores for clearer separation from public-facing data.
  * Internal metadata is automatically excluded from LLM context and frontend source link display.
  * Database migration implemented to update existing internal metadata references across all sources.

* **Documentation**
  * Added clarification on internal source metadata handling and public source URL conventions.

* **Tests**
  * Added test coverage for internal metadata key filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->