### PR TITLE
feat(webhook): add typefrom webhook dra-1315

### DIFF
--- a/.cursor/rules/mcp.mdc
+++ b/.cursor/rules/mcp.mdc
@@ -11,7 +11,7 @@ globs:
 - Auth: `SupabaseProvider` from FastMCP. Tokens are standard Supabase JWTs. MCP server does NOT issue its own tokens.
 - Consent page: lives in `back-office/src/pages/oauth/callback.vue`, NOT in the MCP server. Supabase redirects to `SITE_URL + authorization_path` for consent.
 - Use `get_access_token()` from `fastmcp.server.dependencies` to get the JWT; `.token` for the raw string, `.claims["sub"]` for user ID.
-- Org context: session-scoped via Redis and keyed by the MCP session ID when available. Tools must check for active org before calling org-scoped endpoints (use `require_org_context`). Developer+ operations (create/update/delete/pause/resume cron, OAuth, `create_agent`, knowledge mutations, git sync configure/disconnect) use `require_role`. `trigger_cron` is org-scoped (member+).
+- Org context: session-scoped via Redis and keyed by the MCP session ID when available. Tools must check for active org before calling org-scoped endpoints (use `require_org_context`). Developer+ operations (create/update/delete/pause/resume cron, OAuth, `create_agent`, knowledge mutations, Typeform webhook setup, git sync configure/disconnect) use `require_role`. `trigger_cron` is org-scoped (member+).
 - Workflow creation: `create_workflow` creates workflow-type projects. Agent projects use `create_agent`.
 - Target-org permissions: tools that accept an explicit `org_id` must validate the caller's role on that target organization, not only on the active org session.
 - Component search: `search_components(query)` must reject blank or whitespace-only queries instead of returning the full catalog.

--- a/.cursor/rules/routers.mdc
+++ b/.cursor/rules/routers.mdc
@@ -14,6 +14,8 @@ globs:
 - When adding a new router: register in `main.py`, add to `ada_backend/docs/api-reference.md`, update cursor rules if new patterns emerge.
 - Graph save APIs now have versioned routes; keep legacy and `/v2/...` behavior isolated with dedicated schemas to avoid breaking clients.
 - V2 graph endpoints: granular endpoints (`POST/PUT/DELETE .../components`, `PUT .../map`) for front/MCP. Git sync calls the same service functions internally (no HTTP endpoint). Both paths use the same building blocks (`create_or_update_component_instance`, `upsert_component_node`, `upsert_edge`, etc.).
+- Provider webhook endpoints that use raw-body signatures must verify the signature before parsing JSON.
+- Provider webhook signature, configuration, not-found, and queueing failures are `ServiceError` subclasses; let the global handler translate them instead of remapping them in the router.
 
 ## WebSocket Router Pattern
 

--- a/.cursor/rules/services.mdc
+++ b/.cursor/rules/services.mdc
@@ -16,4 +16,5 @@ globs:
 - Never log full parameter dicts after `replace_secret_placeholders()`; log only parameter names (`list(params.keys())`). Apply the same rule to structured `extra=` logger kwargs.
 - Prefer UUID-typed identifiers in service-facing schemas and payload models; only stringify UUIDs at API/JSON boundaries.
 - Prefer typed schemas/models for service return payloads; avoid untyped `dict` returns when a stable shape exists.
+- Public callback URLs for provider integrations must be built from explicit settings such as `ADA_URL`; do not hardcode production fallbacks.
 - See `ada_backend/docs/` for domain-specific documentation.

--- a/ada_backend/database/alembic/versions/a4b5c6d7e8f9_add_typeform_webhooks.py
+++ b/ada_backend/database/alembic/versions/a4b5c6d7e8f9_add_typeform_webhooks.py
@@ -1,0 +1,30 @@
+"""add typeform webhooks
+
+Revision ID: a4b5c6d7e8f9
+Revises: 9b1f8e3a4c2d
+Create Date: 2026-06-10 10:55:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a4b5c6d7e8f9"
+down_revision: Union[str, None] = "9b1f8e3a4c2d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+deploy_strategy = "migrate-first"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE webhook_provider ADD VALUE IF NOT EXISTS 'typeform'")
+
+    op.add_column("webhooks", sa.Column("encrypted_signing_secret", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("webhooks", "encrypted_signing_secret")

--- a/ada_backend/database/models.py
+++ b/ada_backend/database/models.py
@@ -143,6 +143,7 @@ class WebhookProvider(StrEnum):
     RESEND = "resend"
     AIRCALL = "aircall"
     SLACK = "slack"
+    TYPEFORM = "typeform"
     DIRECT_TRIGGER = "direct_trigger"
 
 
@@ -2416,6 +2417,7 @@ class Webhook(Base):
     organization_id = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     provider = mapped_column(make_pg_enum(WebhookProvider), nullable=False)
     external_client_id = mapped_column(String, nullable=False)
+    encrypted_signing_secret = mapped_column(String, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
@@ -2426,6 +2428,14 @@ class Webhook(Base):
 
     def __str__(self):
         return f"Webhook(id={self.id}, provider={self.provider}, external_client_id={self.external_client_id[:4]}...)"
+
+    def set_signing_secret(self, signing_secret: str) -> None:
+        self.encrypted_signing_secret = CIPHER.encrypt(signing_secret.encode()).decode()
+
+    def get_signing_secret(self) -> str | None:
+        if not self.encrypted_signing_secret:
+            return None
+        return CIPHER.decrypt(self.encrypted_signing_secret.encode()).decode()
 
 
 class IntegrationTrigger(Base):

--- a/ada_backend/docs/api-reference.md
+++ b/ada_backend/docs/api-reference.md
@@ -196,6 +196,8 @@ Run input data is persisted in the `run_inputs` table (keyed by `retry_group_id`
 | POST | `/webhooks/trigger/{project_id}/envs/{env}` | ApiKey | User-triggered webhook |
 | POST | `/webhooks/aircall` | Public | Aircall provider webhook |
 | POST | `/webhooks/resend` | Public | Resend provider webhook |
+| POST | `/webhooks/typeform/{webhook_id}` | Public | Typeform provider webhook with `Typeform-Signature` verification |
+| POST | `/projects/{project_id}/webhooks/typeform` | JWT(Developer) | Create/reuse Typeform webhook setup and return callback URL plus one-time signing secret |
 | POST | `/internal/webhooks/{webhook_id}/execute` | WebhookKey | Internal: execute webhook |
 | POST | `/internal/webhooks/projects/{project_id}/envs/{env}/run` | WebhookKey | Internal: enqueue run |
 

--- a/ada_backend/docs/webhooks.md
+++ b/ada_backend/docs/webhooks.md
@@ -6,19 +6,26 @@ Draft'n Run has three webhook patterns: provider webhooks (external services pus
 
 **Router**: `routers/webhooks/provider_webhooks_router.py`
 
-External services (Aircall, Resend) push events directly to the backend:
+External services (Aircall, Resend, Typeform) push events directly to the backend:
 
 | Endpoint | Provider | Verification |
 |---|---|---|
 | `POST /webhooks/aircall` | Aircall | Token in payload |
 | `POST /webhooks/resend` | Resend | Svix signature header |
+| `POST /webhooks/typeform/{webhook_id}` | Typeform | `Typeform-Signature` HMAC SHA-256 header over the raw request body |
 
-Both endpoints:
+Provider endpoints:
+
 1. Verify provider-specific signature/token
 2. Deduplicate via Redis SET NX with TTL (`check_and_set_webhook_event`)
 3. Push to Redis Stream (`REDIS_WEBHOOK_STREAM`) via XADD
 
-**Providers** (enum `WebhookProvider`): `resend`, `aircall`, `slack`, `direct_trigger`.
+Raw-body signatures, such as Typeform's HMAC header, are verified before parsing JSON so malformed unauthenticated payloads are rejected by the signature check first.
+Webhook service failures, including signature, configuration, not-found, and queueing errors, propagate as `ServiceError` subclasses and are translated by the global error handler.
+
+**Providers** (enum `WebhookProvider`): `resend`, `aircall`, `slack`, `typeform`, `direct_trigger`.
+
+Typeform setup is project-scoped via `POST /projects/{project_id}/webhooks/typeform` (developer role). The setup response returns a `callback_url` and a `signing_secret` when a webhook is created or rotated. The callback URL is built from `ADA_URL`; setup fails if `ADA_URL` is not configured so webhooks cannot be pointed at the wrong environment. Paste the callback URL into Typeform's webhook URL and the signing secret into Typeform's webhook secret field. Existing webhooks do not return the stored secret again unless `rotate_secret=true`.
 
 ## Pattern 2: User-Triggered Webhooks
 
@@ -53,7 +60,7 @@ reusing the parent `cron_run_id`.
 
 ## Event Routing
 
-### Provider webhooks (Aircall, Resend)
+### Provider webhooks (Aircall, Resend, Typeform)
 
 ```text
 Provider → POST /webhooks/{provider}
@@ -105,7 +112,7 @@ The worker maps these markers to processing outcomes and applies ACK policy acco
 
 ## Data Model
 
-- **`Webhook`** (`webhooks`): `organization_id`, `provider`, `external_client_id`. Indexed by `(provider, external_client_id)`.
+- **`Webhook`** (`webhooks`): `organization_id`, `provider`, `external_client_id`, `encrypted_signing_secret` (nullable, used by Typeform). Indexed by `(provider, external_client_id)`.
 - **`IntegrationTrigger`** (`integration_triggers`): Links webhook → project. Has `events` (JSONB), `events_hash`, `enabled`, `filter_options` (JSONB). Unique on `(webhook_id, events_hash, project_id)`.
 - **`Run`** (`runs`): `event_id` (nullable) links the run back to the originating webhook event. For direct triggers, the Run is created before enqueue so it's visible in DB throughout the entire lifecycle.
 
@@ -133,11 +140,14 @@ When a webhook- or cron-triggered run transitions to `FAILED`, an email alert is
 
 ## Key Files
 
-- `routers/webhooks/provider_webhooks_router.py` — Aircall, Resend endpoints
+- `routers/webhooks/provider_webhooks_router.py` — Aircall, Resend, Typeform receiver endpoints
+- `routers/webhooks/webhook_config_router.py` — Typeform setup endpoint
 - `routers/webhooks/webhook_trigger_router.py` — user-triggered webhook
 - `routers/webhooks/webhook_internal_router.py` — worker-called endpoints
 - `routers/alert_email_router.py` — CRUD for alert email recipients
 - `services/webhooks/webhook_service.py` — execution, filtering, input preparation
+- `services/webhooks/typeform_service.py` — Typeform signature verification and event IDs
+- `services/webhooks/typeform_setup_service.py` — Typeform webhook setup
 - `services/alerting/alert_service.py` — run failure alert logic
 - `services/alerting/email_service.py` — Resend email sending wrapper
 - `schemas/webhook_schema.py` — Pydantic schemas

--- a/ada_backend/main.py
+++ b/ada_backend/main.py
@@ -56,6 +56,7 @@ from ada_backend.routers.template_router import router as template_router
 from ada_backend.routers.trace_router import router as trace_router
 from ada_backend.routers.variables_router import org_router as variables_router
 from ada_backend.routers.webhooks.provider_webhooks_router import router as provider_webhooks_router
+from ada_backend.routers.webhooks.webhook_config_router import router as webhook_config_router
 from ada_backend.routers.webhooks.webhook_internal_router import router as webhook_internal_router
 from ada_backend.routers.webhooks.webhook_trigger_router import router as webhook_trigger_router
 from ada_backend.routers.widget_router import router as widget_router
@@ -290,6 +291,7 @@ app.include_router(widget_router)
 app.include_router(git_sync_webhook_router)
 app.include_router(git_sync_org_router)
 app.include_router(provider_webhooks_router)
+app.include_router(webhook_config_router)
 app.include_router(webhook_internal_router)
 app.include_router(webhook_trigger_router)
 app.include_router(scheduler_internal_router)

--- a/ada_backend/repositories/webhook_repository.py
+++ b/ada_backend/repositories/webhook_repository.py
@@ -9,6 +9,12 @@ from ada_backend.database import models as db
 LOGGER = logging.getLogger(__name__)
 
 
+def get_webhook_by_id_and_provider(
+    session: Session, webhook_id: UUID, provider: db.WebhookProvider
+) -> Optional[db.Webhook]:
+    return session.query(db.Webhook).filter(db.Webhook.id == webhook_id, db.Webhook.provider == provider).first()
+
+
 def get_webhook_by_external_client_id(
     session: Session, provider: db.WebhookProvider, external_client_id: str
 ) -> Optional[db.Webhook]:

--- a/ada_backend/routers/webhooks/provider_webhooks_router.py
+++ b/ada_backend/routers/webhooks/provider_webhooks_router.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, Dict
+from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
@@ -17,6 +18,10 @@ from ada_backend.services.webhooks.errors import (
 from ada_backend.services.webhooks.resend_service import (
     get_resend_webhook_service,
     verify_svix_signature,
+)
+from ada_backend.services.webhooks.typeform_service import (
+    get_typeform_webhook_service,
+    verify_typeform_signature,
 )
 from ada_backend.services.webhooks.webhook_service import process_webhook_event
 
@@ -67,12 +72,13 @@ async def receive_resend_webhook(
 ):
     try:
         raw_body = await request.body()
-        payload = await request.json()
 
         webhook = get_resend_webhook_service(session)
 
         headers_dict = dict(request.headers)
         verify_svix_signature(headers_dict, raw_body, webhook.external_client_id)
+
+        payload = await request.json()
 
         result = await process_webhook_event(
             provider=WebhookProvider.RESEND,
@@ -100,3 +106,34 @@ async def receive_resend_webhook(
     except Exception as e:
         LOGGER.error(f"Error processing Resend webhook: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post("/webhooks/typeform/{webhook_id}")
+async def receive_typeform_webhook(
+    webhook_id: UUID,
+    request: Request,
+    session: Session = Depends(get_db),
+):
+    raw_body = await request.body()
+
+    webhook = get_typeform_webhook_service(session, webhook_id)
+    signing_secret = webhook.get_signing_secret()
+
+    verify_typeform_signature(dict(request.headers), raw_body, signing_secret)
+
+    payload = await request.json()
+
+    result = await process_webhook_event(
+        provider=WebhookProvider.TYPEFORM,
+        payload=payload,
+        webhook=webhook,
+    )
+
+    if result.status not in [
+        WebhookProcessingStatus.DUPLICATE,
+        WebhookProcessingStatus.RECEIVED,
+    ]:
+        error_message = "Failed to process Typeform webhook"
+        LOGGER.error(f"Failed to process Typeform webhook: {result.status}", exc_info=True)
+        raise HTTPException(status_code=400, detail=error_message)
+    return {"status": "ok"}

--- a/ada_backend/routers/webhooks/webhook_config_router.py
+++ b/ada_backend/routers/webhooks/webhook_config_router.py
@@ -1,0 +1,32 @@
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ada_backend.database.setup_db import get_db
+from ada_backend.routers.auth_router import UserRights, user_has_access_to_project_dependency
+from ada_backend.schemas.auth_schema import SupabaseUser
+from ada_backend.schemas.webhook_schema import TypeformWebhookCreateRequest, TypeformWebhookCreateResponse
+from ada_backend.services.webhooks.typeform_setup_service import create_typeform_webhook_service
+
+router = APIRouter(prefix="/projects/{project_id}/webhooks", tags=["Webhooks"])
+
+
+@router.post("/typeform", response_model=TypeformWebhookCreateResponse, status_code=201)
+def create_typeform_webhook(
+    project_id: UUID,
+    body: TypeformWebhookCreateRequest,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_project_dependency(allowed_roles=UserRights.DEVELOPER.value)),
+    ],
+    session: Session = Depends(get_db),
+) -> TypeformWebhookCreateResponse:
+    return create_typeform_webhook_service(
+        session=session,
+        project_id=project_id,
+        events=body.events,
+        filter_options=body.filter_options,
+        rotate_secret=body.rotate_secret,
+    )

--- a/ada_backend/schemas/webhook_schema.py
+++ b/ada_backend/schemas/webhook_schema.py
@@ -77,3 +77,20 @@ class WebhookExecuteResponse(BaseModel):
     processed: int
     total: int
     results: List[WebhookExecuteResult]
+
+
+class TypeformWebhookCreateRequest(BaseModel):
+    events: Optional[Dict[str, Any]] = None
+    filter_options: Optional[Dict[str, Any]] = None
+    rotate_secret: bool = Field(default=False, description="Generate a new Typeform signing secret for this webhook.")
+
+
+class TypeformWebhookCreateResponse(BaseModel):
+    webhook_id: UUID
+    integration_trigger_id: UUID
+    callback_url: str
+    signing_secret: Optional[str] = None
+    secret_available: bool = Field(
+        default=False,
+        description="True when signing_secret is included in this response.",
+    )

--- a/ada_backend/services/webhooks/errors.py
+++ b/ada_backend/services/webhooks/errors.py
@@ -22,6 +22,8 @@ class WebhookEmptyTokenError(WebhookServiceError):
 class WebhookNotFoundError(WebhookServiceError):
     """Raised when a webhook is not found."""
 
+    status_code = 404
+
     def __init__(self, provider: WebhookProvider, external_client_id: str):
         self.provider = provider
         self.external_client_id = external_client_id
@@ -69,7 +71,7 @@ class WebhookQueueError(WebhookServiceError):
 
 
 class WebhookSignatureVerificationError(WebhookServiceError):
-    """Raised when Svix signature verification fails."""
+    """Raised when webhook signature verification fails."""
 
     status_code = 401
 

--- a/ada_backend/services/webhooks/typeform_service.py
+++ b/ada_backend/services/webhooks/typeform_service.py
@@ -1,0 +1,55 @@
+import base64
+import hashlib
+import hmac
+from typing import Any, Dict
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ada_backend.database.models import Webhook, WebhookProvider
+from ada_backend.repositories.webhook_repository import get_webhook_by_id_and_provider
+from ada_backend.services.webhooks.errors import (
+    WebhookConfigurationError,
+    WebhookEventIdNotFoundError,
+    WebhookNotFoundError,
+    WebhookSignatureVerificationError,
+)
+
+
+def get_typeform_webhook_service(session: Session, webhook_id: UUID) -> Webhook:
+    webhook = get_webhook_by_id_and_provider(session, webhook_id, WebhookProvider.TYPEFORM)
+    if not webhook:
+        raise WebhookNotFoundError(provider=WebhookProvider.TYPEFORM, external_client_id=str(webhook_id))
+    if not webhook.get_signing_secret():
+        raise WebhookConfigurationError(
+            provider=WebhookProvider.TYPEFORM,
+            message=f"Webhook {webhook_id} has no signing secret configured",
+        )
+    return webhook
+
+
+def get_typeform_event_id(payload: Dict[str, Any]) -> str:
+    form_response = payload.get("form_response") or {}
+    event_id = payload.get("event_id") or form_response.get("token")
+    if not event_id:
+        raise WebhookEventIdNotFoundError(provider=WebhookProvider.TYPEFORM, payload=payload)
+    return str(event_id)
+
+
+def verify_typeform_signature(headers: Dict[str, str], raw_body: bytes, signing_secret: str) -> None:
+    received_signature = headers.get("typeform-signature")
+    if not received_signature:
+        raise WebhookSignatureVerificationError("Missing Typeform-Signature header")
+
+    try:
+        algorithm, signature = received_signature.split("=", 1)
+    except ValueError as e:
+        raise WebhookSignatureVerificationError("Malformed Typeform-Signature header") from e
+
+    if algorithm != "sha256" or not signature:
+        raise WebhookSignatureVerificationError("Unsupported Typeform signature algorithm")
+
+    digest = hmac.new(signing_secret.encode("utf-8"), raw_body, hashlib.sha256).digest()
+    expected_signature = base64.b64encode(digest).decode()
+    if not hmac.compare_digest(signature, expected_signature):
+        raise WebhookSignatureVerificationError("Invalid Typeform signature")

--- a/ada_backend/services/webhooks/typeform_setup_service.py
+++ b/ada_backend/services/webhooks/typeform_setup_service.py
@@ -1,0 +1,119 @@
+import hashlib
+import json
+import secrets
+from typing import Any, Dict
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ada_backend.database.models import IntegrationTrigger, Webhook, WebhookProvider
+from ada_backend.repositories.project_repository import get_project
+from ada_backend.schemas.webhook_schema import TypeformWebhookCreateResponse
+from ada_backend.services.errors import ProjectNotFound
+from ada_backend.services.webhooks.errors import WebhookConfigurationError
+from settings import settings
+
+
+def create_typeform_webhook_service(
+    session: Session,
+    project_id: UUID,
+    events: Dict[str, Any] | None = None,
+    filter_options: Dict[str, Any] | None = None,
+    rotate_secret: bool = False,
+) -> TypeformWebhookCreateResponse:
+    project = get_project(session, project_id)
+    if not project:
+        raise ProjectNotFound(project_id)
+
+    events_hash = _generate_events_hash(events)
+    webhook = _get_typeform_webhook_for_project(session, project_id)
+    secret_to_return: str | None = None
+
+    if webhook is None:
+        secret_to_return = _generate_signing_secret()
+        webhook = Webhook(
+            organization_id=project.organization_id,
+            provider=WebhookProvider.TYPEFORM,
+            external_client_id=f"typeform:{project_id}",
+        )
+        webhook.set_signing_secret(secret_to_return)
+        session.add(webhook)
+        session.flush()
+    elif rotate_secret or not webhook.get_signing_secret():
+        secret_to_return = _generate_signing_secret()
+        webhook.set_signing_secret(secret_to_return)
+        session.flush()
+
+    trigger = _get_typeform_trigger(session, webhook.id, project_id, events_hash)
+    if trigger is None:
+        trigger = IntegrationTrigger(
+            webhook_id=webhook.id,
+            project_id=project_id,
+            events=events,
+            events_hash=events_hash,
+            enabled=True,
+            filter_options=filter_options,
+        )
+        session.add(trigger)
+        session.flush()
+    else:
+        trigger.filter_options = filter_options
+        trigger.enabled = True
+        session.flush()
+
+    session.commit()
+    session.refresh(webhook)
+    session.refresh(trigger)
+
+    return TypeformWebhookCreateResponse(
+        webhook_id=webhook.id,
+        integration_trigger_id=trigger.id,
+        callback_url=_build_typeform_callback_url(webhook.id),
+        signing_secret=secret_to_return,
+        secret_available=secret_to_return is not None,
+    )
+
+
+def _generate_events_hash(events: Dict[str, Any] | None) -> str:
+    events_json = json.dumps(events or {}, sort_keys=True)
+    return hashlib.sha256(events_json.encode()).hexdigest()
+
+
+def _generate_signing_secret() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def _get_typeform_webhook_for_project(session: Session, project_id: UUID) -> Webhook | None:
+    return (
+        session.query(Webhook)
+        .join(IntegrationTrigger, IntegrationTrigger.webhook_id == Webhook.id)
+        .filter(
+            Webhook.provider == WebhookProvider.TYPEFORM,
+            IntegrationTrigger.project_id == project_id,
+        )
+        .first()
+    )
+
+
+def _get_typeform_trigger(
+    session: Session,
+    webhook_id: UUID,
+    project_id: UUID,
+    events_hash: str,
+) -> IntegrationTrigger | None:
+    return (
+        session.query(IntegrationTrigger)
+        .filter(
+            IntegrationTrigger.webhook_id == webhook_id,
+            IntegrationTrigger.project_id == project_id,
+            IntegrationTrigger.events_hash == events_hash,
+        )
+        .first()
+    )
+
+
+def _build_typeform_callback_url(webhook_id: UUID) -> str:
+    if not settings.ADA_URL:
+        raise WebhookConfigurationError(WebhookProvider.TYPEFORM, "ADA_URL is not configured")
+    base_url = settings.ADA_URL
+    return f"{base_url.rstrip('/')}/webhooks/typeform/{webhook_id}"

--- a/ada_backend/services/webhooks/webhook_service.py
+++ b/ada_backend/services/webhooks/webhook_service.py
@@ -35,6 +35,7 @@ from ada_backend.services.webhooks.resend_service import (
     get_resend_event_id,
     prepare_resend_workflow_input,
 )
+from ada_backend.services.webhooks.typeform_service import get_typeform_event_id
 from ada_backend.utils.redis_client import (
     check_and_set_webhook_event,
     push_webhook_event,
@@ -82,6 +83,8 @@ def get_webhook_event_id(payload: Dict[str, Any], provider: WebhookProvider) -> 
         return get_aircall_event_id(payload)
     elif provider == WebhookProvider.RESEND:
         return get_resend_event_id(payload)
+    elif provider == WebhookProvider.TYPEFORM:
+        return get_typeform_event_id(payload)
     else:
         LOGGER.error(f"Webhook event id not found for provider: {provider}")
         raise WebhookEventIdNotFoundError(provider=provider, payload=payload)

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -75,7 +75,7 @@ All domain content lives in `docs.py` (single source of truth).
 
 ## Tool Reference
 
-~94 tools across 15 modules. Use `get_guide(domain)` or the docs:// resources above for detailed usage.
+~95 tools across 16 modules. Use `get_guide(domain)` or the docs:// resources above for detailed usage.
 
 | Module | Tools | Highlights |
 |---|---|---|
@@ -95,6 +95,7 @@ All domain content lives in `docs.py` (single source of truth).
 | OAuth | 3 | List, check status, revoke |
 | Alert Emails | 3 | `list_alert_emails`, `create_alert_email`, `delete_alert_email` — per-project run failure recipients (developer+) |
 | Git Sync | 4 | `configure_git_sync`, `list_git_sync_configs`, `get_git_sync_config`, `disconnect_git_sync` — scan a GitHub repo for `graph.json` files, create projects + sync configs; one-way deploy on push (developer+) |
+| Webhooks | 1 | `create_typeform_webhook` — create/reuse a Typeform webhook and return the callback URL plus signing secret when created/rotated (developer+) |
 | **Docs** | **1** | **`get_guide(domain)` — fallback for domain docs** |
 
 `get_project_overview(project_id)` is the default orientation tool for any version-aware work. It returns the editable draft runner, current production runner, production-only capability hints, warnings, and safe next steps.
@@ -129,7 +130,7 @@ Custom tools (validation, multi-step, client-side logic) are still defined as `@
 
 | Guard | Description |
 |---|---|
-| RBAC | Variables/secrets require admin. Deletions require developer+. `create_agent`, cron writes (create/update/delete/pause/resume), OAuth tools, and `update_document_chunks` require developer+. `trigger_cron` requires member role or above. `invite_org_member` checks admin/super_admin on the target org, not just the active org. |
+| RBAC | Variables/secrets require admin. Deletions require developer+. `create_agent`, cron writes (create/update/delete/pause/resume), OAuth tools, `create_typeform_webhook`, and `update_document_chunks` require developer+. `trigger_cron` requires member role or above. `invite_org_member` checks admin/super_admin on the target org, not just the active org. |
 | Component search | `search_components` rejects blank or whitespace-only queries. |
 | Release stage | Component catalog auto-filtered by org tier. Cannot be overridden by the AI. |
 | Agent name | `create_agent` rejects empty/whitespace names. |

--- a/mcp_server/docs.py
+++ b/mcp_server/docs.py
@@ -1700,6 +1700,17 @@ Alerts require `RESEND_API_KEY` and `RESEND_FROM_EMAIL` to be configured on the 
 If either is missing, alerting silently no-ops. Only runs triggered by webhooks or crons fire alerts \
 (API/sandbox/QA runs do not).
 
+## Webhooks
+
+Typeform webhooks can be registered from MCP for a project:
+
+- `create_typeform_webhook(project_id, events?, filter_options?, rotate_secret=false)` → creates or reuses \
+a Typeform webhook, creates the project trigger, and returns `callback_url`. The response includes \
+`signing_secret` only when the webhook secret is newly created or rotated. Developer+.
+
+Paste `callback_url` into Typeform's webhook URL and `signing_secret` into Typeform's webhook secret field. \
+If the secret is lost, call again with `rotate_secret=true` and update the secret in Typeform.
+
 ## Git Sync
 
 One-way deploy from a GitHub repo to Draft'n Run. On each push to the watched branch, \
@@ -1762,7 +1773,7 @@ DOMAIN_DESCRIPTIONS: dict[str, str] = {
     "integrations": "Function-callable tools, OAuth lifecycle, integration-backed components",
     "known-quirks": "Backend/MCP caveats that require explicit workarounds",
     "qa": "QA datasets, judges, evaluations",
-    "admin": "API keys, crons, OAuth, monitoring, alert emails, git sync",
+    "admin": "API keys, crons, OAuth, monitoring, alert emails, webhooks, git sync",
 }
 
 

--- a/mcp_server/tools/__init__.py
+++ b/mcp_server/tools/__init__.py
@@ -23,6 +23,7 @@ def register_all_tools(mcp: FastMCP) -> None:
         qa,
         runs,
         variables,
+        webhooks,
     )
 
     modules = [
@@ -42,6 +43,7 @@ def register_all_tools(mcp: FastMCP) -> None:
         oauth_connections,
         alert_emails,
         git_sync,
+        webhooks,
     ]
     for module in modules:
         try:

--- a/mcp_server/tools/webhooks.py
+++ b/mcp_server/tools/webhooks.py
@@ -1,0 +1,37 @@
+"""Webhook setup tools."""
+
+from uuid import UUID
+
+from fastmcp import FastMCP
+
+from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
+
+DEVELOPER_ROLES = ("developer", "admin", "super_admin")
+
+SPECS: list[ToolSpec] = [
+    ToolSpec(
+        name="create_typeform_webhook",
+        description=(
+            "Create or reuse a Typeform webhook for a project and return the callback URL plus signing secret. "
+            "Requires developer role. If the webhook already exists, signing_secret is only returned when "
+            "rotate_secret is true."
+        ),
+        method="post",
+        path="/projects/{project_id}/webhooks/typeform",
+        scope="role",
+        roles=DEVELOPER_ROLES,
+        path_params=(
+            Param("project_id", UUID, description="Project ID from list_projects or get_project_overview."),
+        ),
+        body_fields=(
+            Param("events", dict, default=None, description="Optional Typeform event filter metadata."),
+            Param("filter_options", dict, default=None, description="Optional Draft'n Run trigger filter options."),
+            Param("rotate_secret", bool, default=False, description="Generate and return a new signing secret."),
+        ),
+        return_annotation=dict,
+    ),
+]
+
+
+def register(mcp: FastMCP) -> None:
+    register_proxy_tools(mcp, SPECS)

--- a/tests/ada_backend/routers/test_provider_webhooks_router.py
+++ b/tests/ada_backend/routers/test_provider_webhooks_router.py
@@ -1,0 +1,205 @@
+import base64
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from ada_backend.database.models import Webhook, WebhookProvider
+from ada_backend.routers.webhooks.provider_webhooks_router import receive_resend_webhook, receive_typeform_webhook
+from ada_backend.schemas.webhook_schema import WebhookProcessingResponseSchema, WebhookProcessingStatus
+from ada_backend.services.webhooks.errors import WebhookNotFoundError, WebhookSignatureVerificationError
+
+
+def _request(body: bytes, headers: dict[str, str]) -> Request:
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/webhooks/typeform/test",
+            "headers": [(key.lower().encode(), value.encode()) for key, value in headers.items()],
+        },
+        receive,
+    )
+
+
+def _typeform_signature(secret: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).digest()
+    return "sha256=" + base64.b64encode(digest).decode()
+
+
+def _invalid_svix_headers() -> dict[str, str]:
+    return {
+        "svix-id": "msg_1",
+        "svix-timestamp": "123",
+        "svix-signature": "invalid",
+    }
+
+
+@pytest.mark.asyncio
+async def test_receive_resend_webhook_rejects_invalid_signature_before_parsing_json():
+    webhook = Webhook(
+        id=uuid4(),
+        organization_id=uuid4(),
+        provider=WebhookProvider.RESEND,
+        external_client_id="resend-secret",
+    )
+
+    with (
+        patch(
+            "ada_backend.routers.webhooks.provider_webhooks_router.get_resend_webhook_service",
+            return_value=webhook,
+        ),
+        patch(
+            "ada_backend.routers.webhooks.provider_webhooks_router.process_webhook_event",
+            new=AsyncMock(),
+        ) as process_mock,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await receive_resend_webhook(
+                request=_request(b'{"id":', _invalid_svix_headers()),
+                session=MagicMock(),
+            )
+
+    assert exc_info.value.status_code == 401
+    process_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_receive_typeform_webhook_verifies_and_queues():
+    webhook_id = uuid4()
+    secret = "typeform-secret"
+    payload = {"event_id": "evt-1", "form_response": {"token": "token-1"}}
+    raw_body = json.dumps(payload, separators=(",", ":")).encode()
+    webhook = Webhook(
+        id=webhook_id,
+        organization_id=uuid4(),
+        provider=WebhookProvider.TYPEFORM,
+        external_client_id=f"typeform:{webhook_id}",
+    )
+    webhook.set_signing_secret(secret)
+
+    with (
+        patch(
+            "ada_backend.routers.webhooks.provider_webhooks_router.get_typeform_webhook_service",
+            return_value=webhook,
+        ),
+        patch(
+            "ada_backend.routers.webhooks.provider_webhooks_router.process_webhook_event",
+            new=AsyncMock(
+                return_value=WebhookProcessingResponseSchema(
+                    status=WebhookProcessingStatus.RECEIVED,
+                    processed=False,
+                    event_id="evt-1",
+                )
+            ),
+        ) as process_mock,
+    ):
+        response = await receive_typeform_webhook(
+            webhook_id=webhook_id,
+            request=_request(raw_body, {"Typeform-Signature": _typeform_signature(secret, raw_body)}),
+            session=MagicMock(),
+        )
+
+    assert response == {"status": "ok"}
+    process_mock.assert_awaited_once_with(
+        provider=WebhookProvider.TYPEFORM,
+        payload=payload,
+        webhook=webhook,
+    )
+
+
+@pytest.mark.asyncio
+async def test_receive_typeform_webhook_rejects_invalid_signature_before_queueing():
+    webhook_id = uuid4()
+    webhook = Webhook(
+        id=webhook_id,
+        organization_id=uuid4(),
+        provider=WebhookProvider.TYPEFORM,
+        external_client_id=f"typeform:{webhook_id}",
+    )
+    webhook.set_signing_secret("typeform-secret")
+
+    with (
+        patch(
+            "ada_backend.routers.webhooks.provider_webhooks_router.get_typeform_webhook_service",
+            return_value=webhook,
+        ),
+        patch(
+            "ada_backend.routers.webhooks.provider_webhooks_router.process_webhook_event",
+            new=AsyncMock(),
+        ) as process_mock,
+    ):
+        with pytest.raises(WebhookSignatureVerificationError) as exc_info:
+            await receive_typeform_webhook(
+                webhook_id=webhook_id,
+                request=_request(b'{"event_id":"evt-1"}', {"Typeform-Signature": "sha256=invalid"}),
+                session=MagicMock(),
+            )
+
+    assert exc_info.value.status_code == 401
+    process_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_receive_typeform_webhook_rejects_invalid_signature_before_parsing_json():
+    webhook_id = uuid4()
+    webhook = Webhook(
+        id=webhook_id,
+        organization_id=uuid4(),
+        provider=WebhookProvider.TYPEFORM,
+        external_client_id=f"typeform:{webhook_id}",
+    )
+    webhook.set_signing_secret("typeform-secret")
+
+    with (
+        patch(
+            "ada_backend.routers.webhooks.provider_webhooks_router.get_typeform_webhook_service",
+            return_value=webhook,
+        ),
+        patch(
+            "ada_backend.routers.webhooks.provider_webhooks_router.process_webhook_event",
+            new=AsyncMock(),
+        ) as process_mock,
+    ):
+        with pytest.raises(WebhookSignatureVerificationError) as exc_info:
+            await receive_typeform_webhook(
+                webhook_id=webhook_id,
+                request=_request(b'{"event_id":', {"Typeform-Signature": "sha256=invalid"}),
+                session=MagicMock(),
+            )
+
+    assert exc_info.value.status_code == 401
+    process_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_receive_typeform_webhook_propagates_service_errors():
+    webhook_id = uuid4()
+
+    with (
+        patch(
+            "ada_backend.routers.webhooks.provider_webhooks_router.get_typeform_webhook_service",
+            side_effect=WebhookNotFoundError(provider=WebhookProvider.TYPEFORM, external_client_id=str(webhook_id)),
+        ),
+        patch(
+            "ada_backend.routers.webhooks.provider_webhooks_router.process_webhook_event",
+            new=AsyncMock(),
+        ) as process_mock,
+    ):
+        with pytest.raises(WebhookNotFoundError) as exc_info:
+            await receive_typeform_webhook(
+                webhook_id=webhook_id,
+                request=_request(b'{"event_id":"evt-1"}', {"Typeform-Signature": "sha256=invalid"}),
+                session=MagicMock(),
+            )
+
+    assert exc_info.value.status_code == 404
+    process_mock.assert_not_called()

--- a/tests/ada_backend/services/test_typeform_service.py
+++ b/tests/ada_backend/services/test_typeform_service.py
@@ -1,0 +1,168 @@
+import base64
+import hashlib
+import hmac
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from ada_backend.database.models import IntegrationTrigger, Webhook, WebhookProvider
+from ada_backend.services.webhooks.errors import (
+    WebhookConfigurationError,
+    WebhookEventIdNotFoundError,
+    WebhookSignatureVerificationError,
+)
+from ada_backend.services.webhooks.typeform_service import get_typeform_event_id, verify_typeform_signature
+from ada_backend.services.webhooks.typeform_setup_service import (
+    _build_typeform_callback_url,
+    create_typeform_webhook_service,
+)
+
+
+def _typeform_signature(secret: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).digest()
+    return "sha256=" + base64.b64encode(digest).decode()
+
+
+def test_verify_typeform_signature_accepts_valid_signature():
+    secret = "typeform-secret"
+    body = b'{"event_id":"evt-1"}'
+
+    verify_typeform_signature(
+        {"typeform-signature": _typeform_signature(secret, body)},
+        body,
+        secret,
+    )
+
+
+def test_verify_typeform_signature_rejects_invalid_signature():
+    with pytest.raises(WebhookSignatureVerificationError):
+        verify_typeform_signature(
+            {"typeform-signature": "sha256=invalid"},
+            b'{"event_id":"evt-1"}',
+            "typeform-secret",
+        )
+
+
+def test_verify_typeform_signature_requires_header():
+    with pytest.raises(WebhookSignatureVerificationError):
+        verify_typeform_signature({}, b"{}", "typeform-secret")
+
+
+def test_verify_typeform_signature_rejects_malformed_header():
+    with pytest.raises(WebhookSignatureVerificationError):
+        verify_typeform_signature({"typeform-signature": "not-a-signature"}, b"{}", "typeform-secret")
+
+
+def test_get_typeform_event_id_uses_event_id():
+    assert get_typeform_event_id({"event_id": "evt-1", "form_response": {"token": "token-1"}}) == "evt-1"
+
+
+def test_get_typeform_event_id_falls_back_to_response_token():
+    assert get_typeform_event_id({"form_response": {"token": "token-1"}}) == "token-1"
+
+
+def test_get_typeform_event_id_raises_when_missing():
+    with pytest.raises(WebhookEventIdNotFoundError):
+        get_typeform_event_id({"form_response": {}})
+
+
+def test_create_typeform_webhook_creates_encrypted_secret_and_trigger():
+    session = MagicMock()
+    project_id = uuid4()
+    organization_id = uuid4()
+    webhook_id = uuid4()
+    trigger_id = uuid4()
+    added = []
+
+    def add_side_effect(item):
+        added.append(item)
+
+    def flush_side_effect():
+        for item in added:
+            if isinstance(item, Webhook) and item.id is None:
+                item.id = webhook_id
+            if isinstance(item, IntegrationTrigger) and item.id is None:
+                item.id = trigger_id
+
+    session.add.side_effect = add_side_effect
+    session.flush.side_effect = flush_side_effect
+
+    with (
+        patch("ada_backend.services.webhooks.typeform_setup_service.get_project") as get_project_mock,
+        patch(
+            "ada_backend.services.webhooks.typeform_setup_service._get_typeform_webhook_for_project", return_value=None
+        ),
+        patch("ada_backend.services.webhooks.typeform_setup_service._get_typeform_trigger", return_value=None),
+        patch(
+            "ada_backend.services.webhooks.typeform_setup_service._generate_signing_secret",
+            return_value="created-secret",
+        ),
+        patch("ada_backend.services.webhooks.typeform_setup_service.settings.ADA_URL", "https://ada.example.test/"),
+    ):
+        get_project_mock.return_value = SimpleNamespace(id=project_id, organization_id=organization_id)
+        response = create_typeform_webhook_service(session=session, project_id=project_id)
+
+    created_webhook = next(item for item in added if isinstance(item, Webhook))
+    created_trigger = next(item for item in added if isinstance(item, IntegrationTrigger))
+
+    assert created_webhook.provider == WebhookProvider.TYPEFORM
+    assert created_webhook.external_client_id == f"typeform:{project_id}"
+    assert created_webhook.encrypted_signing_secret is not None
+    assert created_webhook.get_signing_secret() == "created-secret"
+    assert created_trigger.webhook_id == webhook_id
+    assert created_trigger.project_id == project_id
+    assert response.webhook_id == webhook_id
+    assert response.integration_trigger_id == trigger_id
+    assert response.callback_url == f"https://ada.example.test/webhooks/typeform/{webhook_id}"
+    assert response.signing_secret == "created-secret"
+    assert response.secret_available is True
+    session.commit.assert_called_once()
+
+
+def test_create_typeform_webhook_reuses_existing_without_returning_secret():
+    session = MagicMock()
+    project_id = uuid4()
+    webhook = Webhook(
+        id=uuid4(),
+        organization_id=uuid4(),
+        provider=WebhookProvider.TYPEFORM,
+        external_client_id=f"typeform:{project_id}",
+    )
+    webhook.set_signing_secret("existing-secret")
+    trigger = IntegrationTrigger(
+        id=uuid4(),
+        webhook_id=webhook.id,
+        project_id=project_id,
+        events_hash="events-hash",
+        enabled=True,
+    )
+
+    with (
+        patch("ada_backend.services.webhooks.typeform_setup_service.get_project") as get_project_mock,
+        patch(
+            "ada_backend.services.webhooks.typeform_setup_service._get_typeform_webhook_for_project",
+            return_value=webhook,
+        ),
+        patch("ada_backend.services.webhooks.typeform_setup_service._get_typeform_trigger", return_value=trigger),
+        patch("ada_backend.services.webhooks.typeform_setup_service.settings.ADA_URL", "https://ada.example.test"),
+    ):
+        get_project_mock.return_value = SimpleNamespace(id=project_id, organization_id=webhook.organization_id)
+        response = create_typeform_webhook_service(session=session, project_id=project_id)
+
+    assert response.webhook_id == webhook.id
+    assert response.integration_trigger_id == trigger.id
+    assert response.callback_url == f"https://ada.example.test/webhooks/typeform/{webhook.id}"
+    assert response.signing_secret is None
+    assert response.secret_available is False
+    assert webhook.get_signing_secret() == "existing-secret"
+    session.add.assert_not_called()
+
+
+def test_build_typeform_callback_url_requires_ada_url():
+    with (
+        patch("ada_backend.services.webhooks.typeform_setup_service.settings.ADA_URL", None),
+        pytest.raises(WebhookConfigurationError, match="ADA_URL is not configured"),
+    ):
+        _build_typeform_callback_url(uuid4())

--- a/tests/mcp_server/test_webhooks_tools.py
+++ b/tests/mcp_server/test_webhooks_tools.py
@@ -1,0 +1,15 @@
+from uuid import UUID
+
+from mcp_server.tools.webhooks import SPECS
+
+
+def test_create_typeform_webhook_tool_spec():
+    spec = next(item for item in SPECS if item.name == "create_typeform_webhook")
+
+    assert spec.method == "post"
+    assert spec.path == "/projects/{project_id}/webhooks/typeform"
+    assert spec.scope == "role"
+    assert spec.roles == ("developer", "admin", "super_admin")
+    assert spec.path_params[0].name == "project_id"
+    assert spec.path_params[0].annotation is UUID
+    assert [param.name for param in spec.body_fields] == ["events", "filter_options", "rotate_secret"]


### PR DESCRIPTION
# Add Typeform as a provider webhook

## Summary
- Add Typeform as a provider webhook with Typeform-Signature HMAC SHA-256 verification over the raw request body.
- Add a project-scoped Typeform webhook setup API and MCP tool that creates/reuses webhook config, stores the signing secret encrypted, and returns the callback URL plus one-time secret.
- Wire Typeform events into the existing webhook dedupe, Redis queue, worker, and run execution flow, with docs and MCP guidance updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Typeform as a provider webhook with raw-body HMAC SHA-256 verification and a project-scoped setup flow. Implements DRA-1315 so projects can securely receive Typeform events, with an MCP tool to create or rotate the secret.

- New Features
  - POST `/webhooks/typeform/{webhook_id}` verifies `Typeform-Signature` over the raw body before parsing JSON, then dedupes, enqueues, and executes.
  - POST `/projects/{project_id}/webhooks/typeform` creates/reuses a webhook and trigger; returns `callback_url`, `integration_trigger_id`, and one-time `signing_secret` on create/rotate; includes `secret_available`; supports `rotate_secret=true` and optional `events`/`filter_options`.
  - Callback URL is built from `ADA_URL`; setup fails if not configured.
  - Added `WebhookProvider.TYPEFORM`, `webhooks.encrypted_signing_secret`, and model helpers to encrypt/decrypt the secret.
  - Updated Resend path to verify signature on the raw body before JSON parse.
  - Errors for signature, not-found, and configuration use `ServiceError` with proper status codes; global handler translates them.
  - MCP tool `create_typeform_webhook` (developer+) calls the setup endpoint; docs and tests updated.

- Migration
  - Alembic: add `typeform` to `webhook_provider` enum and `encrypted_signing_secret` column on `webhooks`.
  - No changes required for existing providers.

<sup>Written for commit f3d1b588f9c1e748bccdffbb6f2b50f51eacfc5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

