### PR TITLE
feat(frontend): fix version selector dra-1306

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -39,7 +39,7 @@ DAG of ComponentInstances connected via FieldExpressions (JSON AST). See `ada_ba
 ### Frontend Version Selection
 
 Projects and agents share the frontend version selector. After graph runner refreshes caused by version actions, keep current-runner selection logic in `frontend/src/composables/useVersionSelection.ts`; loading a version as draft should select the refreshed draft runner, even when the source version still exists.
-When adding version-selector context-menu actions, snapshot `menuTargetId`, close the context menu, then open follow-up dialogs on the next Vue tick so Vuetify menu overlays do not block the dialog.
+When adding version-selector context-menu actions, snapshot `menuTargetId`, close both the context menu and underlying select menu, then open follow-up dialogs only after Vue has flushed overlay teardown so Vuetify menu overlays do not block the dialog.
 
 ### Project Tags
 

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -36,6 +36,10 @@ DAG of ComponentInstances connected via FieldExpressions (JSON AST). See `ada_ba
 
 `draft` / `production` bound to specific GraphRunner versions via `ProjectEnvironmentBinding`. Each `Run` records its `graph_runner_id` (set when the worker transitions the run to `RUNNING`).
 
+### Frontend Version Selection
+
+Projects and agents share the frontend version selector. After graph runner refreshes caused by version actions, keep current-runner selection logic in `frontend/src/composables/useVersionSelection.ts`; loading a version as draft should select the refreshed draft runner, even when the source version still exists.
+
 ### Project Tags
 
 Free-form string tags on projects via `project_tags` table (many-to-many). Tags are lowercase, unique per project. Used for filtering/organizing projects in the UI. Git-synced projects automatically receive a `"github"` tag. Management endpoints: `POST /projects/{id}/tags`, `DELETE /projects/{id}/tags/{tag}`. List endpoint supports `?tags=foo&tags=bar` filter (AND semantics). Org-level autocomplete: `GET /projects/org/{org_id}/tags`.

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -39,6 +39,7 @@ DAG of ComponentInstances connected via FieldExpressions (JSON AST). See `ada_ba
 ### Frontend Version Selection
 
 Projects and agents share the frontend version selector. After graph runner refreshes caused by version actions, keep current-runner selection logic in `frontend/src/composables/useVersionSelection.ts`; loading a version as draft should select the refreshed draft runner, even when the source version still exists.
+When adding version-selector context-menu actions, snapshot `menuTargetId`, close the context menu, then open follow-up dialogs on the next Vue tick so Vuetify menu overlays do not block the dialog.
 
 ### Project Tags
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -165,6 +165,10 @@ One file per domain (e.g. `useAgentsQuery.ts`, `useProjectsQuery.ts`).
 Mutations use `useMutation` with cache patching (`setQueryData`) for inline edits
 and `invalidateQueries` only for destructive/structural changes.
 
+### Version selection
+
+The shared version selector is used by projects and agents. After version actions that refresh graph runners, `src/composables/useVersionSelection.ts` decides which runner should become current; loading a version as draft must switch to the refreshed draft runner.
+
 ### Logging
 
 Centralized `logger` in `src/utils/logger.ts` with Sentry integration.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -168,6 +168,7 @@ and `invalidateQueries` only for destructive/structural changes.
 ### Version selection
 
 The shared version selector is used by projects and agents. After version actions that refresh graph runners, `src/composables/useVersionSelection.ts` decides which runner should become current; loading a version as draft must switch to the refreshed draft runner.
+Context-menu actions in `src/components/shared/VersionSelector.vue` snapshot the target graph runner, close the menu, then open confirmation dialogs on the next Vue tick so Vuetify menu overlays do not block the dialog.
 
 ### Logging
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -168,7 +168,7 @@ and `invalidateQueries` only for destructive/structural changes.
 ### Version selection
 
 The shared version selector is used by projects and agents. After version actions that refresh graph runners, `src/composables/useVersionSelection.ts` decides which runner should become current; loading a version as draft must switch to the refreshed draft runner.
-Context-menu actions in `src/components/shared/VersionSelector.vue` snapshot the target graph runner, close the menu, then open confirmation dialogs on the next Vue tick so Vuetify menu overlays do not block the dialog.
+Context-menu actions in `src/components/shared/VersionSelector.vue` snapshot the target graph runner, close both the context menu and underlying select menu, then open confirmation dialogs after Vue has flushed overlay teardown.
 
 ### Logging
 

--- a/frontend/src/components/shared/VersionSelector.vue
+++ b/frontend/src/components/shared/VersionSelector.vue
@@ -66,12 +66,18 @@ const handleContextMenu = (event: MouseEvent, graphRunnerId: string) => {
   contextMenu.openMenu(event, graphRunnerId)
 }
 
+const closeVersionMenus = async () => {
+  contextMenu.closeMenu()
+  isSelectMenuOpen.value = false
+  await nextTick()
+  await nextTick()
+}
+
 const handleDeploy = async () => {
   const graphRunnerId = contextMenu.menuTargetId.value
   if (!graphRunnerId) return
 
-  contextMenu.closeMenu()
-  await nextTick()
+  await closeVersionMenus()
   await deployment.deployToProduction(graphRunnerId)
 }
 
@@ -79,8 +85,7 @@ const handleLoadDraft = async () => {
   const graphRunnerId = contextMenu.menuTargetId.value
   if (!graphRunnerId) return
 
-  contextMenu.closeMenu()
-  await nextTick()
+  await closeVersionMenus()
   await draftLoading.loadAsDraft(graphRunnerId)
 }
 

--- a/frontend/src/components/shared/VersionSelector.vue
+++ b/frontend/src/components/shared/VersionSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, toRef, watch } from 'vue'
+import { computed, nextTick, ref, toRef, watch } from 'vue'
 import GenericConfirmDialog from '@/components/dialogs/GenericConfirmDialog.vue'
 import { useVersionSorting } from '@/composables/useVersionSorting'
 import { useVersionDeployment } from '@/composables/useVersionDeployment'
@@ -66,19 +66,22 @@ const handleContextMenu = (event: MouseEvent, graphRunnerId: string) => {
   contextMenu.openMenu(event, graphRunnerId)
 }
 
-const handleDeploy = () => {
-  if (contextMenu.menuTargetId.value) {
-    deployment.deployToProduction(contextMenu.menuTargetId.value)
-    contextMenu.closeMenu()
-  }
+const handleDeploy = async () => {
+  const graphRunnerId = contextMenu.menuTargetId.value
+  if (!graphRunnerId) return
+
+  contextMenu.closeMenu()
+  await nextTick()
+  await deployment.deployToProduction(graphRunnerId)
 }
 
 const handleLoadDraft = async () => {
-  if (contextMenu.menuTargetId.value) {
-    await draftLoading.loadAsDraft(contextMenu.menuTargetId.value)
-    contextMenu.closeMenu()
-    // Callback handles emission now
-  }
+  const graphRunnerId = contextMenu.menuTargetId.value
+  if (!graphRunnerId) return
+
+  contextMenu.closeMenu()
+  await nextTick()
+  await draftLoading.loadAsDraft(graphRunnerId)
 }
 
 // Check if current menu target is production version
@@ -150,7 +153,7 @@ const isCurrentMenuTargetProduction = computed(() => {
           :disabled="
             deployment.isDeploying.value || draftLoading.isLoadingDraft.value || isCurrentMenuTargetProduction
           "
-          @click="handleDeploy"
+          @click.stop="handleDeploy"
           @contextmenu.prevent
         >
           <template #prepend>
@@ -162,7 +165,7 @@ const isCurrentMenuTargetProduction = computed(() => {
 
         <VListItem
           :disabled="deployment.isDeploying.value || draftLoading.isLoadingDraft.value"
-          @click="handleLoadDraft"
+          @click.stop="handleLoadDraft"
           @contextmenu.prevent
         >
           <template #prepend>

--- a/frontend/src/components/shared/VersionSelectorContainer.vue
+++ b/frontend/src/components/shared/VersionSelectorContainer.vue
@@ -3,6 +3,7 @@ import { computed, toRef, watch } from 'vue'
 import VersionSelector from './VersionSelector.vue'
 import { logger } from '@/utils/logger'
 import { useVersionRefresh } from '@/composables/useVersionRefresh'
+import { resolveGraphRunnerAfterVersionAction } from '@/composables/useVersionSelection'
 import { useCurrentAgent } from '@/composables/queries/useAgentsQuery'
 import { useCurrentProject } from '@/composables/queries/useProjectsQuery'
 import type { GraphRunner } from '@/types/version'
@@ -99,20 +100,14 @@ const handleDeployed = async (graphRunnerId: string, env: 'production' | 'draft'
         emit('refresh-project')
       }
 
-      // Handle case where current graph runner no longer exists (for both agents and projects)
-      if (currentGraphRunner.value) {
-        const runnerStillExists = updatedGraphRunners.some(
-          r => r.graph_runner_id === currentGraphRunner.value?.graph_runner_id
-        )
+      const runnerToSelect = resolveGraphRunnerAfterVersionAction({
+        currentGraphRunner: currentGraphRunner.value,
+        updatedGraphRunners,
+        env,
+      })
 
-        if (!runnerStillExists) {
-          // Select the new draft if available, otherwise the first runner
-          const newDraftRunner = updatedGraphRunners.find(r => r.env === 'draft')
-          const replacementRunner = newDraftRunner || updatedGraphRunners[0]
-          if (replacementRunner) {
-            setCurrentGraphRunner(replacementRunner)
-          }
-        }
+      if (runnerToSelect) {
+        setCurrentGraphRunner(runnerToSelect)
       }
     }
   } catch (error) {

--- a/frontend/src/composables/__tests__/useVersionSelection.test.ts
+++ b/frontend/src/composables/__tests__/useVersionSelection.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { resolveGraphRunnerAfterVersionAction } from '../useVersionSelection'
+import type { GraphRunner } from '@/types/version'
+
+const runner = (graphRunnerId: string, env: GraphRunner['env']): GraphRunner => ({
+  graph_runner_id: graphRunnerId,
+  env,
+  tag_name: env === 'draft' ? null : `v-${graphRunnerId}`,
+})
+
+describe('resolveGraphRunnerAfterVersionAction', () => {
+  it('selects the refreshed draft after loading a version as draft', () => {
+    const current = runner('saved-version', null)
+    const refreshedDraft = runner('new-draft', 'draft')
+
+    expect(
+      resolveGraphRunnerAfterVersionAction({
+        currentGraphRunner: current,
+        updatedGraphRunners: [current, refreshedDraft],
+        env: 'draft',
+      })
+    ).toBe(refreshedDraft)
+  })
+
+  it('keeps the current runner after production deployment when it still exists', () => {
+    const current = runner('saved-version', null)
+
+    expect(
+      resolveGraphRunnerAfterVersionAction({
+        currentGraphRunner: current,
+        updatedGraphRunners: [current, runner('draft', 'draft')],
+        env: 'production',
+      })
+    ).toBeNull()
+  })
+
+  it('falls back to the draft after production deployment removes the current runner', () => {
+    const refreshedDraft = runner('draft', 'draft')
+
+    expect(
+      resolveGraphRunnerAfterVersionAction({
+        currentGraphRunner: runner('deleted-runner', null),
+        updatedGraphRunners: [runner('production', 'production'), refreshedDraft],
+        env: 'production',
+      })
+    ).toBe(refreshedDraft)
+  })
+})

--- a/frontend/src/composables/useVersionSelection.ts
+++ b/frontend/src/composables/useVersionSelection.ts
@@ -1,0 +1,27 @@
+import type { GraphRunner } from '@/types/version'
+
+interface VersionSelectionOptions {
+  currentGraphRunner: GraphRunner | null
+  updatedGraphRunners: GraphRunner[]
+  env: 'production' | 'draft'
+}
+
+export function resolveGraphRunnerAfterVersionAction({
+  currentGraphRunner,
+  updatedGraphRunners,
+  env,
+}: VersionSelectionOptions): GraphRunner | null {
+  if (env === 'draft') {
+    return updatedGraphRunners.find(runner => runner.env === 'draft') || updatedGraphRunners[0] || null
+  }
+
+  if (!currentGraphRunner) return null
+
+  const runnerStillExists = updatedGraphRunners.some(
+    runner => runner.graph_runner_id === currentGraphRunner.graph_runner_id
+  )
+
+  if (runnerStillExists) return null
+
+  return updatedGraphRunners.find(runner => runner.env === 'draft') || updatedGraphRunners[0] || null
+}


### PR DESCRIPTION
## Summary

- Fixes the shared version selector so “Start draft from this version” switches the UI to the newly refreshed draft runner after the backend creates it.
- Extracts post-version-action runner selection into `useVersionSelection` so draft reload and production deploy behavior are covered in one place.
- Adds regression coverage for draft reload selection and preserves existing production deployment fallback behavior.
- Updates frontend docs and architecture rules for the shared version selection pattern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the shared version selector so “Start draft from this version” switches to the refreshed draft runner and keeps selection consistent for projects and agents. Also hardens context‑menu actions by closing both the menu and the underlying select overlay before opening dialogs; addresses Linear DRA-1306 by preventing stale selection after version actions.

- **Bug Fixes**
  - Switch to the refreshed draft runner after loading a version as draft.
  - Keep current runner after production deploy if it still exists; otherwise fall back to draft.
  - Ensure context‑menu actions work by snapshotting `menuTargetId`, closing both menus, awaiting Vue flush (`nextTick` twice), then opening dialogs; add `@click.stop`.
  - Add tests for draft reload selection, production fallback, and preserving current runner when it still exists.

- **Refactors**
  - Centralize runner selection in `resolveGraphRunnerAfterVersionAction` (`frontend/src/composables/useVersionSelection.ts`) and use it in `VersionSelectorContainer.vue`.
  - Update `frontend/README.md` and `.cursor/rules/architecture.mdc` with version selection and overlay teardown notes.

<sup>Written for commit 5bc4f13e3f4d4563a0617ce2987466e5f002d7ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced version selection behavior to ensure the correct runner is selected after version refresh or deployment actions. When loading a version as draft, the system now properly switches to the refreshed draft runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->