### PR TITLE
fix(version-selector): fix stuck context menu (cursor-positioned, not dropdown-anchored) DRA-1310

### DIFF
--- a/frontend/src/components/shared/VersionSelector.vue
+++ b/frontend/src/components/shared/VersionSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, toRef, watch } from 'vue'
+import { computed, ref, toRef } from 'vue'
 import GenericConfirmDialog from '@/components/dialogs/GenericConfirmDialog.vue'
 import { useVersionSorting } from '@/composables/useVersionSorting'
 import { useVersionDeployment } from '@/composables/useVersionDeployment'
@@ -42,10 +42,6 @@ const contextMenu = useContextMenu()
 // VSelect menu state
 const isSelectMenuOpen = ref(false)
 
-// Close context menu whenever the VSelect open state changes; otherwise the
-// context menu can be left open against an item element that has just unmounted.
-watch(isSelectMenuOpen, () => contextMenu.closeMenu())
-
 // Watch for deployment completion (watcher only stops spinner, doesn't emit)
 deployment.watchDeploymentCompletion(
   toRef(() => props.graphRunners),
@@ -63,6 +59,9 @@ const handleContextMenu = (event: MouseEvent, graphRunnerId: string) => {
   const runner = props.graphRunners.find(r => r.graph_runner_id === graphRunnerId)
   if (runner?.env === 'draft') return // Don't show menu for draft
 
+  // Close the dropdown so the cursor-positioned context menu is the only open overlay.
+  // Two stacked overlays is what made the menu unclickable/stuck (DRA-1310).
+  isSelectMenuOpen.value = false
   contextMenu.openMenu(event, graphRunnerId)
 }
 
@@ -136,11 +135,12 @@ const isCurrentMenuTargetProduction = computed(() => {
       </template>
     </VSelect>
 
-    <!-- Context menu for deployment actions (single shared instance, outside item loop) -->
+    <!-- Context menu for deployment actions: positioned at the cursor via coordinates rather than
+         anchored to a dropdown item (which unmounts and leaves the menu stuck) — DRA-1310. -->
     <VMenu
       v-if="projectId"
       v-model="contextMenu.menuVisible.value"
-      :activator="contextMenu.menuActivatorElement.value as any"
+      :target="[contextMenu.menuPosition.value.x, contextMenu.menuPosition.value.y]"
       location="bottom end"
       :close-on-content-click="false"
       @click:outside="contextMenu.closeMenu"

--- a/frontend/src/composables/useVersionContextMenu.ts
+++ b/frontend/src/composables/useVersionContextMenu.ts
@@ -2,30 +2,35 @@ import { ref } from 'vue'
 
 /**
  * Composable for managing context menu state and positioning.
+ *
+ * The menu is positioned by viewport coordinates (VMenu `:target="[x, y]"`) captured from the
+ * right-click event, NOT by anchoring to a DOM element. Anchoring to a list item that lives
+ * inside the VSelect dropdown overlay made the menu get stuck open / unclickable once the
+ * dropdown closed and that element unmounted (DRA-1310). This mirrors the working context-menu
+ * pattern in KnowledgeEditor.vue.
  */
 export function useContextMenu() {
   const menuVisible = ref(false)
   const menuTargetId = ref<string | null>(null)
-  const menuActivatorElement = ref<HTMLElement | null>(null)
+  const menuPosition = ref<{ x: number; y: number }>({ x: 0, y: 0 })
 
   const openMenu = (event: MouseEvent, targetId: string) => {
     event.preventDefault()
     event.stopPropagation()
-    menuActivatorElement.value = event.currentTarget as HTMLElement
+    menuPosition.value = { x: event.clientX, y: event.clientY }
     menuTargetId.value = targetId
     menuVisible.value = true
   }
 
   const closeMenu = () => {
     menuVisible.value = false
-    menuActivatorElement.value = null
     menuTargetId.value = null
   }
 
   return {
     menuVisible,
     menuTargetId,
-    menuActivatorElement,
+    menuPosition,
     openMenu,
     closeMenu,
   }


### PR DESCRIPTION
## What & why

The version dropdown's right-click context menu (Deploy / Start draft / create version from draft) was getting **stuck open and unclickable** — the floating menu stayed forever and clicks did nothing.

**Root cause:** the `VMenu` was anchored to `event.currentTarget` — a `VListItem` rendered **inside the `VSelect` dropdown overlay**. When the dropdown closed, that activator element unmounted, leaving the menu with a detached anchor (stuck open, swallowing clicks). The DRA-1268 refactor introduced this and only band-aided it with a `watch`.

**Fix** (mirrors the working context menu in `KnowledgeEditor.vue`): position the `VMenu` by the cursor coordinates from the right-click (`:target="[x, y]"`) instead of a DOM element, close the dropdown when the menu opens so it's the only overlay, and remove the band-aid `watch` / `menuActivatorElement`.

## Test plan
- [ ] Right-click a version → menu appears at the cursor, is clickable, and closes properly (no stuck-forever)
- [ ] Each action works (Deploy, Start draft, create version from draft)
- [ ] No page freeze (DRA-1268)

## Notes
- **Frontend-only.** The earlier backend clone change was dropped — it wasn't the real fix for the menu.

Related: DRA-1268 (introduced the regression).
