### PR TITLE
fix(auth): short-lived DB session in verify_api_key_dependency to stop pool exhaustion DRA-1313

### DIFF
--- a/ada_backend/routers/auth_router.py
+++ b/ada_backend/routers/auth_router.py
@@ -10,7 +10,7 @@ from supabase import Client, create_client
 
 from ada_backend.context import get_request_context
 from ada_backend.database.models import ApiKeyType
-from ada_backend.database.setup_db import get_db
+from ada_backend.database.setup_db import get_db, get_db_session
 from ada_backend.repositories.project_repository import get_project
 from ada_backend.schemas.auth_schema import (
     ApiKeyCreatedResponse,
@@ -402,10 +402,15 @@ async def delete_api_key_route(
 
 async def verify_api_key_dependency(
     x_api_key: str = Header(..., alias="X-API-Key"),
-    session: Session = Depends(get_db),
 ) -> VerifiedApiKey:
     """
     Dependency to verify an API key from the 'X-API-Key' header.
+
+    Uses a short-lived DB session (not ``Depends(get_db)``) so the connection is returned to the
+    pool right after the key lookup. This dependency guards the long-running agent-run endpoints;
+    with a request-scoped session the connection stayed checked out (idle-in-transaction on the
+    org_api_keys lookup) for the entire run, so under concurrency every in-flight request pinned a
+    pool connection and exhausted the pool, crash-looping the API (DRA-1313).
     """
     if not x_api_key:
         raise HTTPException(status_code=401, detail="Missing API key")
@@ -413,7 +418,8 @@ async def verify_api_key_dependency(
     cleaned_x_api_key = x_api_key.replace("\\n", "\n").strip('"')
 
     try:
-        return verify_api_key(session, private_key=cleaned_x_api_key)
+        with get_db_session() as session:
+            return verify_api_key(session, private_key=cleaned_x_api_key)
     except ValueError as e:
         LOGGER.error("API key verification failed", exc_info=True)
         raise HTTPException(status_code=401, detail="Invalid API key") from e
@@ -534,7 +540,6 @@ def user_has_access_to_organization_xor_verify_api_key(allowed_roles: set[str]):
         organization_id: UUID,
         authorization: HTTPAuthorizationCredentials | None = Depends(HTTPBearer(auto_error=False)),
         x_api_key: str | None = Header(None, alias="X-API-Key"),
-        session: Session = Depends(get_db),
     ) -> AuthenticatedEntity:
         """Flexible authentication: tries user auth first, falls back to API key auth."""
 
@@ -565,7 +570,7 @@ def user_has_access_to_organization_xor_verify_api_key(allowed_roles: set[str]):
 
         if x_api_key:
             try:
-                verified_api_key = await verify_api_key_dependency(x_api_key=x_api_key, session=session)
+                verified_api_key = await verify_api_key_dependency(x_api_key=x_api_key)
                 if verified_api_key.organization_id != organization_id:
                     LOGGER.exception(
                         "API Key is for organization %s => access to organization %s denied",


### PR DESCRIPTION
## Prod incident — ada-api pods crash-looping (DB pool exhaustion)

**Symptom:** `ada-api` pods crash-looping; requests failing with
`sqlalchemy.exc.TimeoutError: QueuePool limit of size 10 overflow 20 reached, connection timed out, timeout 60.00`
at `verify_project_access` → `get_project`.

**Root cause:** `verify_api_key_dependency` acquired its DB session via `Depends(get_db)`, which FastAPI keeps open for the **entire request**. This dependency guards the long-running `run_env_agent` endpoints, so on every agent call the auth connection stayed checked out (idle-in-transaction on the `org_api_keys` lookup) for the whole LLM/MCP run. Under concurrency, all 30 pool connections (size 10 + overflow 20) got pinned → new requests' auth query waited 60s, timed out, and the pods went unhealthy and restarted. (Postgres itself was healthy — 25/181 connections; the limit hit was the per-process SQLAlchemy pool.)

**Fix:** the dependency now uses a short-lived `with get_db_session()` that returns the connection to the pool immediately after the key lookup, before any long work. Also removed the now-unused request-scoped `Depends(get_db)` session from the org-access wrapper that was the only manual caller. `VerifiedApiKey` is a detached Pydantic model, so closing the session early is safe.

## Test plan
- [ ] Auth still works: valid key → 200, invalid/missing key → 401
- [ ] Under concurrent agent runs, `pg_stat_activity` no longer accumulates `idle in transaction` `org_api_keys` connections; the pool stays healthy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a short‑lived DB session for API key verification to release connections immediately and prevent pool exhaustion on long‑running agent endpoints. Addresses Linear DRA-1313 (prod `ada-api` pods crash-looping).

- **Bug Fixes**
  - Switched `verify_api_key_dependency` from request-scoped `Depends(get_db)` to `with get_db_session()` so the connection is returned right after the `org_api_keys` lookup.
  - Removed the now-unneeded `Depends(get_db)` from the org-access wrapper and updated its call to `verify_api_key_dependency`.

<sup>Written for commit e2b85b08cf2c3549890094d9f2a273b5eb36d81a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

