### PR TITLE
feat(git-sync): auto-discover new project folders on push DRA-1295

### DIFF
--- a/ada_backend/docs/git-sync.md
+++ b/ada_backend/docs/git-sync.md
@@ -58,6 +58,8 @@ GitHub repo (push to main)
   → Backend looks up matching GitSyncConfig by (owner, repo_name, branch)
   → For prompt changes (draftnrun/prompts/**/*.md): enqueue prompt sync job (first)
   → For project changes (draftnrun/projects/*/...): enqueue graph sync job (second)
+  → Auto-discovery: detect new project folders (graph.json added but no config yet)
+    → Create project + GitSyncConfig + enqueue initial sync
   → Webhook returns immediately (non-blocking)
   → Git sync queue worker picks up each job (FIFO):
     Prompt sync (runs first):
@@ -142,7 +144,8 @@ This happens automatically on each webhook — no user interaction needed.
 3. Looks up matching `git_sync_configs` by `(github_owner, github_repo_name, branch)`
 4. For each matching config where any file in the tracked folder changed, enqueues a graph sync job. Enqueue is idempotent per `(config_id, commit_sha)` via a Redis `SET NX` dedup key (TTL 1 hour)
 5. If changed files include paths under `draftnrun/prompts/**/*.md`, enqueues a prompt sync job with the list of changed prompt paths
-6. The `GitSyncQueueWorker` (daemon thread in the API process) picks up each job:
+6. **Auto-discovery**: scans `changed_files` for `draftnrun/projects/<name>/graph.json` paths that have no matching `GitSyncConfig`. For each new folder, creates a project (tagged `"github"`, type `WORKFLOW`), a `GitSyncConfig` row, and enqueues an initial graph sync. Requires a registered `GitHubAppInstallation` to resolve the `organization_id`. The `created_by_user_id` is inherited from an existing config in the same repo when available, otherwise `NULL`
+7. The `GitSyncQueueWorker` (daemon thread in the API process) picks up each job:
 
    **Graph sync** (existing behavior):
    - Loads the config from DB

--- a/ada_backend/services/git_sync_service.py
+++ b/ada_backend/services/git_sync_service.py
@@ -25,7 +25,7 @@ from ada_backend.schemas.pipeline.graph_schema import GraphSaveV2Schema, GraphUp
 from ada_backend.schemas.pipeline.port_instance_schema import FieldExpressionSchema
 from ada_backend.services import github_client
 from ada_backend.services.errors import ServiceError
-from ada_backend.services.github_client import PROMPT_LIBRARY_DIR
+from ada_backend.services.github_client import PROJECTS_DIR, PROMPT_LIBRARY_DIR
 from ada_backend.services.graph.deploy_graph_service import deploy_graph_service
 from ada_backend.services.graph.graph_v2_mapper_service import graph_save_v2_to_graph_update
 from ada_backend.services.graph.update_graph_service import update_graph_service
@@ -207,6 +207,62 @@ async def import_from_github(
     return imported_projects, skipped_projects, imported_prompts, skipped_prompts
 
 
+def _create_synced_project(
+    session: Session,
+    organization_id: UUID,
+    github_owner: str,
+    github_repo_name: str,
+    branch: str,
+    github_installation_id: int,
+    github_folder: str,
+    project_type: ProjectType,
+    created_by_user_id: UUID | None,
+    description: str,
+) -> tuple[db.Project, str, db.GitSyncConfig] | None:
+    """Create a project + GitSyncConfig for a single repo folder.
+
+    Returns ``(project, project_name, config)`` on success, or ``None``
+    if a config already exists (``IntegrityError``).
+    """
+    folder_basename = github_folder.rsplit("/", 1)[-1] if "/" in github_folder else github_folder
+    project_name = folder_basename if folder_basename else github_repo_name
+
+    project, _graph_runner_id = create_project_with_graph_runner(
+        session=session,
+        organization_id=organization_id,
+        project_id=uuid4(),
+        project_name=project_name,
+        description=description,
+        project_type=project_type,
+        template=None,
+        graph_id=uuid4(),
+        add_input=True,
+        tags=["github"],
+    )
+
+    try:
+        config = git_sync_repository.create_git_sync_config(
+            session=session,
+            organization_id=organization_id,
+            project_id=project.id,
+            github_owner=github_owner,
+            github_repo_name=github_repo_name,
+            graph_folder=github_folder,
+            branch=branch,
+            github_installation_id=github_installation_id,
+            created_by_user_id=created_by_user_id,
+        )
+    except IntegrityError:
+        session.rollback()
+        LOGGER.warning(
+            "Sync config already exists for folder %r in %s/%s — skipping",
+            github_folder, github_owner, github_repo_name,
+        )
+        return None
+
+    return project, project_name, config
+
+
 async def _import_projects(
     session: Session,
     organization_id: UUID,
@@ -232,43 +288,25 @@ async def _import_projects(
             skipped.append(github_folder)
             continue
 
-        folder_basename = github_folder.rsplit("/", 1)[-1] if "/" in github_folder else github_folder
-        project_name = folder_basename if folder_basename else github_repo_name
-        project_id = uuid4()
-
-        project, _graph_runner_id = create_project_with_graph_runner(
+        result = _create_synced_project(
             session=session,
             organization_id=organization_id,
-            project_id=project_id,
-            project_name=project_name,
+            github_owner=github_owner,
+            github_repo_name=github_repo_name,
+            branch=branch,
+            github_installation_id=github_installation_id,
+            github_folder=github_folder,
+            project_type=project_type,
+            created_by_user_id=user_id,
             description=f"Imported from GitHub {github_repo} ({github_folder})"
             if github_folder
             else f"Imported from GitHub {github_repo}",
-            project_type=project_type,
-            template=None,
-            graph_id=uuid4(),
-            add_input=True,
-            tags=["github"],
         )
-
-        try:
-            config = git_sync_repository.create_git_sync_config(
-                session=session,
-                organization_id=organization_id,
-                project_id=project.id,
-                github_owner=github_owner,
-                github_repo_name=github_repo_name,
-                graph_folder=github_folder,
-                branch=branch,
-                github_installation_id=github_installation_id,
-                created_by_user_id=user_id,
-            )
-        except IntegrityError:
-            session.rollback()
-            LOGGER.warning("Sync config already exists for folder %r in %s — skipping", github_folder, github_repo)
+        if result is None:
             skipped.append(github_folder)
             continue
 
+        project, project_name, config = result
         await _enqueue_initial_sync(config)
 
         imported.append(
@@ -629,6 +667,81 @@ def _collect_changed_prompt_paths(changed_files: set[str]) -> set[str]:
     return result
 
 
+def _detect_new_project_folders(changed_files: set[str], existing_folders: set[str]) -> set[str]:
+    """Return project folder paths from *changed_files* that are not yet tracked.
+
+    Only folders where ``graph.json`` itself was added/modified are returned —
+    changes to other files under a new folder are not enough.
+    """
+    prefix = f"{PROJECTS_DIR}/"
+    new_folders: set[str] = set()
+    for path in changed_files:
+        if not path.startswith(prefix):
+            continue
+        rest = path[len(prefix):]
+        parts = rest.split("/", 1)
+        if len(parts) < 2:
+            continue
+        folder = f"{PROJECTS_DIR}/{parts[0]}"
+        if parts[1] == "graph.json" and folder not in existing_folders:
+            new_folders.add(folder)
+    return new_folders
+
+
+def _auto_import_new_projects(
+    session: Session,
+    github_owner: str,
+    github_repo_name: str,
+    branch: str,
+    github_installation_id: int,
+    organization_id: UUID,
+    created_by_user_id: UUID | None,
+    new_folders: set[str],
+    commit_sha: str,
+) -> tuple[int, int]:
+    """Create projects + sync configs for newly discovered folders and enqueue initial sync.
+
+    Returns ``(queued, failed)`` counts.
+    """
+    github_repo = f"{github_owner}/{github_repo_name}"
+    queued = 0
+    failed = 0
+
+    for folder in sorted(new_folders):
+        result = _create_synced_project(
+            session=session,
+            organization_id=organization_id,
+            github_owner=github_owner,
+            github_repo_name=github_repo_name,
+            branch=branch,
+            github_installation_id=github_installation_id,
+            github_folder=folder,
+            project_type=ProjectType.WORKFLOW,
+            created_by_user_id=created_by_user_id,
+            description=f"Auto-discovered from GitHub {github_repo} ({folder})",
+        )
+        if result is None:
+            continue
+
+        _project, _project_name, config = result
+        if push_git_sync_task(config.id, commit_sha):
+            queued += 1
+        else:
+            failed += 1
+            LOGGER.error("Failed to enqueue initial sync for auto-discovered config %s", config.id)
+
+    if queued or failed:
+        LOGGER.info(
+            "Auto-discovered %d new project folder(s) from push to %s (branch %s): %d queued, %d failed",
+            len(new_folders),
+            github_repo,
+            branch,
+            queued,
+            failed,
+        )
+    return queued, failed
+
+
 def handle_github_push(
     session: Session,
     github_owner: str,
@@ -640,7 +753,8 @@ def handle_github_push(
 ) -> tuple[int, int]:
     """Queue git sync tasks for configs whose tracked graph file changed in a push.
 
-    Also enqueues prompt sync tasks when files under ``draftnrun/prompts/`` changed.
+    Also enqueues prompt sync tasks when files under ``draftnrun/prompts/`` changed,
+    and auto-discovers new project folders that don't have a ``GitSyncConfig`` yet.
     """
     queued = 0
     failed = 0
@@ -707,6 +821,26 @@ def handle_github_push(
         else:
             failed += 1
             LOGGER.error("Failed to enqueue git sync task for config %s", config.id)
+
+    existing_folders = {c.graph_folder for c in configs}
+    new_folders = _detect_new_project_folders(changed_files, existing_folders)
+    if new_folders and github_installation_id is not None:
+        install_row = github_app_installation_repository.get_by_installation_id(session, github_installation_id)
+        if install_row:
+            created_by = next((c.created_by_user_id for c in configs if c.created_by_user_id), None)
+            disc_queued, disc_failed = _auto_import_new_projects(
+                session=session,
+                github_owner=github_owner,
+                github_repo_name=github_repo_name,
+                branch=branch,
+                github_installation_id=github_installation_id,
+                organization_id=install_row.organization_id,
+                created_by_user_id=created_by,
+                new_folders=new_folders,
+                commit_sha=commit_sha,
+            )
+            queued += disc_queued
+            failed += disc_failed
 
     return queued, failed
 

--- a/tests/ada_backend/services/test_git_sync_service.py
+++ b/tests/ada_backend/services/test_git_sync_service.py
@@ -16,6 +16,7 @@ from ada_backend.services.git_sync_service import (
     GitSyncError,
     GraphJsonNotFound,
     InstallationOwnershipError,
+    _detect_new_project_folders,
     disconnect_sync,
     ensure_installation_owned,
     handle_github_push,
@@ -1341,3 +1342,372 @@ class TestGitHubInstallState:
             mock_settings.BACKEND_SECRET_KEY = "test-secret-key"
             with pytest.raises(ValueError, match="expired"):
                 verify_install_state(state, org_id, user_id)
+
+
+class TestDetectNewProjectFolders:
+    def test_detects_new_graph_json(self):
+        changed = {"draftnrun/projects/new-agent/graph.json"}
+        existing: set[str] = set()
+        result = _detect_new_project_folders(changed, existing)
+        assert result == {"draftnrun/projects/new-agent"}
+
+    def test_ignores_non_graph_json_files(self):
+        changed = {
+            "draftnrun/projects/new-agent/start.json",
+            "draftnrun/projects/new-agent/llm.json",
+        }
+        result = _detect_new_project_folders(changed, set())
+        assert result == set()
+
+    def test_ignores_already_tracked_folders(self):
+        changed = {"draftnrun/projects/existing/graph.json"}
+        existing = {"draftnrun/projects/existing"}
+        result = _detect_new_project_folders(changed, existing)
+        assert result == set()
+
+    def test_ignores_unrelated_paths(self):
+        changed = {
+            "README.md",
+            "src/main.py",
+            "draftnrun/prompts/system.md",
+        }
+        result = _detect_new_project_folders(changed, set())
+        assert result == set()
+
+    def test_multiple_new_folders(self):
+        changed = {
+            "draftnrun/projects/agent-a/graph.json",
+            "draftnrun/projects/agent-b/graph.json",
+            "draftnrun/projects/agent-b/start.json",
+        }
+        result = _detect_new_project_folders(changed, set())
+        assert result == {"draftnrun/projects/agent-a", "draftnrun/projects/agent-b"}
+
+    def test_ignores_file_directly_under_projects_dir(self):
+        changed = {"draftnrun/projects/graph.json"}
+        result = _detect_new_project_folders(changed, set())
+        assert result == set()
+
+    def test_mixed_new_and_existing(self):
+        changed = {
+            "draftnrun/projects/old/graph.json",
+            "draftnrun/projects/new/graph.json",
+        }
+        existing = {"draftnrun/projects/old"}
+        result = _detect_new_project_folders(changed, existing)
+        assert result == {"draftnrun/projects/new"}
+
+
+class TestAutoDiscoveryOnPush:
+    def _make_config(self, org_id, folder, **kwargs):
+        defaults = dict(
+            id=uuid4(),
+            organization_id=org_id,
+            project_id=uuid4(),
+            github_owner="owner",
+            github_repo_name="repo",
+            github_repo="owner/repo",
+            graph_folder=folder,
+            branch="main",
+            github_installation_id=42,
+            created_by_user_id=uuid4(),
+        )
+        defaults.update(kwargs)
+        return SimpleNamespace(**defaults)
+
+    def test_auto_creates_project_for_new_folder(self):
+        session = MagicMock()
+        org_id = uuid4()
+        install_row = SimpleNamespace(organization_id=org_id)
+        new_project = SimpleNamespace(id=uuid4(), name="new-agent", organization_id=org_id)
+        new_config = self._make_config(org_id, "draftnrun/projects/new-agent")
+
+        with (
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.get_configs_by_repo_and_branch",
+                return_value=[],
+            ),
+            patch(
+                f"{PATCH_INSTALL_REPO}.get_by_installation_id",
+                return_value=install_row,
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.create_project_with_graph_runner",
+                return_value=(new_project, uuid4()),
+            ) as create_mock,
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.create_git_sync_config",
+                return_value=new_config,
+            ) as config_mock,
+            patch(
+                "ada_backend.services.git_sync_service.push_git_sync_task",
+                return_value=True,
+            ) as push_mock,
+        ):
+            queued, failed = handle_github_push(
+                session,
+                "owner",
+                "repo",
+                "main",
+                changed_files={"draftnrun/projects/new-agent/graph.json"},
+                commit_sha="abc123",
+                github_installation_id=42,
+            )
+
+        assert queued == 1
+        assert failed == 0
+        create_mock.assert_called_once()
+        assert create_mock.call_args.kwargs["tags"] == ["github"]
+        assert create_mock.call_args.kwargs["project_name"] == "new-agent"
+        config_mock.assert_called_once()
+        assert config_mock.call_args.kwargs["graph_folder"] == "draftnrun/projects/new-agent"
+        push_mock.assert_called_once_with(new_config.id, "abc123")
+
+    def test_skips_existing_tracked_folder(self):
+        session = MagicMock()
+        org_id = uuid4()
+        existing = self._make_config(org_id, "draftnrun/projects/existing")
+
+        with (
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.get_configs_by_repo_and_branch",
+                return_value=[existing],
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.push_git_sync_task",
+                return_value=True,
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.create_project_with_graph_runner",
+            ) as create_mock,
+        ):
+            queued, failed = handle_github_push(
+                session,
+                "owner",
+                "repo",
+                "main",
+                changed_files={
+                    "draftnrun/projects/existing/graph.json",
+                },
+                commit_sha="abc123",
+                github_installation_id=42,
+            )
+
+        assert queued == 1
+        assert failed == 0
+        create_mock.assert_not_called()
+
+    def test_no_auto_create_without_graph_json(self):
+        session = MagicMock()
+
+        with (
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.get_configs_by_repo_and_branch",
+                return_value=[],
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.create_project_with_graph_runner",
+            ) as create_mock,
+        ):
+            queued, failed = handle_github_push(
+                session,
+                "owner",
+                "repo",
+                "main",
+                changed_files={"draftnrun/projects/new-agent/start.json"},
+                commit_sha="abc123",
+                github_installation_id=42,
+            )
+
+        assert queued == 0
+        assert failed == 0
+        create_mock.assert_not_called()
+
+    def test_skips_when_no_installation_id(self):
+        session = MagicMock()
+
+        with (
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.get_configs_by_repo_and_branch",
+                return_value=[],
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.create_project_with_graph_runner",
+            ) as create_mock,
+        ):
+            queued, failed = handle_github_push(
+                session,
+                "owner",
+                "repo",
+                "main",
+                changed_files={"draftnrun/projects/new-agent/graph.json"},
+                commit_sha="abc123",
+                github_installation_id=None,
+            )
+
+        assert queued == 0
+        assert failed == 0
+        create_mock.assert_not_called()
+
+    def test_skips_when_installation_not_registered(self):
+        session = MagicMock()
+
+        with (
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.get_configs_by_repo_and_branch",
+                return_value=[],
+            ),
+            patch(
+                f"{PATCH_INSTALL_REPO}.get_by_installation_id",
+                return_value=None,
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.create_project_with_graph_runner",
+            ) as create_mock,
+        ):
+            queued, failed = handle_github_push(
+                session,
+                "owner",
+                "repo",
+                "main",
+                changed_files={"draftnrun/projects/new-agent/graph.json"},
+                commit_sha="abc123",
+                github_installation_id=42,
+            )
+
+        assert queued == 0
+        assert failed == 0
+        create_mock.assert_not_called()
+
+    def test_inherits_created_by_from_existing_config(self):
+        session = MagicMock()
+        org_id = uuid4()
+        user_id = uuid4()
+        existing = self._make_config(org_id, "draftnrun/projects/old", created_by_user_id=user_id)
+        install_row = SimpleNamespace(organization_id=org_id)
+        new_project = SimpleNamespace(id=uuid4(), name="new-agent", organization_id=org_id)
+        new_config = self._make_config(org_id, "draftnrun/projects/new-agent")
+
+        with (
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.get_configs_by_repo_and_branch",
+                return_value=[existing],
+            ),
+            patch(
+                f"{PATCH_INSTALL_REPO}.get_by_installation_id",
+                return_value=install_row,
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.create_project_with_graph_runner",
+                return_value=(new_project, uuid4()),
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.create_git_sync_config",
+                return_value=new_config,
+            ) as config_mock,
+            patch("ada_backend.services.git_sync_service.push_git_sync_task", return_value=True),
+        ):
+            handle_github_push(
+                session,
+                "owner",
+                "repo",
+                "main",
+                changed_files={"draftnrun/projects/new-agent/graph.json"},
+                commit_sha="abc123",
+                github_installation_id=42,
+            )
+
+        assert config_mock.call_args.kwargs["created_by_user_id"] == user_id
+
+    def test_integrity_error_on_config_skips_gracefully(self):
+        session = MagicMock()
+        org_id = uuid4()
+        install_row = SimpleNamespace(organization_id=org_id)
+        new_project = SimpleNamespace(id=uuid4(), name="new-agent", organization_id=org_id)
+
+        with (
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.get_configs_by_repo_and_branch",
+                return_value=[],
+            ),
+            patch(
+                f"{PATCH_INSTALL_REPO}.get_by_installation_id",
+                return_value=install_row,
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.create_project_with_graph_runner",
+                return_value=(new_project, uuid4()),
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.create_git_sync_config",
+                side_effect=IntegrityError("INSERT", {}, Exception("unique constraint")),
+            ),
+            patch("ada_backend.services.git_sync_service.push_git_sync_task") as push_mock,
+        ):
+            queued, failed = handle_github_push(
+                session,
+                "owner",
+                "repo",
+                "main",
+                changed_files={"draftnrun/projects/new-agent/graph.json"},
+                commit_sha="abc123",
+                github_installation_id=42,
+            )
+
+        assert queued == 0
+        assert failed == 0
+        push_mock.assert_not_called()
+        session.rollback.assert_called_once()
+
+    def test_multiple_new_folders_in_single_push(self):
+        session = MagicMock()
+        org_id = uuid4()
+        install_row = SimpleNamespace(organization_id=org_id)
+
+        project_a = SimpleNamespace(id=uuid4(), name="agent-a", organization_id=org_id)
+        project_b = SimpleNamespace(id=uuid4(), name="agent-b", organization_id=org_id)
+        config_a = self._make_config(org_id, "draftnrun/projects/agent-a")
+        config_b = self._make_config(org_id, "draftnrun/projects/agent-b")
+
+        with (
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.get_configs_by_repo_and_branch",
+                return_value=[],
+            ),
+            patch(
+                f"{PATCH_INSTALL_REPO}.get_by_installation_id",
+                return_value=install_row,
+            ),
+            patch(
+                "ada_backend.services.git_sync_service.create_project_with_graph_runner",
+                side_effect=[(project_a, uuid4()), (project_b, uuid4())],
+            ) as create_mock,
+            patch(
+                "ada_backend.services.git_sync_service.git_sync_repository.create_git_sync_config",
+                side_effect=[config_a, config_b],
+            ) as config_mock,
+            patch(
+                "ada_backend.services.git_sync_service.push_git_sync_task",
+                return_value=True,
+            ) as push_mock,
+        ):
+            queued, failed = handle_github_push(
+                session,
+                "owner",
+                "repo",
+                "main",
+                changed_files={
+                    "draftnrun/projects/agent-a/graph.json",
+                    "draftnrun/projects/agent-b/graph.json",
+                },
+                commit_sha="abc123",
+                github_installation_id=42,
+            )
+
+        assert queued == 2
+        assert failed == 0
+        assert create_mock.call_count == 2
+        assert config_mock.call_count == 2
+        assert push_mock.call_count == 2
+        push_mock.assert_any_call(config_a.id, "abc123")
+        push_mock.assert_any_call(config_b.id, "abc123")


### PR DESCRIPTION
# Summary
- When a GitHub push includes a new `graph.json` under `draftnrun/projects/<name>/`, automatically create the project + GitSyncConfig and enqueue the initial sync — no manual import step needed.
- Resolves the org via the registered GitHubAppInstallation; inherits `created_by_user_id` from an existing config in the same repo when available.
- Refactored `_import_projects` and the new auto-discovery path to share a single `_create_synced_project` helper, eliminating duplicated project+config creation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook-driven auto-discovery of newly added project folders on push, automatically creating projects, associated sync configs, and enqueueing initial syncs.
  * New projects inherit existing configuration fields (e.g., creator) when applicable.

* **Bug Fixes**
  * Handles conflicts during auto-import to avoid duplicate configs and rolls back partial changes.

* **Documentation**
  * Docs updated to describe the sync flow on push and auto-discovery behavior.

* **Tests**
  * Added tests for detection, auto-import, inheritance, and conflict/error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Scopeo/draftnrun/pull/721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->