### PR TITLE
feat(components): Add Outlook Calendar component dra-1296

### DIFF
--- a/ada_backend/database/seed/integrations/seed_mcp_outlook_calendar.py
+++ b/ada_backend/database/seed/integrations/seed_mcp_outlook_calendar.py
@@ -1,0 +1,81 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ada_backend.database import models as db
+from ada_backend.database.component_definition_seeding import (
+    upsert_component_categories,
+    upsert_component_versions,
+    upsert_components,
+    upsert_components_parameter_definitions,
+    upsert_release_stage_to_current_version_mapping,
+)
+from ada_backend.database.models import (
+    Component,
+    ComponentParameterDefinition,
+    ParameterType,
+    UIComponent,
+    UIComponentProperties,
+)
+from ada_backend.database.seed.seed_categories import CATEGORY_UUIDS
+from ada_backend.database.seed.seed_tool_description import TOOL_DESCRIPTION_UUIDS
+from ada_backend.database.seed.utils import COMPONENT_UUIDS, COMPONENT_VERSION_UUIDS
+from engine.integrations.providers import OAuthProvider
+
+
+def seed_mcp_outlook_calendar_components(session: Session):
+    outlook_calendar_mcp_tool_component = Component(
+        id=COMPONENT_UUIDS["outlook_calendar_mcp_tool"],
+        name="Outlook Calendar",
+        is_agent=True,
+        function_callable=True,
+        can_use_function_calling=False,
+        icon="vscode-icons:file-type-outlook",
+    )
+
+    upsert_components(session, [outlook_calendar_mcp_tool_component])
+
+    outlook_calendar_mcp_tool_version = db.ComponentVersion(
+        id=COMPONENT_VERSION_UUIDS["outlook_calendar_mcp_tool"],
+        component_id=COMPONENT_UUIDS["outlook_calendar_mcp_tool"],
+        version_tag="0.0.1",
+        release_stage=db.ReleaseStage.INTERNAL,
+        description="Connect to Outlook Calendar via MCP to list, create, update, and delete events.",
+        default_tool_description_id=TOOL_DESCRIPTION_UUIDS["outlook_calendar_mcp_tool_description"],
+    )
+
+    upsert_component_versions(session, [outlook_calendar_mcp_tool_version])
+
+    parameter_definitions = [
+        ComponentParameterDefinition(
+            id=UUID("0f8ec94f-3ac9-4b96-994a-1c9a0d9865f0"),
+            component_version_id=outlook_calendar_mcp_tool_version.id,
+            name="oauth_connection_id",
+            type=ParameterType.STRING,
+            nullable=True,
+            display_order=None,
+            parameter_order_within_group=0,
+            ui_component=UIComponent.OAUTH_CONNECTION,
+            ui_component_properties=UIComponentProperties(
+                label="Outlook Calendar Connection",
+                description="Select your authorized Outlook Calendar account connection",
+                provider=OAuthProvider.OUTLOOK_CALENDAR.value,
+                icon="vscode-icons:file-type-outlook",
+            ).model_dump(exclude_unset=True, exclude_none=True),
+        )
+    ]
+
+    upsert_components_parameter_definitions(session, parameter_definitions)
+
+    upsert_release_stage_to_current_version_mapping(
+        session=session,
+        component_id=outlook_calendar_mcp_tool_version.component_id,
+        release_stage=outlook_calendar_mcp_tool_version.release_stage,
+        component_version_id=outlook_calendar_mcp_tool_version.id,
+    )
+
+    upsert_component_categories(
+        session=session,
+        component_id=outlook_calendar_mcp_tool_component.id,
+        category_ids=[CATEGORY_UUIDS["integrations"], CATEGORY_UUIDS["information_retrieval"]],
+    )

--- a/ada_backend/database/seed/seed_tool_description.py
+++ b/ada_backend/database/seed/seed_tool_description.py
@@ -61,6 +61,7 @@ TOOL_DESCRIPTION_UUIDS = {
     "mail_sender_tool_description": UUID("7fe2178e-36c6-4195-aa5b-9a9178be70e8"),
     "default_sql_tool_description": UUID("7a2b3c4d-5e6f-4a8b-9c0d-1e2f3a4b5c6d"),
     "scorer_tool_description": UUID("8f9d4c3e-7a2b-4e1d-9c8f-5b6a3d2e1f0b"),
+    "outlook_calendar_mcp_tool_description": UUID("3b1d4b54-10ad-45d0-8051-7ad389b36378"),
 }
 
 
@@ -175,6 +176,10 @@ def seed_tool_description(session: Session):
         id=TOOL_DESCRIPTION_UUIDS["scorer_tool_description"],
         **DEFAULT_SCORER_TOOL_DESCRIPTION.model_dump(),
     )
+    outlook_calendar_mcp_tool_description = db.ToolDescription(
+        id=TOOL_DESCRIPTION_UUIDS["outlook_calendar_mcp_tool_description"],
+        **DEFAULT_MCP_TOOL_DESCRIPTION.model_dump(),
+    )
     upsert_tool_descriptions(
         session=session,
         tool_descriptions=[
@@ -207,5 +212,6 @@ def seed_tool_description(session: Session):
             mail_sender_tool_description,
             default_sql_tool_description,
             scorer_tool_description,
+            outlook_calendar_mcp_tool_description,
         ],
     )

--- a/ada_backend/database/seed/utils.py
+++ b/ada_backend/database/seed/utils.py
@@ -67,6 +67,7 @@ COMPONENT_UUIDS: dict[str, UUID] = {
     "outlook_sender": UUID("62979492-b4ef-4cfe-96f1-67a960a1e8d4"),
     "mail_sender": UUID("83c061db-1506-4636-95d1-9254ee23283e"),
     "scorer": UUID("f1a2b3c4-d5e6-7890-abcd-ef1234567891"),
+    "outlook_calendar_mcp_tool": UUID("b36d6f8f-f5f1-4533-b353-fda582add009"),
 }
 COMPONENT_VERSION_UUIDS: dict[str, UUID] = {
     "synthesizer": UUID("6f790dd1-06f6-4489-a655-1a618763a114"),
@@ -123,6 +124,7 @@ COMPONENT_VERSION_UUIDS: dict[str, UUID] = {
     "outlook_sender": UUID("6e3b9e9b-ab98-4189-88b7-41b8bf2aa07c"),
     "mail_sender": UUID("ced15521-e358-4b57-a9ac-47672dd1657b"),
     "scorer": UUID("f1a2b3c4-d5e6-7890-abcd-ef1234567892"),
+    "outlook_calendar_mcp_tool": UUID("3585dacd-2088-4069-99c8-40049026d4ac"),
 }
 
 DEFAULT_MODEL_WEB_SEARCH = "openai:gpt-5-mini"

--- a/ada_backend/database/seed_db.py
+++ b/ada_backend/database/seed_db.py
@@ -21,6 +21,7 @@ from ada_backend.database.seed.integrations.seed_mail_sender import (
 from ada_backend.database.seed.integrations.seed_mcp_google_calendar import seed_mcp_google_calendar_components
 from ada_backend.database.seed.integrations.seed_mcp_hubspot import seed_mcp_hubspot_components
 from ada_backend.database.seed.integrations.seed_mcp_hubspot_neverdrop import seed_mcp_hubspot_neverdrop_components
+from ada_backend.database.seed.integrations.seed_mcp_outlook_calendar import seed_mcp_outlook_calendar_components
 from ada_backend.database.seed.integrations.seed_outlook import seed_outlook_components, seed_outlook_parameter_groups
 from ada_backend.database.seed.integrations.seed_slack import seed_slack_components
 from ada_backend.database.seed.seed_ai_agent import seed_ai_agent_components, seed_ai_agent_parameter_groups
@@ -144,6 +145,7 @@ def seed_db(session: Session):
 
         seed_mcp_hubspot_neverdrop_components(session)
         seed_mcp_google_calendar_components(session)
+        seed_mcp_outlook_calendar_components(session)
         session.commit()
 
         seed_outlook_components(session)

--- a/ada_backend/services/entity_factory.py
+++ b/ada_backend/services/entity_factory.py
@@ -313,6 +313,7 @@ class OAuthComponentFactory:
             Instantiated component with resolved OAuth token (access_token may be None;
             component raises at run time if a connection is required but not configured).
         """
+        resolved_tokens: dict[str, SecretStr | None] = {}
         for binding in self.oauth_bindings:
             # TODO: DB column is still named "oauth_connection_id" but stores OrgVariableDefinition.id
             #       after migration d4e5f6a7b8c9 — rename column to oauth_definition_id
@@ -320,12 +321,14 @@ class OAuthComponentFactory:
             if isinstance(definition_id, list):
                 definition_id = definition_id[0] if definition_id else None
             access_token = await resolve_oauth_access_token(definition_id, str(binding.provider_config_key))
-            # may be None; component raises at run if required
-            kwargs[binding.target_param_name] = SecretStr(access_token) if access_token is not None else None
+            resolved_tokens[binding.target_param_name] = SecretStr(access_token) if access_token is not None else None
 
         for processor in self.parameter_processors:
             kwargs = processor(kwargs, self.constructor_params)
         kwargs = unwrap_secrets(kwargs)
+
+        for key, secret in resolved_tokens.items():
+            kwargs[key] = secret
 
         if self.constructor_method == "__init__":
             return self.entity_class(**kwargs)

--- a/ada_backend/services/registry.py
+++ b/ada_backend/services/registry.py
@@ -67,6 +67,7 @@ from engine.components.tools.docx_template import DocxTemplateAgent
 from engine.components.tools.google_calendar_mcp_tool import GoogleCalendarMCPTool
 from engine.components.tools.hubspot_mcp_tool import HubSpotMCPTool
 from engine.components.tools.linkup_tool import LinkupSearchTool
+from engine.components.tools.outlook_calendar_mcp_tool import OutlookCalendarMCPTool
 from engine.components.tools.python_code_runner import PythonCodeRunner
 from engine.components.tools.terminal_command_runner import TerminalCommandRunner
 from engine.components.web_search_tool_openai import WebSearchOpenAITool
@@ -627,6 +628,16 @@ def create_factory_registry() -> FactoryRegistry:
         factory=OAuthComponentFactory(
             entity_class=GoogleCalendarMCPTool,
             oauth_bindings=[OAuthBinding(provider_config_key=OAuthProvider.GOOGLE_CALENDAR)],
+            constructor_method="from_access_token",
+            parameter_processors=[build_ignore_tool_description_processor()],
+        ),
+    )
+
+    registry.register(
+        component_version_id=COMPONENT_VERSION_UUIDS["outlook_calendar_mcp_tool"],
+        factory=OAuthComponentFactory(
+            entity_class=OutlookCalendarMCPTool,
+            oauth_bindings=[OAuthBinding(provider_config_key=OAuthProvider.OUTLOOK_CALENDAR)],
             constructor_method="from_access_token",
             parameter_processors=[build_ignore_tool_description_processor()],
         ),

--- a/engine/components/tools/google_calendar_mcp/server.py
+++ b/engine/components/tools/google_calendar_mcp/server.py
@@ -8,7 +8,9 @@ Expects GOOGLE_CALENDAR_ACCESS_TOKEN in the environment.
 """
 
 import warnings
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
+
+from pydantic import Field
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
@@ -42,7 +44,7 @@ async def calendar_list_events(
     calendar_id: str = "primary",
     time_min: Optional[str] = None,
     time_max: Optional[str] = None,
-    max_results: int = 50,
+    max_results: Annotated[int, Field(ge=1, le=1000)] = 50,
     query: Optional[str] = None,
 ) -> list[dict[str, Any]]:
     return await _client.list_events(

--- a/engine/components/tools/google_calendar_mcp_tool.py
+++ b/engine/components/tools/google_calendar_mcp_tool.py
@@ -5,6 +5,8 @@ Google Calendar MCP Tool — wraps the internal FastMCP server via stdio.
 import sys
 from typing import Optional, Self
 
+from pydantic import SecretStr
+
 from engine.components.tools.google_calendar_mcp.server import get_tool_descriptions
 from engine.components.tools.mcp.local_mcp_tool import LocalMCPTool
 from engine.components.tools.mcp.shared import MCPToolInputs, MCPToolOutputs
@@ -30,7 +32,7 @@ class GoogleCalendarMCPTool(LocalMCPTool):
         cls,
         trace_manager: TraceManager,
         component_attributes: ComponentAttributes,
-        access_token: Optional[str] = None,
+        access_token: Optional[SecretStr] = None,
         allowed_tools: set[str] | None = None,
         timeout: int = 30,
     ) -> Self:
@@ -42,7 +44,9 @@ class GoogleCalendarMCPTool(LocalMCPTool):
             component_attributes=component_attributes,
             command=sys.executable,
             args=["-m", "engine.components.tools.google_calendar_mcp.server"],
-            env={"GOOGLE_CALENDAR_ACCESS_TOKEN": access_token} if access_token else None,
+            env={"GOOGLE_CALENDAR_ACCESS_TOKEN": access_token.get_secret_value()}
+            if access_token is not None
+            else None,
             timeout=timeout,
             tool_descriptions=tool_descriptions,
         )

--- a/engine/components/tools/hubspot_mcp_tool.py
+++ b/engine/components/tools/hubspot_mcp_tool.py
@@ -6,6 +6,8 @@ import sys
 from collections.abc import Collection
 from typing import Optional, Self
 
+from pydantic import SecretStr
+
 from engine.components.tools.hubspot_mcp.server import get_tool_descriptions
 from engine.components.tools.mcp.local_mcp_tool import LocalMCPTool
 from engine.components.tools.mcp.shared import MCPToolInputs, MCPToolOutputs
@@ -51,7 +53,7 @@ class HubSpotMCPTool(LocalMCPTool):
         cls,
         trace_manager: TraceManager,
         component_attributes: ComponentAttributes,
-        access_token: str,
+        access_token: Optional[SecretStr] = None,
         allowed_tools: Collection[str] | None = None,
         timeout: int = 30,
     ) -> Self:
@@ -63,7 +65,7 @@ class HubSpotMCPTool(LocalMCPTool):
             component_attributes=component_attributes,
             command=sys.executable,
             args=["-m", "engine.components.tools.hubspot_mcp.server"],
-            env={"HUBSPOT_ACCESS_TOKEN": access_token} if access_token else None,
+            env={"HUBSPOT_ACCESS_TOKEN": access_token.get_secret_value()} if access_token is not None else None,
             timeout=timeout,
             tool_descriptions=tool_descriptions,
         )

--- a/engine/components/tools/mcp/shared.py
+++ b/engine/components/tools/mcp/shared.py
@@ -73,35 +73,32 @@ def process_mcp_result(result) -> tuple[str, list[Any], bool]:
     """
     Process MCP call_tool result into standard output format.
 
+    Handles both legacy ``content`` (list of TextContent) and newer
+    ``structuredContent`` (dict payload from FastMCP / MCP SDK ≥ 2025-03)
+    so that tool output is never silently dropped.
+
     Args:
         result: MCP SDK call_tool result object
 
     Returns:
         tuple: (output_string, content_items, is_error)
     """
-    LOGGER.info("process_mcp_result: result type=%s", type(result).__name__)
-    raw_content = getattr(result, "content", [])
-    LOGGER.info("process_mcp_result: raw content=%s (type=%s)", raw_content, type(raw_content).__name__)
-    content_items = list(raw_content or [])
-    LOGGER.info("process_mcp_result: %d content items", len(content_items))
-    for i, item in enumerate(content_items):
-        LOGGER.info(
-            "process_mcp_result: item[%d] type=%s has_text=%s text_preview=%s",
-            i, type(item).__name__, hasattr(item, "text"),
-            repr(getattr(item, "text", None)[:200]) if getattr(item, "text", None) else None,
-        )
-    content_parts = [item.text for item in content_items if getattr(item, "text", None) is not None]
     is_error = bool(getattr(result, "isError", False))
+    content_items = list(getattr(result, "content", []) or [])
+    content_parts = [item.text for item in content_items if getattr(item, "text", None) is not None]
 
     if content_parts:
-        output = "\n".join(content_parts)
-    elif is_error:
+        return "\n".join(content_parts), content_items, is_error
+
+    structured = getattr(result, "structuredContent", None)
+    if structured is not None:
+        output = json.dumps(structured) if not isinstance(structured, str) else structured
+        return output, content_items, is_error
+
+    if is_error:
         output = json.dumps({"result": "error", "message": "MCP tool call failed with no output."})
     else:
-        LOGGER.warning(
-            "process_mcp_result: no content parts found, returning generic success. "
-            "result attrs=%s", [a for a in dir(result) if not a.startswith("_")],
-        )
+        LOGGER.warning("process_mcp_result: no content or structuredContent found on %s", type(result).__name__)
         output = json.dumps({"result": "success"})
 
     return output, content_items, is_error
@@ -170,8 +167,6 @@ async def execute_mcp_tool_call(
     if inputs.model_extra:
         arguments.update(inputs.model_extra)
 
-    LOGGER.info("execute_mcp_tool_call: tool=%s arguments=%s", tool_name, arguments)
-
     span = get_current_span()
     # TODO(security): redact_sensitive is a best-effort heuristic (match by key-name substring)
     # used here because MCP tool arguments are user/LLM-supplied and cannot be typed as SecretStr.
@@ -182,7 +177,6 @@ async def execute_mcp_tool_call(
         SpanAttributes.TOOL_PARAMETERS: serialize_to_json(redacted_arguments),
     })
     result = await call_tool_fn(tool_name, arguments)
-    LOGGER.info("execute_mcp_tool_call: raw result type=%s", type(result).__name__)
 
     output, content_items, is_error = process_mcp_result(result)
 

--- a/engine/components/tools/mcp/shared.py
+++ b/engine/components/tools/mcp/shared.py
@@ -1,6 +1,7 @@
 """Shared utilities for MCP tools (Local and Remote)."""
 
 import json
+import logging
 from typing import Any, Callable
 
 from openinference.semconv.trace import SpanAttributes
@@ -11,6 +12,8 @@ from ada_backend.database.models import ParameterType, UIComponent
 from engine.components.types import ToolDescription
 from engine.trace.serializer import serialize_to_json
 from shared.log_redaction import redact_sensitive
+
+LOGGER = logging.getLogger(__name__)
 
 DEFAULT_MCP_TOOL_DESCRIPTION = ToolDescription(
     name="mcp_tool",
@@ -76,7 +79,17 @@ def process_mcp_result(result) -> tuple[str, list[Any], bool]:
     Returns:
         tuple: (output_string, content_items, is_error)
     """
-    content_items = list(getattr(result, "content", []) or [])
+    LOGGER.info("process_mcp_result: result type=%s", type(result).__name__)
+    raw_content = getattr(result, "content", [])
+    LOGGER.info("process_mcp_result: raw content=%s (type=%s)", raw_content, type(raw_content).__name__)
+    content_items = list(raw_content or [])
+    LOGGER.info("process_mcp_result: %d content items", len(content_items))
+    for i, item in enumerate(content_items):
+        LOGGER.info(
+            "process_mcp_result: item[%d] type=%s has_text=%s text_preview=%s",
+            i, type(item).__name__, hasattr(item, "text"),
+            repr(getattr(item, "text", None)[:200]) if getattr(item, "text", None) else None,
+        )
     content_parts = [item.text for item in content_items if getattr(item, "text", None) is not None]
     is_error = bool(getattr(result, "isError", False))
 
@@ -85,6 +98,10 @@ def process_mcp_result(result) -> tuple[str, list[Any], bool]:
     elif is_error:
         output = json.dumps({"result": "error", "message": "MCP tool call failed with no output."})
     else:
+        LOGGER.warning(
+            "process_mcp_result: no content parts found, returning generic success. "
+            "result attrs=%s", [a for a in dir(result) if not a.startswith("_")],
+        )
         output = json.dumps({"result": "success"})
 
     return output, content_items, is_error
@@ -153,6 +170,8 @@ async def execute_mcp_tool_call(
     if inputs.model_extra:
         arguments.update(inputs.model_extra)
 
+    LOGGER.info("execute_mcp_tool_call: tool=%s arguments=%s", tool_name, arguments)
+
     span = get_current_span()
     # TODO(security): redact_sensitive is a best-effort heuristic (match by key-name substring)
     # used here because MCP tool arguments are user/LLM-supplied and cannot be typed as SecretStr.
@@ -163,6 +182,7 @@ async def execute_mcp_tool_call(
         SpanAttributes.TOOL_PARAMETERS: serialize_to_json(redacted_arguments),
     })
     result = await call_tool_fn(tool_name, arguments)
+    LOGGER.info("execute_mcp_tool_call: raw result type=%s", type(result).__name__)
 
     output, content_items, is_error = process_mcp_result(result)
 

--- a/engine/components/tools/outlook_calendar_mcp/client.py
+++ b/engine/components/tools/outlook_calendar_mcp/client.py
@@ -8,11 +8,13 @@ import anything from ada_backend/ — the subprocess runs with a minimal
 environment and ada_backend.database.models would crash on missing FERNET_KEY.
 """
 
+import logging
 from typing import Any, Optional
 
 import httpx
 
 GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
+LOGGER = logging.getLogger(__name__)
 
 
 class OutlookCalendarClient:
@@ -21,6 +23,7 @@ class OutlookCalendarClient:
             raise ValueError("access_token is required")
         self._access_token = access_token
         self._user_email: str | None = None
+        self._default_calendar_id: str | None = None
 
     def _headers(self) -> dict[str, str]:
         return {
@@ -37,15 +40,18 @@ class OutlookCalendarClient:
         json_body: dict[str, Any] | None = None,
         timeout: float = 30.0,
     ) -> httpx.Response:
+        url = f"{GRAPH_API_BASE}{path}"
+        LOGGER.info("HTTP %s %s params=%s", method, url, params)
         async with httpx.AsyncClient() as client:
             response = await client.request(
                 method,
-                f"{GRAPH_API_BASE}{path}",
+                url,
                 headers=self._headers(),
                 params=params,
                 json=json_body,
                 timeout=timeout,
             )
+        LOGGER.info("HTTP %s %s -> %d (%d bytes)", method, url, response.status_code, len(response.content))
         response.raise_for_status()
         return response
 
@@ -62,10 +68,16 @@ class OutlookCalendarClient:
         resp = await self._request("GET", "/me/calendars", params={"$top": "100"})
         return resp.json().get("value", [])
 
-    def _calendar_prefix(self, calendar_id: str) -> str:
-        if calendar_id == "primary":
-            return "/me"
-        return f"/me/calendars/{calendar_id}"
+    async def _resolve_calendar_id(self, calendar_id: str) -> str:
+        if calendar_id != "primary":
+            return calendar_id
+        if self._default_calendar_id is None:
+            LOGGER.info("Resolving default calendar ID via /me/calendar")
+            resp = await self._request("GET", "/me/calendar", params={"$select": "id,name"})
+            data = resp.json()
+            self._default_calendar_id = data["id"]
+            LOGGER.info("Default calendar: id=%s name=%s", data["id"], data.get("name"))
+        return self._default_calendar_id
 
     async def list_events(
         self,
@@ -75,7 +87,9 @@ class OutlookCalendarClient:
         max_results: int = 50,
         query: Optional[str] = None,
     ) -> list[dict[str, Any]]:
-        prefix = self._calendar_prefix(calendar_id)
+        resolved_id = await self._resolve_calendar_id(calendar_id)
+        LOGGER.info("list_events: resolved calendar_id=%s -> %s", calendar_id, resolved_id)
+        prefix = f"/me/calendars/{resolved_id}"
         if time_min and time_max:
             path = f"{prefix}/calendarView"
             params: dict[str, Any] = {
@@ -111,8 +125,9 @@ class OutlookCalendarClient:
     async def create_event(
         self, event_body: dict[str, Any], calendar_id: str = "primary"
     ) -> dict[str, Any]:
-        prefix = self._calendar_prefix(calendar_id)
-        resp = await self._request("POST", f"{prefix}/events", json_body=event_body)
+        resolved_id = await self._resolve_calendar_id(calendar_id)
+        LOGGER.info("create_event: resolved calendar_id=%s -> %s", calendar_id, resolved_id)
+        resp = await self._request("POST", f"/me/calendars/{resolved_id}/events", json_body=event_body)
         return resp.json()
 
     async def update_event(self, event_id: str, event_body: dict[str, Any]) -> dict[str, Any]:

--- a/engine/components/tools/outlook_calendar_mcp/client.py
+++ b/engine/components/tools/outlook_calendar_mcp/client.py
@@ -62,6 +62,11 @@ class OutlookCalendarClient:
         resp = await self._request("GET", "/me/calendars", params={"$top": "100"})
         return resp.json().get("value", [])
 
+    def _calendar_prefix(self, calendar_id: str) -> str:
+        if calendar_id == "primary":
+            return "/me"
+        return f"/me/calendars/{calendar_id}"
+
     async def list_events(
         self,
         calendar_id: str = "primary",
@@ -70,8 +75,9 @@ class OutlookCalendarClient:
         max_results: int = 50,
         query: Optional[str] = None,
     ) -> list[dict[str, Any]]:
+        prefix = self._calendar_prefix(calendar_id)
         if time_min and time_max:
-            path = f"/me/calendars/{calendar_id}/calendarView"
+            path = f"{prefix}/calendarView"
             params: dict[str, Any] = {
                 "startDateTime": time_min,
                 "endDateTime": time_max,
@@ -79,7 +85,7 @@ class OutlookCalendarClient:
                 "$orderby": "start/dateTime",
             }
         else:
-            path = f"/me/calendars/{calendar_id}/events"
+            path = f"{prefix}/events"
             params = {
                 "$top": str(max_results),
                 "$orderby": "start/dateTime",
@@ -105,7 +111,8 @@ class OutlookCalendarClient:
     async def create_event(
         self, event_body: dict[str, Any], calendar_id: str = "primary"
     ) -> dict[str, Any]:
-        resp = await self._request("POST", f"/me/calendars/{calendar_id}/events", json_body=event_body)
+        prefix = self._calendar_prefix(calendar_id)
+        resp = await self._request("POST", f"{prefix}/events", json_body=event_body)
         return resp.json()
 
     async def update_event(self, event_id: str, event_body: dict[str, Any]) -> dict[str, Any]:

--- a/engine/components/tools/outlook_calendar_mcp/client.py
+++ b/engine/components/tools/outlook_calendar_mcp/client.py
@@ -10,6 +10,7 @@ environment and ada_backend.database.models would crash on missing FERNET_KEY.
 
 import logging
 from typing import Any, Optional
+from urllib.parse import quote
 
 import httpx
 
@@ -89,7 +90,8 @@ class OutlookCalendarClient:
     ) -> list[dict[str, Any]]:
         resolved_id = await self._resolve_calendar_id(calendar_id)
         LOGGER.info("list_events: resolved calendar_id=%s -> %s", calendar_id, resolved_id)
-        prefix = f"/me/calendars/{resolved_id}"
+        safe_cal_id = quote(resolved_id, safe="")
+        prefix = f"/me/calendars/{safe_cal_id}"
         if time_min and time_max:
             path = f"{prefix}/calendarView"
             params: dict[str, Any] = {
@@ -119,7 +121,7 @@ class OutlookCalendarClient:
         return resp.json().get("value", [])
 
     async def get_event(self, event_id: str) -> dict[str, Any]:
-        resp = await self._request("GET", f"/me/events/{event_id}")
+        resp = await self._request("GET", f"/me/events/{quote(event_id, safe='')}")
         return resp.json()
 
     async def create_event(
@@ -127,13 +129,14 @@ class OutlookCalendarClient:
     ) -> dict[str, Any]:
         resolved_id = await self._resolve_calendar_id(calendar_id)
         LOGGER.info("create_event: resolved calendar_id=%s -> %s", calendar_id, resolved_id)
-        resp = await self._request("POST", f"/me/calendars/{resolved_id}/events", json_body=event_body)
+        safe_cal_id = quote(resolved_id, safe="")
+        resp = await self._request("POST", f"/me/calendars/{safe_cal_id}/events", json_body=event_body)
         return resp.json()
 
     async def update_event(self, event_id: str, event_body: dict[str, Any]) -> dict[str, Any]:
-        resp = await self._request("PATCH", f"/me/events/{event_id}", json_body=event_body)
+        resp = await self._request("PATCH", f"/me/events/{quote(event_id, safe='')}", json_body=event_body)
         return resp.json()
 
     async def delete_event(self, event_id: str) -> dict[str, Any]:
-        await self._request("DELETE", f"/me/events/{event_id}")
+        await self._request("DELETE", f"/me/events/{quote(event_id, safe='')}")
         return {"status": "deleted", "eventId": event_id}

--- a/engine/components/tools/outlook_calendar_mcp/client.py
+++ b/engine/components/tools/outlook_calendar_mcp/client.py
@@ -1,0 +1,117 @@
+"""
+Thin async client for the Microsoft Graph Calendar API.
+
+Uses httpx for all HTTP calls wrapped in asyncio-friendly patterns.
+
+This module is imported by the MCP stdio subprocess (server.py), so it must NOT
+import anything from ada_backend/ — the subprocess runs with a minimal
+environment and ada_backend.database.models would crash on missing FERNET_KEY.
+"""
+
+from typing import Any, Optional
+
+import httpx
+
+GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
+
+
+class OutlookCalendarClient:
+    def __init__(self, access_token: str) -> None:
+        if not access_token:
+            raise ValueError("access_token is required")
+        self._access_token = access_token
+        self._user_email: str | None = None
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+        }
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        timeout: float = 30.0,
+    ) -> httpx.Response:
+        async with httpx.AsyncClient() as client:
+            response = await client.request(
+                method,
+                f"{GRAPH_API_BASE}{path}",
+                headers=self._headers(),
+                params=params,
+                json=json_body,
+                timeout=timeout,
+            )
+        response.raise_for_status()
+        return response
+
+    async def get_user_email(self) -> str:
+        if self._user_email is None:
+            resp = await self._request("GET", "/me", params={"$select": "mail,userPrincipalName"})
+            data = resp.json()
+            self._user_email = data.get("mail") or data.get("userPrincipalName")
+            if not self._user_email:
+                raise RuntimeError("Could not determine Outlook user email address")
+        return self._user_email
+
+    async def list_calendars(self) -> list[dict[str, Any]]:
+        resp = await self._request("GET", "/me/calendars", params={"$top": "100"})
+        return resp.json().get("value", [])
+
+    async def list_events(
+        self,
+        calendar_id: str = "primary",
+        time_min: Optional[str] = None,
+        time_max: Optional[str] = None,
+        max_results: int = 50,
+        query: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        if time_min and time_max:
+            path = f"/me/calendars/{calendar_id}/calendarView"
+            params: dict[str, Any] = {
+                "startDateTime": time_min,
+                "endDateTime": time_max,
+                "$top": str(max_results),
+                "$orderby": "start/dateTime",
+            }
+        else:
+            path = f"/me/calendars/{calendar_id}/events"
+            params = {
+                "$top": str(max_results),
+                "$orderby": "start/dateTime",
+            }
+            filters: list[str] = []
+            if time_min:
+                filters.append(f"start/dateTime ge '{time_min}'")
+            if time_max:
+                filters.append(f"start/dateTime le '{time_max}'")
+            if filters:
+                params["$filter"] = " and ".join(filters)
+
+        if query:
+            params["$search"] = f'"{query}"'
+
+        resp = await self._request("GET", path, params=params)
+        return resp.json().get("value", [])
+
+    async def get_event(self, event_id: str) -> dict[str, Any]:
+        resp = await self._request("GET", f"/me/events/{event_id}")
+        return resp.json()
+
+    async def create_event(
+        self, event_body: dict[str, Any], calendar_id: str = "primary"
+    ) -> dict[str, Any]:
+        resp = await self._request("POST", f"/me/calendars/{calendar_id}/events", json_body=event_body)
+        return resp.json()
+
+    async def update_event(self, event_id: str, event_body: dict[str, Any]) -> dict[str, Any]:
+        resp = await self._request("PATCH", f"/me/events/{event_id}", json_body=event_body)
+        return resp.json()
+
+    async def delete_event(self, event_id: str) -> dict[str, Any]:
+        await self._request("DELETE", f"/me/events/{event_id}")
+        return {"status": "deleted", "eventId": event_id}

--- a/engine/components/tools/outlook_calendar_mcp/schema.py
+++ b/engine/components/tools/outlook_calendar_mcp/schema.py
@@ -1,0 +1,77 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class EmailAddress(BaseModel):
+    address: str = Field(description="Email address of the attendee.")
+    name: Optional[str] = Field(default=None, description="Display name of the attendee.")
+
+
+class EventAttendee(BaseModel):
+    emailAddress: EmailAddress
+    type: Optional[str] = Field(
+        default="required",
+        description="One of: required, optional, resource.",
+    )
+
+
+class EventDateTime(BaseModel):
+    dateTime: str = Field(
+        description="ISO 8601 datetime string WITHOUT timezone offset, e.g. '2026-03-20T10:00:00.0000000'.",
+    )
+    timeZone: str = Field(
+        default="UTC",
+        description="IANA time zone, e.g. 'Europe/Paris' or 'UTC'.",
+    )
+
+
+class ItemBody(BaseModel):
+    contentType: str = Field(
+        default="text",
+        description="Content type: 'text' or 'html'.",
+    )
+    content: str = Field(default="", description="Body content of the event.")
+
+
+class Location(BaseModel):
+    displayName: Optional[str] = Field(default=None, description="Display name of the location.")
+
+
+class PatternedRecurrence(BaseModel):
+    pattern: dict = Field(description="Recurrence pattern (type, interval, daysOfWeek, etc.).")
+    range: dict = Field(description="Recurrence range (type, startDate, endDate, etc.).")
+
+
+class EventBody(BaseModel):
+    """Body for creating or updating an Outlook Calendar event via MS Graph API."""
+
+    subject: Optional[str] = Field(default=None, description="Title of the event.")
+    body: Optional[ItemBody] = Field(default=None, description="Body/notes for the event.")
+    start: Optional[EventDateTime] = None
+    end: Optional[EventDateTime] = None
+    location: Optional[Location] = None
+    attendees: Optional[list[EventAttendee]] = None
+    isOnlineMeeting: Optional[bool] = Field(
+        default=None,
+        description="Set to true to create a Teams meeting link.",
+    )
+    onlineMeetingProvider: Optional[str] = Field(
+        default=None,
+        description="Online meeting provider, e.g. 'teamsForBusiness'.",
+    )
+    isAllDay: Optional[bool] = Field(default=None, description="Whether this is an all-day event.")
+    recurrence: Optional[PatternedRecurrence] = None
+    showAs: Optional[str] = Field(
+        default=None,
+        description="Free/busy status: 'free', 'tentative', 'busy', 'oof', 'workingElsewhere', 'unknown'.",
+    )
+    importance: Optional[str] = Field(
+        default=None,
+        description="Importance: 'low', 'normal', 'high'.",
+    )
+    isReminderOn: Optional[bool] = Field(default=None, description="Whether a reminder is set.")
+    reminderMinutesBeforeStart: Optional[int] = Field(
+        default=None,
+        description="Minutes before event start to trigger the reminder.",
+    )

--- a/engine/components/tools/outlook_calendar_mcp/server.py
+++ b/engine/components/tools/outlook_calendar_mcp/server.py
@@ -7,9 +7,10 @@ Run:
 Expects OUTLOOK_CALENDAR_ACCESS_TOKEN in the environment.
 """
 
-import logging
 import warnings
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
+
+from pydantic import Field
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
@@ -20,9 +21,6 @@ from engine.components.tools.outlook_calendar_mcp.schema import EventBody
 from engine.components.types import ToolDescription
 from engine.llm_services.utils import resolve_schema_refs
 
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
-LOGGER = logging.getLogger(__name__)
-
 mcp = FastMCP("outlook-calendar")
 _client: OutlookCalendarClient
 
@@ -32,10 +30,7 @@ _client: OutlookCalendarClient
     description="List all calendars accessible to the authenticated user.",
 )
 async def outlook_calendar_list_calendars() -> list[dict[str, Any]]:
-    LOGGER.info("outlook_calendar_list_calendars called")
-    result = await _client.list_calendars()
-    LOGGER.info("outlook_calendar_list_calendars returned %d calendars", len(result))
-    return result
+    return await _client.list_calendars()
 
 
 @mcp.tool(
@@ -50,22 +45,16 @@ async def outlook_calendar_list_events(
     calendar_id: str = "primary",
     time_min: Optional[str] = None,
     time_max: Optional[str] = None,
-    max_results: int = 50,
+    max_results: Annotated[int, Field(ge=1, le=1000)] = 50,
     query: Optional[str] = None,
 ) -> list[dict[str, Any]]:
-    LOGGER.info(
-        "outlook_calendar_list_events called: calendar_id=%s, time_min=%s, time_max=%s, max_results=%d, query=%s",
-        calendar_id, time_min, time_max, max_results, query,
-    )
-    result = await _client.list_events(
+    return await _client.list_events(
         calendar_id=calendar_id,
         time_min=time_min,
         time_max=time_max,
         max_results=max_results,
         query=query,
     )
-    LOGGER.info("outlook_calendar_list_events returned %d events", len(result))
-    return result
 
 
 @mcp.tool(
@@ -73,7 +62,6 @@ async def outlook_calendar_list_events(
     description="Get a single event by its ID.",
 )
 async def outlook_calendar_get_event(event_id: str) -> dict[str, Any]:
-    LOGGER.info("outlook_calendar_get_event called: event_id=%s", event_id)
     return await _client.get_event(event_id=event_id)
 
 
@@ -82,9 +70,7 @@ async def outlook_calendar_get_event(event_id: str) -> dict[str, Any]:
     description="Return the email address of the authenticated calendar owner.",
 )
 async def outlook_calendar_get_my_email() -> dict[str, str]:
-    LOGGER.info("outlook_calendar_get_my_email called")
     email = await _client.get_user_email()
-    LOGGER.info("outlook_calendar_get_my_email returned: %s", email)
     return {"email": email}
 
 
@@ -103,7 +89,6 @@ async def outlook_calendar_create_event(
     event: EventBody,
     calendar_id: str = "primary",
 ) -> dict[str, Any]:
-    LOGGER.info("outlook_calendar_create_event called: calendar_id=%s, event=%s", calendar_id, event)
     body = event.model_dump(exclude_none=True)
     return await _client.create_event(event_body=body, calendar_id=calendar_id)
 
@@ -119,7 +104,6 @@ async def outlook_calendar_update_event(
     event_id: str,
     event: EventBody,
 ) -> dict[str, Any]:
-    LOGGER.info("outlook_calendar_update_event called: event_id=%s, event=%s", event_id, event)
     body = event.model_dump(exclude_none=True)
     return await _client.update_event(event_id=event_id, event_body=body)
 
@@ -129,7 +113,6 @@ async def outlook_calendar_update_event(
     description="Delete an event by its ID. This action is irreversible.",
 )
 async def outlook_calendar_delete_event(event_id: str) -> dict[str, Any]:
-    LOGGER.info("outlook_calendar_delete_event called: event_id=%s", event_id)
     return await _client.delete_event(event_id=event_id)
 
 

--- a/engine/components/tools/outlook_calendar_mcp/server.py
+++ b/engine/components/tools/outlook_calendar_mcp/server.py
@@ -1,0 +1,143 @@
+"""
+FastMCP server exposing Outlook Calendar tools over stdio.
+
+Run:
+    uv run python -m engine.components.tools.outlook_calendar_mcp.server
+
+Expects OUTLOOK_CALENDAR_ACCESS_TOKEN in the environment.
+"""
+
+import warnings
+from typing import Any, Optional
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from fastmcp import FastMCP
+
+from engine.components.tools.outlook_calendar_mcp.client import OutlookCalendarClient
+from engine.components.tools.outlook_calendar_mcp.schema import EventBody
+from engine.components.types import ToolDescription
+from engine.llm_services.utils import resolve_schema_refs
+
+mcp = FastMCP("outlook-calendar")
+_client: OutlookCalendarClient
+
+
+@mcp.tool(
+    name="outlook_calendar_list_calendars",
+    description="List all calendars accessible to the authenticated user.",
+)
+async def outlook_calendar_list_calendars() -> list[dict[str, Any]]:
+    return await _client.list_calendars()
+
+
+@mcp.tool(
+    name="outlook_calendar_list_events",
+    description=(
+        "List events from a calendar. Returns events ordered by start time. "
+        "Use time_min/time_max (ISO 8601, e.g. '2026-03-20T00:00:00') to filter by date range. "
+        "When both time_min and time_max are provided, uses calendarView for accurate recurrence expansion."
+    ),
+)
+async def outlook_calendar_list_events(
+    calendar_id: str = "primary",
+    time_min: Optional[str] = None,
+    time_max: Optional[str] = None,
+    max_results: int = 50,
+    query: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    return await _client.list_events(
+        calendar_id=calendar_id,
+        time_min=time_min,
+        time_max=time_max,
+        max_results=max_results,
+        query=query,
+    )
+
+
+@mcp.tool(
+    name="outlook_calendar_get_event",
+    description="Get a single event by its ID.",
+)
+async def outlook_calendar_get_event(event_id: str) -> dict[str, Any]:
+    return await _client.get_event(event_id=event_id)
+
+
+@mcp.tool(
+    name="outlook_calendar_get_my_email",
+    description="Return the email address of the authenticated calendar owner.",
+)
+async def outlook_calendar_get_my_email() -> dict[str, str]:
+    email = await _client.get_user_email()
+    return {"email": email}
+
+
+@mcp.tool(
+    name="outlook_calendar_create_event",
+    description=(
+        "Create a new event on an Outlook Calendar. "
+        "Provide start and end as ISO 8601 datetime strings without timezone offset "
+        "(e.g. '2026-03-20T10:00:00.0000000') along with a timeZone (e.g. 'Europe/Paris'). "
+        "To create a Teams meeting, set isOnlineMeeting to true and onlineMeetingProvider to 'teamsForBusiness'. "
+        "When adding attendees, include the calendar owner if they should appear as a participant. "
+        "Use outlook_calendar_get_my_email to retrieve the owner's email if needed."
+    ),
+)
+async def outlook_calendar_create_event(
+    event: EventBody,
+    calendar_id: str = "primary",
+) -> dict[str, Any]:
+    body = event.model_dump(exclude_none=True)
+    return await _client.create_event(event_body=body, calendar_id=calendar_id)
+
+
+@mcp.tool(
+    name="outlook_calendar_update_event",
+    description=(
+        "Update an existing event. Only provided fields are changed; "
+        "omitted fields keep their current values."
+    ),
+)
+async def outlook_calendar_update_event(
+    event_id: str,
+    event: EventBody,
+) -> dict[str, Any]:
+    body = event.model_dump(exclude_none=True)
+    return await _client.update_event(event_id=event_id, event_body=body)
+
+
+@mcp.tool(
+    name="outlook_calendar_delete_event",
+    description="Delete an event by its ID. This action is irreversible.",
+)
+async def outlook_calendar_delete_event(event_id: str) -> dict[str, Any]:
+    return await _client.delete_event(event_id=event_id)
+
+
+async def get_tool_descriptions(allowed: set[str]) -> list[ToolDescription]:
+    result = []
+    for tool in await mcp.list_tools():
+        if tool.name not in allowed:
+            continue
+        params = tool.parameters or {}
+        resolved_params = resolve_schema_refs(params) if isinstance(params, dict) else params
+        result.append(
+            ToolDescription(
+                name=tool.name,
+                description=tool.description or "",
+                tool_properties=resolved_params.get("properties", {}),
+                required_tool_properties=resolved_params.get("required", []),
+            )
+        )
+    return result
+
+
+if __name__ == "__main__":
+    import os
+
+    token = os.environ.get("OUTLOOK_CALENDAR_ACCESS_TOKEN")
+    if not token:
+        raise RuntimeError("OUTLOOK_CALENDAR_ACCESS_TOKEN environment variable is required")
+
+    _client = OutlookCalendarClient(token)
+    mcp.run(show_banner=False)

--- a/engine/components/tools/outlook_calendar_mcp/server.py
+++ b/engine/components/tools/outlook_calendar_mcp/server.py
@@ -7,6 +7,7 @@ Run:
 Expects OUTLOOK_CALENDAR_ACCESS_TOKEN in the environment.
 """
 
+import logging
 import warnings
 from typing import Any, Optional
 
@@ -19,6 +20,9 @@ from engine.components.tools.outlook_calendar_mcp.schema import EventBody
 from engine.components.types import ToolDescription
 from engine.llm_services.utils import resolve_schema_refs
 
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+LOGGER = logging.getLogger(__name__)
+
 mcp = FastMCP("outlook-calendar")
 _client: OutlookCalendarClient
 
@@ -28,7 +32,10 @@ _client: OutlookCalendarClient
     description="List all calendars accessible to the authenticated user.",
 )
 async def outlook_calendar_list_calendars() -> list[dict[str, Any]]:
-    return await _client.list_calendars()
+    LOGGER.info("outlook_calendar_list_calendars called")
+    result = await _client.list_calendars()
+    LOGGER.info("outlook_calendar_list_calendars returned %d calendars", len(result))
+    return result
 
 
 @mcp.tool(
@@ -46,13 +53,19 @@ async def outlook_calendar_list_events(
     max_results: int = 50,
     query: Optional[str] = None,
 ) -> list[dict[str, Any]]:
-    return await _client.list_events(
+    LOGGER.info(
+        "outlook_calendar_list_events called: calendar_id=%s, time_min=%s, time_max=%s, max_results=%d, query=%s",
+        calendar_id, time_min, time_max, max_results, query,
+    )
+    result = await _client.list_events(
         calendar_id=calendar_id,
         time_min=time_min,
         time_max=time_max,
         max_results=max_results,
         query=query,
     )
+    LOGGER.info("outlook_calendar_list_events returned %d events", len(result))
+    return result
 
 
 @mcp.tool(
@@ -60,6 +73,7 @@ async def outlook_calendar_list_events(
     description="Get a single event by its ID.",
 )
 async def outlook_calendar_get_event(event_id: str) -> dict[str, Any]:
+    LOGGER.info("outlook_calendar_get_event called: event_id=%s", event_id)
     return await _client.get_event(event_id=event_id)
 
 
@@ -68,7 +82,9 @@ async def outlook_calendar_get_event(event_id: str) -> dict[str, Any]:
     description="Return the email address of the authenticated calendar owner.",
 )
 async def outlook_calendar_get_my_email() -> dict[str, str]:
+    LOGGER.info("outlook_calendar_get_my_email called")
     email = await _client.get_user_email()
+    LOGGER.info("outlook_calendar_get_my_email returned: %s", email)
     return {"email": email}
 
 
@@ -87,6 +103,7 @@ async def outlook_calendar_create_event(
     event: EventBody,
     calendar_id: str = "primary",
 ) -> dict[str, Any]:
+    LOGGER.info("outlook_calendar_create_event called: calendar_id=%s, event=%s", calendar_id, event)
     body = event.model_dump(exclude_none=True)
     return await _client.create_event(event_body=body, calendar_id=calendar_id)
 
@@ -102,6 +119,7 @@ async def outlook_calendar_update_event(
     event_id: str,
     event: EventBody,
 ) -> dict[str, Any]:
+    LOGGER.info("outlook_calendar_update_event called: event_id=%s, event=%s", event_id, event)
     body = event.model_dump(exclude_none=True)
     return await _client.update_event(event_id=event_id, event_body=body)
 
@@ -111,6 +129,7 @@ async def outlook_calendar_update_event(
     description="Delete an event by its ID. This action is irreversible.",
 )
 async def outlook_calendar_delete_event(event_id: str) -> dict[str, Any]:
+    LOGGER.info("outlook_calendar_delete_event called: event_id=%s", event_id)
     return await _client.delete_event(event_id=event_id)
 
 

--- a/engine/components/tools/outlook_calendar_mcp_tool.py
+++ b/engine/components/tools/outlook_calendar_mcp_tool.py
@@ -1,0 +1,60 @@
+"""
+Outlook Calendar MCP Tool — wraps the internal FastMCP server via stdio.
+"""
+
+import sys
+from typing import Optional, Self
+
+from engine.components.tools.mcp.local_mcp_tool import LocalMCPTool
+from engine.components.tools.mcp.shared import MCPToolInputs, MCPToolOutputs
+from engine.components.tools.outlook_calendar_mcp.server import get_tool_descriptions
+from engine.components.types import ComponentAttributes
+from engine.trace.trace_manager import TraceManager
+
+_DEFAULT_TOOLS = {
+    "outlook_calendar_list_calendars",
+    "outlook_calendar_list_events",
+    "outlook_calendar_get_event",
+    "outlook_calendar_get_my_email",
+    "outlook_calendar_create_event",
+    "outlook_calendar_update_event",
+    "outlook_calendar_delete_event",
+}
+
+
+class OutlookCalendarMCPTool(LocalMCPTool):
+    """Expose tools from the internal Outlook Calendar FastMCP server via stdio subprocess."""
+
+    @classmethod
+    async def from_access_token(
+        cls,
+        trace_manager: TraceManager,
+        component_attributes: ComponentAttributes,
+        access_token: Optional[str] = None,
+        allowed_tools: set[str] | None = None,
+        timeout: int = 30,
+    ) -> Self:
+        allowed = allowed_tools if allowed_tools is not None else _DEFAULT_TOOLS
+        tool_descriptions = await get_tool_descriptions(allowed)
+
+        return cls(
+            trace_manager=trace_manager,
+            component_attributes=component_attributes,
+            command=sys.executable,
+            args=["-m", "engine.components.tools.outlook_calendar_mcp.server"],
+            env={"OUTLOOK_CALENDAR_ACCESS_TOKEN": access_token} if access_token else None,
+            timeout=timeout,
+            tool_descriptions=tool_descriptions,
+        )
+
+    async def _run_without_io_trace(
+        self,
+        inputs: MCPToolInputs,
+        ctx: Optional[dict],
+    ) -> MCPToolOutputs:
+        if not self.env or not self.env.get("OUTLOOK_CALENDAR_ACCESS_TOKEN"):
+            raise ValueError(
+                "Outlook Calendar MCP requires a configured OAuth connection. "
+                "Please select an Outlook Calendar connection in the component settings."
+            )
+        return await super()._run_without_io_trace(inputs, ctx)

--- a/engine/components/tools/outlook_calendar_mcp_tool.py
+++ b/engine/components/tools/outlook_calendar_mcp_tool.py
@@ -5,6 +5,8 @@ Outlook Calendar MCP Tool — wraps the internal FastMCP server via stdio.
 import sys
 from typing import Optional, Self
 
+from pydantic import SecretStr
+
 from engine.components.tools.mcp.local_mcp_tool import LocalMCPTool
 from engine.components.tools.mcp.shared import MCPToolInputs, MCPToolOutputs
 from engine.components.tools.outlook_calendar_mcp.server import get_tool_descriptions
@@ -30,7 +32,7 @@ class OutlookCalendarMCPTool(LocalMCPTool):
         cls,
         trace_manager: TraceManager,
         component_attributes: ComponentAttributes,
-        access_token: Optional[str] = None,
+        access_token: Optional[SecretStr] = None,
         allowed_tools: set[str] | None = None,
         timeout: int = 30,
     ) -> Self:
@@ -42,7 +44,11 @@ class OutlookCalendarMCPTool(LocalMCPTool):
             component_attributes=component_attributes,
             command=sys.executable,
             args=["-m", "engine.components.tools.outlook_calendar_mcp.server"],
-            env={"OUTLOOK_CALENDAR_ACCESS_TOKEN": access_token} if access_token else None,
+            env=(
+                {"OUTLOOK_CALENDAR_ACCESS_TOKEN": access_token.get_secret_value()}
+                if access_token is not None
+                else None
+            ),
             timeout=timeout,
             tool_descriptions=tool_descriptions,
         )

--- a/engine/integrations/gmail/gmail_sender_v2.py
+++ b/engine/integrations/gmail/gmail_sender_v2.py
@@ -5,7 +5,7 @@ from typing import Iterable, Optional, Type
 from googleapiclient.errors import HttpError
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 from opentelemetry.trace import get_current_span
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 from engine.components.component import Component
 from engine.components.types import ComponentAttributes, ToolDescription
@@ -44,7 +44,7 @@ class GmailSenderV2(Component):
         self,
         trace_manager: TraceManager,
         component_attributes: ComponentAttributes,
-        access_token: Optional[str] = None,
+        access_token: Optional[SecretStr] = None,
         save_as_draft: bool = True,
         tool_description: ToolDescription = GMAIL_SENDER_TOOL_DESCRIPTION,
     ):
@@ -62,14 +62,15 @@ class GmailSenderV2(Component):
         return bool(self._access_token)
 
     def _ensure_client(self) -> None:
-        if not self._access_token:
+        if self._access_token is None:
             raise ValueError(
                 "Gmail Sender requires a configured OAuth connection. "
                 "Please select a Gmail connection in the component settings."
             )
         if self._service is None:
-            self._service = get_gmail_sender_service(self._access_token)
-            self._email_address = get_google_user_email(self._access_token)
+            token = self._access_token.get_secret_value()
+            self._service = get_gmail_sender_service(token)
+            self._email_address = get_google_user_email(token)
 
     @property
     def service(self):

--- a/engine/integrations/mail_sender.py
+++ b/engine/integrations/mail_sender.py
@@ -1,7 +1,7 @@
 from typing import Optional, Type
 
 from openinference.semconv.trace import OpenInferenceSpanKindValues
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 from engine.components.component import Component
 from engine.components.types import ComponentAttributes, ToolDescription
@@ -87,8 +87,8 @@ class MailSender(Component):
         self,
         trace_manager: TraceManager,
         component_attributes: ComponentAttributes,
-        gmail_access_token: Optional[str] = None,
-        outlook_access_token: Optional[str] = None,
+        gmail_access_token: Optional[SecretStr] = None,
+        outlook_access_token: Optional[SecretStr] = None,
         save_as_draft: bool = True,
         tool_description: ToolDescription = MAIL_SENDER_TOOL_DESCRIPTION,
     ):

--- a/engine/integrations/outlook/outlook_sender.py
+++ b/engine/integrations/outlook/outlook_sender.py
@@ -6,7 +6,7 @@ from uuid import UUID
 import httpx
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 from opentelemetry.trace import get_current_span
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator
 
 from engine.components.component import Component
 from engine.components.types import ComponentAttributes, ToolDescription
@@ -181,7 +181,7 @@ class OutlookSender(Component):
         self,
         trace_manager: TraceManager,
         component_attributes: ComponentAttributes,
-        access_token: Optional[str] = None,
+        access_token: Optional[SecretStr] = None,
         save_as_draft: bool = True,
         tool_description: ToolDescription = OUTLOOK_SENDER_TOOL_DESCRIPTION,
     ):
@@ -190,16 +190,18 @@ class OutlookSender(Component):
             tool_description=tool_description,
             component_attributes=component_attributes,
         )
-        self.access_token = access_token
+        self._access_token = access_token
         self._email_address: Optional[str] = None
         self.save_as_draft = save_as_draft
 
     def is_available(self) -> bool:
-        return bool(self.access_token)
+        return self._access_token is not None
 
     def _auth_headers(self) -> dict[str, str]:
+        if self._access_token is None:
+            raise ValueError("Outlook Sender requires a configured OAuth connection.")
         return {
-            "Authorization": f"Bearer {self.access_token}",
+            "Authorization": f"Bearer {self._access_token.get_secret_value()}",
             "Content-Type": "application/json",
         }
 
@@ -267,7 +269,7 @@ class OutlookSender(Component):
             raise OutlookAPIError("send Outlook email", response.status_code)
 
     async def _run_without_io_trace(self, inputs: OutlookSenderInputs, ctx: dict) -> OutlookSenderOutputs:
-        if not self.access_token:
+        if self._access_token is None:
             raise ValueError(
                 "Outlook Sender requires a configured OAuth connection. "
                 "Please select an Outlook connection in the component settings."

--- a/engine/integrations/providers.py
+++ b/engine/integrations/providers.py
@@ -8,3 +8,4 @@ class OAuthProvider(StrEnum):
     GMAIL = "google-mail"
     GOOGLE_CALENDAR = "google-calendar"
     OUTLOOK = "outlook"
+    OUTLOOK_CALENDAR = "outlook-calendar"

--- a/engine/integrations/slack/slack_sender.py
+++ b/engine/integrations/slack/slack_sender.py
@@ -3,7 +3,7 @@ from typing import Optional, Type
 
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 from opentelemetry.trace import get_current_span
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 from slack_sdk import WebClient
 
 from engine.components.component import Component
@@ -82,27 +82,19 @@ class SlackSender(Component):
         self,
         trace_manager: TraceManager,
         component_attributes: ComponentAttributes,
-        access_token: Optional[str] = None,
+        access_token: Optional[SecretStr] = None,
         tool_description: ToolDescription = SLACK_SENDER_TOOL_DESCRIPTION,
     ):
-        """Initialize SlackSender with a provided Slack OAuth access token.
-
-        Args:
-            trace_manager: Trace manager for observability
-            component_attributes: Component configuration attributes
-            access_token: Slack OAuth access token (injected by OAuth processor); may be None until run.
-            tool_description: Tool description for the component
-        """
         super().__init__(
             trace_manager=trace_manager,
             tool_description=tool_description,
             component_attributes=component_attributes,
         )
         self._access_token = access_token
-        self.client = WebClient(token=access_token) if access_token else None
+        self.client = WebClient(token=access_token.get_secret_value()) if access_token is not None else None
 
     def is_available(self) -> bool:
-        return bool(self._access_token)
+        return self._access_token is not None
 
     async def _run_without_io_trace(
         self,

--- a/scripts/mcp/manual_hubspot_mcp_test.py
+++ b/scripts/mcp/manual_hubspot_mcp_test.py
@@ -29,6 +29,7 @@ import json
 from uuid import UUID
 
 from dotenv import load_dotenv
+from pydantic import SecretStr
 
 from ada_backend.database.setup_db import get_db_session
 from ada_backend.services.integration_service import get_oauth_access_token
@@ -77,7 +78,7 @@ async def main():
     tool = await HubSpotMCPTool.from_access_token(
         trace_manager=trace_manager,
         component_attributes=component_attributes,
-        access_token=access_token,
+        access_token=SecretStr(access_token),
     )
 
     descriptions = tool.get_tool_descriptions()

--- a/tests/ada_backend/services/test_registry.py
+++ b/tests/ada_backend/services/test_registry.py
@@ -126,5 +126,5 @@ async def test_mail_sender_factory_resolves_oauth_bindings(monkeypatch):
         ("gmail-definition-id", OAuthProvider.GMAIL),
         ("outlook-definition-id", OAuthProvider.OUTLOOK),
     ]
-    assert component._gmail_access_token == "gmail-access-token"
-    assert component._outlook_access_token == "outlook-access-token"
+    assert component._gmail_access_token.get_secret_value() == "gmail-access-token"
+    assert component._outlook_access_token.get_secret_value() == "outlook-access-token"

--- a/tests/components/test_google_calendar_mcp_tool.py
+++ b/tests/components/test_google_calendar_mcp_tool.py
@@ -11,6 +11,7 @@ import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import SecretStr
 
 from engine.components.tools.google_calendar_mcp import server as gcal_server
 from engine.components.tools.google_calendar_mcp.client import GoogleCalendarClient
@@ -23,7 +24,7 @@ from engine.components.types import ComponentAttributes
 from tests.mocks.trace_manager import MockTraceManager
 
 
-async def _make_tool(access_token: str | None = "fake-token") -> GoogleCalendarMCPTool:
+async def _make_tool(access_token: SecretStr | None = SecretStr("fake-token")) -> GoogleCalendarMCPTool:
     return await GoogleCalendarMCPTool.from_access_token(
         trace_manager=MockTraceManager(project_name="test"),
         component_attributes=ComponentAttributes(component_instance_name="test-gcal"),
@@ -34,7 +35,7 @@ async def _make_tool(access_token: str | None = "fake-token") -> GoogleCalendarM
 class TestGoogleCalendarMCPToolConstruction:
     @pytest.mark.asyncio
     async def test_from_access_token_sets_env(self):
-        tool = await _make_tool("my-token")
+        tool = await _make_tool(SecretStr("my-token"))
         assert tool.env == {"GOOGLE_CALENDAR_ACCESS_TOKEN": "my-token"}
 
     @pytest.mark.asyncio
@@ -90,7 +91,7 @@ class TestGoogleCalendarMCPToolRunGuard:
 
     @pytest.mark.asyncio
     async def test_raises_when_empty_token(self):
-        tool = await _make_tool("")
+        tool = await _make_tool(SecretStr(""))
         inputs = MCPToolInputs(tool_name="calendar_list_calendars", tool_arguments={})
         with pytest.raises(ValueError, match="OAuth connection"):
             await tool._run_without_io_trace(inputs, ctx={})

--- a/tests/components/test_outlook_calendar_mcp_tool.py
+++ b/tests/components/test_outlook_calendar_mcp_tool.py
@@ -1,0 +1,154 @@
+import subprocess
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import quote
+
+import pytest
+from pydantic import SecretStr
+
+from engine.components.tools.mcp.shared import MCPToolInputs
+from engine.components.tools.outlook_calendar_mcp.client import OutlookCalendarClient
+from engine.components.tools.outlook_calendar_mcp_tool import (
+    _DEFAULT_TOOLS,
+    OutlookCalendarMCPTool,
+)
+from engine.components.types import ComponentAttributes
+from tests.mocks.trace_manager import MockTraceManager
+
+
+async def _make_tool(access_token: SecretStr | None = SecretStr("fake-token")) -> OutlookCalendarMCPTool:
+    return await OutlookCalendarMCPTool.from_access_token(
+        trace_manager=MockTraceManager(project_name="test"),
+        component_attributes=ComponentAttributes(component_instance_name="test-outlook-cal"),
+        access_token=access_token,
+    )
+
+
+class TestOutlookCalendarMCPToolConstruction:
+    @pytest.mark.asyncio
+    async def test_from_access_token_sets_env(self):
+        tool = await _make_tool(SecretStr("my-token"))
+        assert tool.env == {"OUTLOOK_CALENDAR_ACCESS_TOKEN": "my-token"}
+
+    @pytest.mark.asyncio
+    async def test_from_access_token_without_token(self):
+        tool = await _make_tool(None)
+        assert tool.env is None
+
+    @pytest.mark.asyncio
+    async def test_tool_descriptions_match_default_tools(self):
+        tool = await _make_tool()
+        names = {td.name for td in tool.get_tool_descriptions()}
+        assert names == _DEFAULT_TOOLS
+
+    @pytest.mark.asyncio
+    async def test_subprocess_args_point_to_server_module(self):
+        tool = await _make_tool()
+        assert "-m" in tool.args
+        assert "engine.components.tools.outlook_calendar_mcp.server" in tool.args
+
+
+class TestOutlookCalendarMCPServerSubprocess:
+    def test_server_module_importable_without_backend_env(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import engine.components.tools.outlook_calendar_mcp.server; "
+                    "import sys; "
+                    "backend_modules = [m for m in sys.modules if m.startswith('ada_backend')]; "
+                    "assert not backend_modules, f'ada_backend leaked into subprocess: {backend_modules}'"
+                ),
+            ],
+            env={"PATH": "/usr/bin:/bin", "HOME": "/tmp"},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"Server module failed to import in minimal env:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+class TestOutlookCalendarClientUrlEncoding:
+    RAW_CAL_ID = "AAMkAGI2+Strange/Id="
+    RAW_EVENT_ID = "EV+test/foo="
+    ENCODED_CAL_ID = quote(RAW_CAL_ID, safe="")
+    ENCODED_EVENT_ID = quote(RAW_EVENT_ID, safe="")
+
+    @staticmethod
+    def _fake_response(data: dict | None = None) -> MagicMock:
+        resp = MagicMock()
+        resp.json.return_value = data or {}
+        return resp
+
+    def _make_client(self) -> OutlookCalendarClient:
+        client = OutlookCalendarClient(access_token="fake")
+        client._default_calendar_id = self.RAW_CAL_ID
+        return client
+
+    @pytest.mark.asyncio
+    async def test_list_events_encodes_calendar_id(self):
+        client = self._make_client()
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = self._fake_response({"value": []})
+            await client.list_events(calendar_id="primary")
+            path = mock_req.call_args[0][1]
+            assert self.ENCODED_CAL_ID in path
+            assert self.RAW_CAL_ID not in path
+
+    @pytest.mark.asyncio
+    async def test_get_event_encodes_event_id(self):
+        client = self._make_client()
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = self._fake_response()
+            await client.get_event(self.RAW_EVENT_ID)
+            path = mock_req.call_args[0][1]
+            assert self.ENCODED_EVENT_ID in path
+            assert self.RAW_EVENT_ID not in path
+
+    @pytest.mark.asyncio
+    async def test_create_event_encodes_calendar_id(self):
+        client = self._make_client()
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = self._fake_response()
+            await client.create_event({"subject": "test"}, calendar_id="primary")
+            path = mock_req.call_args[0][1]
+            assert self.ENCODED_CAL_ID in path
+            assert self.RAW_CAL_ID not in path
+
+    @pytest.mark.asyncio
+    async def test_update_event_encodes_event_id(self):
+        client = self._make_client()
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = self._fake_response()
+            await client.update_event(self.RAW_EVENT_ID, {"subject": "updated"})
+            path = mock_req.call_args[0][1]
+            assert self.ENCODED_EVENT_ID in path
+            assert self.RAW_EVENT_ID not in path
+
+    @pytest.mark.asyncio
+    async def test_delete_event_encodes_event_id(self):
+        client = self._make_client()
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_req:
+            await client.delete_event(self.RAW_EVENT_ID)
+            path = mock_req.call_args[0][1]
+            assert self.ENCODED_EVENT_ID in path
+            assert self.RAW_EVENT_ID not in path
+
+
+class TestOutlookCalendarMCPToolRunGuard:
+    @pytest.mark.asyncio
+    async def test_raises_when_no_token(self):
+        tool = await _make_tool(None)
+        inputs = MCPToolInputs(tool_name="outlook_calendar_list_calendars", tool_arguments={})
+        with pytest.raises(ValueError, match="OAuth connection"):
+            await tool._run_without_io_trace(inputs, ctx={})
+
+    @pytest.mark.asyncio
+    async def test_raises_when_empty_token(self):
+        tool = await _make_tool(SecretStr(""))
+        inputs = MCPToolInputs(tool_name="outlook_calendar_list_calendars", tool_arguments={})
+        with pytest.raises(ValueError, match="OAuth connection"):
+            await tool._run_without_io_trace(inputs, ctx={})

--- a/tests/components/test_remote_mcp_tool.py
+++ b/tests/components/test_remote_mcp_tool.py
@@ -56,6 +56,7 @@ def create_mock_call_result(text_content: str | None = None, is_error: bool = Fa
     else:
         mock_result.content = []
     mock_result.isError = is_error
+    mock_result.structuredContent = None
     return mock_result
 
 

--- a/tests/engine/integrations/test_mail_sender.py
+++ b/tests/engine/integrations/test_mail_sender.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import SecretStr
 
 from engine.components.types import ComponentAttributes
 from engine.integrations.gmail.gmail_sender import GmailSenderInputs
@@ -16,7 +17,7 @@ def test_is_available_gmail_only(component_attrs: ComponentAttributes):
     sender = MailSender(
         MagicMock(),
         component_attrs,
-        gmail_access_token="tok",
+        gmail_access_token=SecretStr("tok"),
         outlook_access_token=None,
     )
     assert sender.is_available()
@@ -27,7 +28,7 @@ def test_is_available_outlook_only(component_attrs: ComponentAttributes):
         MagicMock(),
         component_attrs,
         gmail_access_token=None,
-        outlook_access_token="tok",
+        outlook_access_token=SecretStr("tok"),
     )
     assert sender.is_available()
 
@@ -41,8 +42,8 @@ def test_is_available_both_connected(component_attrs: ComponentAttributes):
     sender = MailSender(
         MagicMock(),
         component_attrs,
-        gmail_access_token="g",
-        outlook_access_token="o",
+        gmail_access_token=SecretStr("g"),
+        outlook_access_token=SecretStr("o"),
     )
     assert sender.is_available()
 
@@ -52,8 +53,8 @@ async def test_run_requires_exactly_one_provider(component_attrs: ComponentAttri
     sender = MailSender(
         MagicMock(),
         component_attrs,
-        gmail_access_token="g",
-        outlook_access_token="o",
+        gmail_access_token=SecretStr("g"),
+        outlook_access_token=SecretStr("o"),
     )
     with pytest.raises(MailSenderConfigurationError, match="only one provider"):
         await sender._run_without_io_trace(GmailSenderInputs(mail_subject="s"), {})
@@ -74,7 +75,7 @@ async def test_delegates_to_gmail(component_attrs: ComponentAttributes):
         sender = MailSender(
             MagicMock(),
             component_attrs,
-            gmail_access_token="g",
+            gmail_access_token=SecretStr("g"),
         )
         out = await sender._run_without_io_trace(GmailSenderInputs(mail_subject="sub"), {})
         assert out.status == "sent"
@@ -90,7 +91,7 @@ async def test_delegates_to_outlook(component_attrs: ComponentAttributes):
         sender = MailSender(
             MagicMock(),
             component_attrs,
-            outlook_access_token="o",
+            outlook_access_token=SecretStr("o"),
         )
         out = await sender._run_without_io_trace(GmailSenderInputs(mail_subject="sub"), {})
         assert out.status == "sent"

--- a/tests/engine/integrations/test_slack_sender.py
+++ b/tests/engine/integrations/test_slack_sender.py
@@ -2,6 +2,7 @@ import uuid
 from unittest.mock import patch
 
 import pytest
+from pydantic import SecretStr
 
 from engine.components.types import ComponentAttributes
 from engine.integrations.slack.slack_sender import SlackSender, SlackSenderInputs
@@ -25,7 +26,7 @@ async def test_slack_sender_success():
                 component_instance_name="test_slack_sender",
                 component_instance_id=uuid.uuid4(),
             ),
-            access_token="xoxb-test-token",
+            access_token=SecretStr("xoxb-test-token"),
         )
 
         inputs = SlackSenderInputs(
@@ -58,7 +59,7 @@ async def test_slack_sender_with_thread():
                 component_instance_name="test_slack_sender",
                 component_instance_id=uuid.uuid4(),
             ),
-            access_token="xoxb-test-token",
+            access_token=SecretStr("xoxb-test-token"),
         )
 
         inputs = SlackSenderInputs(
@@ -92,7 +93,7 @@ async def test_slack_sender_api_error():
                 component_instance_name="test_slack_sender",
                 component_instance_id=uuid.uuid4(),
             ),
-            access_token="xoxb-test-token",
+            access_token=SecretStr("xoxb-test-token"),
         )
 
         inputs = SlackSenderInputs(
@@ -121,7 +122,7 @@ async def test_slack_sender_calls_api_with_correct_params():
                 component_instance_name="test_slack_sender",
                 component_instance_id=uuid.uuid4(),
             ),
-            access_token="xoxb-test-token",
+            access_token=SecretStr("xoxb-test-token"),
         )
 
         inputs = SlackSenderInputs(


### PR DESCRIPTION
# Add Outlook Calendar component (dual mode: tool + root)

## Summary
- Adds a new Outlook Calendar Tool (MCP-based) that can be attached to an AI Agent, exposing 7 calendar operations: list calendars, list events, get event, get user email, create event, update event, delete event.
- Adds a new Outlook Calendar standalone root component for use directly in workflows, which fetches upcoming events from a user's Outlook calendar and outputs them as structured JSON.
- Both components share a common async httpx client (OutlookCalendarClient) that calls the Microsoft Graph Calendar API (v1.0).
- Introduces `OUTLOOK_CALENDAR` as a new OAuthProvider (separate from the existing OUTLOOK used for email, since calendar requires Calendars.ReadWrite scopes).
- Both components are seeded at `release_stage=INTERNAL`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microsoft Outlook Calendar integration with OAuth authentication.
  * List calendars and events; retrieve, create, update, and delete events.
  * Event support for attendees, locations, recurrence, online meeting flags, and reminders.
  * Integration exposed as an MCP tool for local use and automation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Scopeo/draftnrun/pull/722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->