### PR TITLE
feat(factory): Fixes SQLAlchemy pool exhaustion dra-1300

### DIFF
--- a/.cursor/rules/services.mdc
+++ b/.cursor/rules/services.mdc
@@ -12,6 +12,7 @@ globs:
 - Secrets: encrypted with Fernet before storage, decrypted on read via `ada_backend/utils/encryption.py`.
 - Runtime secret values passed toward the engine should use `SecretStr` (`pydantic.SecretStr`) until an explicit execution boundary requires plaintext.
 - When passing constructor params to engine factories or placeholder/template resolvers, unwrap secrets explicitly and as late as possible.
+- During graph component instantiation, resolve DB-backed factory inputs with the existing builder `Session`; do not add nested `get_db_session()` calls in factory parameter processors for per-component metadata.
 - Never log full parameter dicts after `replace_secret_placeholders()`; log only parameter names (`list(params.keys())`). Apply the same rule to structured `extra=` logger kwargs.
 - Prefer UUID-typed identifiers in service-facing schemas and payload models; only stringify UUIDs at API/JSON boundaries.
 - Prefer typed schemas/models for service return payloads; avoid untyped `dict` returns when a stable shape exists.

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -68,6 +68,14 @@ The concrete base class implementing `Runnable`. Key attributes:
 
 When removing a component from the product, delete the runtime class, registry entry, seed data, existing DB catalog rows (with a migration), default tool description, and wrapper components that only exist to call it. Leaving only part of the catalog wiring in place can keep a dead component instantiable through backend seeds or MCP graph validation even after it disappears from the front-end.
 
+### Component Instantiation DB Usage
+
+`ada_backend/services/agent_builder_service.py` instantiates graph components while holding the graph-building SQLAlchemy
+session. Any database lookups needed to prepare factory inputs should use that existing session before calling
+`FACTORY_REGISTRY.create(...)`. Factory parameter processors in `ada_backend/services/entity_factory.py` should consume
+already-resolved values and avoid opening their own `get_db_session()` for per-component metadata such as LLM model IDs,
+because nested checkouts multiply connection-pool pressure during concurrent runs.
+
 ## Port System
 
 Three layers spanning database (backend) and runtime (engine):

--- a/ada_backend/services/agent_builder_service.py
+++ b/ada_backend/services/agent_builder_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from ada_backend.context import set_current_project_id
 from ada_backend.database.models import PortSetupMode
+from ada_backend.database.seed.constants import COMPLETION_MODEL_IN_DB
 from ada_backend.database.seed.utils import COMPONENT_VERSION_UUIDS
 from ada_backend.repositories.component_repository import (
     get_base_component_from_version,
@@ -24,6 +25,7 @@ from ada_backend.repositories.integration_repository import (
 from ada_backend.repositories.organization_repository import get_organization_secrets_from_project_id
 from ada_backend.repositories.tool_port_configuration_repository import get_tool_port_configurations
 from ada_backend.services.errors import MissingDataSourceError, MissingIntegrationError
+from ada_backend.services.llm_models_service import get_model_id_by_name_service
 from ada_backend.services.registry import FACTORY_REGISTRY
 from ada_backend.services.tool_description_generator import generate_tool_description
 from ada_backend.utils.secret_resolver import replace_secret_placeholders
@@ -35,6 +37,15 @@ from engine.field_expressions.serializer import from_json as expression_from_jso
 from engine.graph_runner.field_expression_management import evaluate_expression
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _add_llm_model_id(session: Session, input_params: dict[str, Any]) -> None:
+    completion_model = input_params.get(COMPLETION_MODEL_IN_DB)
+    if not isinstance(completion_model, str) or ":" not in completion_model:
+        return
+
+    model_name = completion_model.split(":", 1)[1]
+    input_params["model_id"] = get_model_id_by_name_service(session, model_name)
 
 
 def get_component_params(
@@ -333,6 +344,7 @@ async def instantiate_component(
         key_to_secret = {s.key: s.secret for s in secrets}
 
     input_params = replace_secret_placeholders(input_params, key_to_secret)
+    _add_llm_model_id(session, input_params)
 
     factory = FACTORY_REGISTRY.get(component_instance.component_version_id)
     entity_class = getattr(factory, "entity_class", None)

--- a/ada_backend/services/entity_factory.py
+++ b/ada_backend/services/entity_factory.py
@@ -26,7 +26,6 @@ from ada_backend.services.errors import MissingDataSourceError
 from ada_backend.services.integration_service import get_oauth_access_token
 from ada_backend.services.llm_models_service import (
     get_llm_models_by_capability_select_options_service,
-    get_model_id_by_name_service,
 )
 from engine.components.rag.cohere_reranker import CohereReranker
 from engine.components.rag.formatter import Formatter
@@ -51,12 +50,6 @@ class ParameterToValidate(BaseModel):
     argument: Any
     type: Any
     optional: bool = False
-
-
-# TODO: Remove this when llm service has only model_id as an argument
-def fetch_model_id_by_name(model_name: str) -> UUID | None:
-    with get_db_session() as session:
-        return get_model_id_by_name_service(session, model_name)
 
 
 class EntityFactory:
@@ -645,7 +638,7 @@ def build_completion_service_processor(
     def processor(params: dict, constructor_params: dict[str, Any]) -> dict:
         provider, model_name = get_llm_provider_and_model(llm_model=params.pop("completion_model"))
 
-        model_id = fetch_model_id_by_name(model_name)
+        model_id = params.pop("model_id", None)
 
         completion_service = CompletionService(
             provider=provider,
@@ -699,7 +692,7 @@ def build_web_service_processor(
     def processor(params: dict, constructor_params: dict[str, Any]) -> dict:
         provider, model_name = get_llm_provider_and_model(llm_model=params.pop("completion_model"))
 
-        model_id = fetch_model_id_by_name(model_name)
+        model_id = params.pop("model_id", None)
 
         web_service = WebSearchService(
             trace_manager=get_trace_manager(),
@@ -725,7 +718,7 @@ def build_ocr_service_processor(
     def processor(params: dict, constructor_params: dict[str, Any]) -> dict:
         provider, model_name = get_llm_provider_and_model(llm_model=params.pop("completion_model"))
 
-        model_id = fetch_model_id_by_name(model_name)
+        model_id = params.pop("model_id", None)
 
         ocr_service = OCRService(
             trace_manager=get_trace_manager(),
@@ -1000,7 +993,7 @@ def build_synthesizer_processor(target_name: str = "synthesizer") -> ParameterPr
             except ValueError as e:
                 raise ValueError(f"temperature must be a float, got {temperature}: {e}")
 
-        model_id = fetch_model_id_by_name(model_name)
+        model_id = params.pop("model_id", None)
 
         completion_service = CompletionService(
             provider=provider,

--- a/tests/ada_backend/services/test_agent_builder_service.py
+++ b/tests/ada_backend/services/test_agent_builder_service.py
@@ -1,7 +1,14 @@
-"""Regression tests for OAuth tool skipping via AIAgent._build_tool_cache."""
+"""Regression tests for agent/component building behavior."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+from uuid import uuid4
 
+import pytest
+
+from ada_backend.database.seed.constants import COMPLETION_MODEL_IN_DB, TEMPERATURE_IN_DB
+from ada_backend.database.seed.utils import COMPONENT_VERSION_UUIDS
+from ada_backend.services import agent_builder_service, entity_factory
 from engine.components.ai_agent import AIAgent
 from engine.components.types import ComponentAttributes, ToolDescription
 
@@ -78,3 +85,83 @@ def test_no_tools_skipped_when_all_available():
     agent = _make_ai_agent(tools, skip_tools_with_missing_oauth=True)
 
     assert set(agent._tool_registry.keys()) == {"slack", "gmail", "outlook"}
+
+
+@pytest.mark.asyncio
+async def test_llm_component_instantiation_reuses_builder_session_for_model_id(monkeypatch):
+    component_instance_id = uuid4()
+    model_id = uuid4()
+    session = MagicMock(name="builder_session")
+
+    class FakeCompletionService:
+        def __init__(
+            self,
+            provider,
+            model_name,
+            trace_manager,
+            temperature,
+            api_key,
+            verbosity,
+            reasoning,
+            model_id,
+        ):
+            self.provider = provider
+            self.model_name = model_name
+            self.trace_manager = trace_manager
+            self.temperature = temperature
+            self.api_key = api_key
+            self.verbosity = verbosity
+            self.reasoning = reasoning
+            self._model_id = model_id
+
+    component_instance = SimpleNamespace(
+        id=component_instance_id,
+        component_version_id=COMPONENT_VERSION_UUIDS["llm_call"],
+        name="AI",
+        ref="ai",
+    )
+
+    monkeypatch.setattr(
+        agent_builder_service,
+        "get_component_instance_by_id",
+        lambda received_session, received_id: component_instance,
+    )
+    monkeypatch.setattr(agent_builder_service, "get_component_name_from_instance", lambda *_: "AI")
+    monkeypatch.setattr(
+        agent_builder_service,
+        "get_component_params",
+        lambda *_args, **_kwargs: {
+            COMPLETION_MODEL_IN_DB: "openai:gpt-4.1",
+            TEMPERATURE_IN_DB: 0.2,
+            "api_key": "test-key",
+            "verbosity": "low",
+            "reasoning": "minimal",
+        },
+    )
+    monkeypatch.setattr(agent_builder_service, "get_integration_from_component", lambda *_: None)
+    monkeypatch.setattr(agent_builder_service, "get_component_sub_components", lambda *_: [])
+    monkeypatch.setattr(agent_builder_service, "get_global_parameters_by_component_version_id", lambda *_: [])
+    monkeypatch.setattr(agent_builder_service, "replace_secret_placeholders", lambda params, _secrets: params)
+    monkeypatch.setattr(agent_builder_service, "generate_tool_description", lambda *_: _make_tool_description("ai"))
+    monkeypatch.setattr(agent_builder_service, "get_base_component_from_version", lambda *_: None)
+
+    def fake_get_model_id_by_name_service(received_session, model_name):
+        assert received_session is session
+        assert model_name == "gpt-4.1"
+        return model_id
+
+    monkeypatch.setattr(agent_builder_service, "get_model_id_by_name_service", fake_get_model_id_by_name_service)
+    monkeypatch.setattr(entity_factory, "CompletionService", FakeCompletionService)
+    monkeypatch.setattr(entity_factory, "get_trace_manager", lambda: MagicMock())
+    monkeypatch.setattr(entity_factory, "get_db_session", MagicMock(side_effect=AssertionError("nested DB session")))
+
+    component = await agent_builder_service.instantiate_component(session, component_instance_id)
+
+    completion_service = component._completion_service
+    assert completion_service.provider == "openai"
+    assert completion_service.model_name == "gpt-4.1"
+    assert completion_service.temperature == 0.2
+    assert completion_service.api_key == "test-key"
+    assert completion_service.verbosity == "low"
+    assert completion_service.reasoning == "minimal"
+    assert completion_service._model_id == model_id


### PR DESCRIPTION
# Fixes SQLAlchemy pool exhaustion during `AI` / `llm_call` component instantiation

## Summary
- Fixes SQLAlchemy pool exhaustion during `AI` / `llm_call` component instantiation by removing a nested DB session checkout from LLM factory preprocessing.
- Resolves LLM model_id in `agent_builder_service.py` using the existing graph-building session.
- Updates LLM-backed factory processors to consume pre-resolved `model_id` instead of opening `get_db_session()`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SQLAlchemy connection pool exhaustion when instantiating `AI`/`llm_call` by removing nested DB sessions in factory preprocessing. Resolves LLM `model_id` using the existing builder `Session` to improve stability under load (DRA-1300).

- **Bug Fixes**
  - Resolve LLM `model_id` in `agent_builder_service.py` via the current graph-building session and pass it to factories.
  - Update factory processors to consume `model_id` and stop calling `get_db_session()` during instantiation.
  - Add regression test to ensure session reuse and prevent nested checkouts.

- **Refactors**
  - Document and codify the rule to use the existing builder `Session` for DB-backed factory inputs; added notes to engine docs and service rules.

<sup>Written for commit 64d3707002ebe179ca839bd2502e083ce5344d6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/724?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized LLM component instantiation to efficiently derive model identifiers during agent building, improving database session reuse and resource efficiency.

* **Documentation**
  * Added guidance on component instantiation and database session management conventions.

* **Tests**
  * Added regression test ensuring LLM component instantiation correctly reuses database sessions without introducing nested calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Scopeo/draftnrun/pull/724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->