### PR TITLE
feat(components): add text as an injectable artifact in python code dra-1317

### DIFF
--- a/.cursor/rules/engine.mdc
+++ b/.cursor/rules/engine.mdc
@@ -19,6 +19,7 @@ globs:
 - `GoogleProvider` must not replay prior assistant `tool_calls` in multi-turn function-calling requests; Gemini requires hidden `thought_signature` data that the OpenAI-compatible response does not expose. Preserve tool outputs by converting `tool` role messages into user-visible tool-result context.
 - `requires_tool_name = True` for components that need a `tool_name` input (MCP tools, API tools).
 - Legacy system: some components still use `AgentPayload` pattern (`migrated = False`). New components MUST use the multi-port `NodeData` system (`migrated = True`).
+- Python Code Runner keeps the full E2B payload in `artifacts.execution_result`; when a text result exists, it also exposes `artifacts.text` for `@{{instance.artifacts::text}}` injection.
 - `SQLLocalService` engine pools are cached per `engine_url` (process-level). Avoid patterns that instantiate many services for the same URL expecting independent pools.
 - In ingestion code paths, reuse one `SQLLocalService` per job when possible, and ensure `await close()` is called in a `finally` block.
 - `IS_CLOUD_S3` controls folder-source ingestion URL strategy: keep it `False` in local/dev and custom `S3_ENDPOINT_URL` setups (direct file reads; presigned URL getter returns `None`), set it `True` in cloud AWS S3 prod to require presigned URL generation and fail fast on missing URLs.

--- a/.cursor/rules/engine.mdc
+++ b/.cursor/rules/engine.mdc
@@ -19,7 +19,7 @@ globs:
 - `GoogleProvider` must not replay prior assistant `tool_calls` in multi-turn function-calling requests; Gemini requires hidden `thought_signature` data that the OpenAI-compatible response does not expose. Preserve tool outputs by converting `tool` role messages into user-visible tool-result context.
 - `requires_tool_name = True` for components that need a `tool_name` input (MCP tools, API tools).
 - Legacy system: some components still use `AgentPayload` pattern (`migrated = False`). New components MUST use the multi-port `NodeData` system (`migrated = True`).
-- Python Code Runner keeps the full E2B payload in `artifacts.execution_result`; when a text result exists, it also exposes `artifacts.text` for `@{{instance.artifacts::text}}` injection.
+- Python Code Runner keeps the full E2B payload in `artifacts.execution_result`; when a text result exists, it also exposes `artifacts.text` for `@{{instance.artifacts::text}}` injection. Shared E2B sandboxes from tracing context must pass a current-loop async health check before reuse; stale or closed-loop clients are discarded and replaced.
 - `SQLLocalService` engine pools are cached per `engine_url` (process-level). Avoid patterns that instantiate many services for the same URL expecting independent pools.
 - In ingestion code paths, reuse one `SQLLocalService` per job when possible, and ensure `await close()` is called in a `finally` block.
 - `IS_CLOUD_S3` controls folder-source ingestion URL strategy: keep it `False` in local/dev and custom `S3_ENDPOINT_URL` setups (direct file reads; presigned URL getter returns `None`), set it `True` in cloud AWS S3 prod to require presigned URL generation and fail fast on missing URLs.

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -70,6 +70,10 @@ The concrete base class implementing `Runnable`. Key attributes:
 text result, it also exposes that value as `artifacts.text` so downstream field expressions can inject it with
 `@{{<python_runner_instance_id>.artifacts::text}}` without relying on nested array traversal.
 
+When a tracing context provides `shared_sandbox`, the runner reuses it only after a successful async health check on the
+current event loop. If the health check fails, including closed-loop errors from a previously cached E2B client, the helper
+discards the stale sandbox and creates a fresh one for the current context.
+
 ### Component Catalog Lifecycle
 
 When removing a component from the product, delete the runtime class, registry entry, seed data, existing DB catalog rows (with a migration), default tool description, and wrapper components that only exist to call it. Leaving only part of the catalog wiring in place can keep a dead component instantiable through backend seeds or MCP graph validation even after it disappears from the front-end.

--- a/ada_backend/docs/engine.md
+++ b/ada_backend/docs/engine.md
@@ -64,6 +64,12 @@ The concrete base class implementing `Runnable`. Key attributes:
 
 **`_run_without_io_trace(inputs: BaseModel, ctx: dict) -> BaseModel`** is the abstract method subclasses implement.
 
+### Python Code Runner Artifacts
+
+`PythonCodeRunner` preserves the full E2B execution payload at `artifacts.execution_result`. When the execution returns a
+text result, it also exposes that value as `artifacts.text` so downstream field expressions can inject it with
+`@{{<python_runner_instance_id>.artifacts::text}}` without relying on nested array traversal.
+
 ### Component Catalog Lifecycle
 
 When removing a component from the product, delete the runtime class, registry entry, seed data, existing DB catalog rows (with a migration), default tool description, and wrapper components that only exist to call it. Leaving only part of the catalog wiring in place can keep a dead component instantiable through backend seeds or MCP graph validation even after it disappears from the front-end.

--- a/engine/components/tools/python_code_runner.py
+++ b/engine/components/tools/python_code_runner.py
@@ -46,6 +46,20 @@ def _serialize_result(result) -> dict:
     }
 
 
+def _extract_injectable_text(execution_result: dict) -> str | None:
+    results = execution_result.get("results") or []
+    if not isinstance(results, list):
+        return None
+
+    main_results = [result for result in results if isinstance(result, dict) and result.get("is_main_result")]
+    for result in main_results + [result for result in results if isinstance(result, dict)]:
+        text = result.get("text")
+        if isinstance(text, str):
+            return text
+
+    return None
+
+
 PYTHON_CODE_RUNNER_TOOL_DESCRIPTION = ToolDescription(
     name="python_code_runner",
     description=(
@@ -382,6 +396,9 @@ class PythonCodeRunner(Component):
 
         images_paths = self._save_images_from_results(execution_result_dict, records)
         artifacts = {"execution_result": execution_result_dict}
+        injectable_text = _extract_injectable_text(execution_result_dict)
+        if injectable_text is not None:
+            artifacts["text"] = injectable_text
         if images_paths:
             artifacts["images"] = images_paths
             content += (

--- a/engine/components/tools/sandbox_utils.py
+++ b/engine/components/tools/sandbox_utils.py
@@ -7,19 +7,42 @@ from engine.trace.span_context import get_tracing_span
 LOGGER = logging.getLogger(__name__)
 
 
+async def _clear_shared_sandbox(params, reason: str) -> None:
+    sandbox = params.shared_sandbox
+    if sandbox is None:
+        return
+    params.shared_sandbox = None
+    LOGGER.warning("Discarding shared E2B sandbox: %s", reason)
+    try:
+        await sandbox.kill()
+    except RuntimeError as e:
+        LOGGER.warning("Failed to kill discarded shared E2B sandbox: %s", e)
+    except Exception as e:
+        LOGGER.warning("Failed to kill discarded shared E2B sandbox: %s", e, exc_info=True)
+
+
 async def get_or_create_sandbox(api_key: str) -> tuple[AsyncSandbox, bool]:
     params = get_tracing_span()
     should_cleanup_locally = False
     sandbox: AsyncSandbox | None = None
 
     if params and params.shared_sandbox:
-        if await params.shared_sandbox.is_running():
+        try:
+            is_running = await params.shared_sandbox.is_running()
+        except RuntimeError as e:
+            await _clear_shared_sandbox(params, str(e))
+            is_running = False
+        except Exception as e:
+            await _clear_shared_sandbox(params, str(e))
+            is_running = False
+
+        if is_running:
             LOGGER.info("Shared sandbox is running, using it")
             sandbox = params.shared_sandbox
         else:
             LOGGER.info("Shared sandbox is not running, killing it")
-            await params.shared_sandbox.kill()
-            params.shared_sandbox = None
+            if params.shared_sandbox:
+                await _clear_shared_sandbox(params, "shared sandbox is not running")
 
     if sandbox is None:
         LOGGER.info("Creating new sandbox")

--- a/tests/components/test_python_code_runner.py
+++ b/tests/components/test_python_code_runner.py
@@ -194,6 +194,57 @@ async def test_run_without_io_trace_success(
 
 
 @pytest.mark.asyncio
+@patch("engine.components.tools.python_code_runner.get_output_dir")
+async def test_run_without_io_trace_exposes_text_artifact(mock_get_output_dir, python_code_runner_tool):
+    execution_result = {
+        "results": [
+            {
+                "text": "first result",
+                "html": None,
+                "markdown": None,
+                "svg": None,
+                "png": None,
+                "jpeg": None,
+                "pdf": None,
+                "latex": None,
+                "json": None,
+                "javascript": None,
+                "data": None,
+                "chart": None,
+                "is_main_result": False,
+                "extra": {},
+            },
+            {
+                "text": "main result",
+                "html": None,
+                "markdown": None,
+                "svg": None,
+                "png": None,
+                "jpeg": None,
+                "pdf": None,
+                "latex": None,
+                "json": None,
+                "javascript": None,
+                "data": None,
+                "chart": None,
+                "is_main_result": True,
+                "extra": {},
+            },
+        ],
+        "stdout": [],
+        "stderr": [],
+        "error": None,
+        "execution_count": 1,
+    }
+    python_code_runner_tool.execute_python_code = AsyncMock(return_value=(execution_result, []))
+
+    result = await python_code_runner_tool._run_without_io_trace(PythonCodeRunnerToolInputs(python_code="2 + 2"), {})
+
+    assert result.artifacts["execution_result"] == execution_result
+    assert result.artifacts["text"] == "main result"
+
+
+@pytest.mark.asyncio
 @patch("engine.components.tools.sandbox_utils.AsyncSandbox")
 @patch("engine.components.tools.sandbox_utils.get_tracing_span")
 @patch("engine.components.tools.python_code_runner.get_output_dir")

--- a/tests/components/test_sandbox_utils.py
+++ b/tests/components/test_sandbox_utils.py
@@ -1,0 +1,29 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from engine.components.tools.sandbox_utils import get_or_create_sandbox
+
+
+@pytest.mark.asyncio
+@patch("engine.components.tools.sandbox_utils.AsyncSandbox")
+@patch("engine.components.tools.sandbox_utils.get_tracing_span")
+async def test_get_or_create_sandbox_replaces_shared_sandbox_with_closed_event_loop(
+    mock_get_tracing_span, mock_sandbox_class
+):
+    stale_sandbox = AsyncMock()
+    stale_sandbox.is_running.side_effect = RuntimeError("Event loop is closed")
+    stale_sandbox.kill.side_effect = RuntimeError("Event loop is closed")
+    new_sandbox = AsyncMock()
+    params = Mock(shared_sandbox=stale_sandbox)
+    mock_get_tracing_span.return_value = params
+    mock_sandbox_class.create = AsyncMock(return_value=new_sandbox)
+
+    sandbox, should_cleanup_locally = await get_or_create_sandbox("test_api_key")
+
+    assert sandbox is new_sandbox
+    assert should_cleanup_locally is False
+    assert params.shared_sandbox is new_sandbox
+    stale_sandbox.is_running.assert_awaited_once()
+    stale_sandbox.kill.assert_awaited_once()
+    mock_sandbox_class.create.assert_awaited_once_with(api_key="test_api_key")


### PR DESCRIPTION
# Python code runner: Add text as an injectable artifact

## Summary

- Expose Python Code Runner text results as `artifacts.text` so downstream components can inject them with `@{{<instance_id>.artifacts::text}}`.
- Preserve the existing `artifacts.execution_result` payload unchanged for backward compatibility.
- Document the new injectable artifact alias and add regression coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose Python Code Runner text output as `artifacts.text` while keeping the full E2B payload at `artifacts.execution_result`. Adds a health check for shared E2B sandboxes to avoid reusing stale clients. Addresses Linear DRA-1317.

- **New Features**
  - Adds `artifacts.text` when a text result exists; inject via `@{{<instance_id>.artifacts::text}}`.
  - Prefers the main result’s text; falls back to the first text result.
  - Updates docs and engine rules; adds tests.

- **Bug Fixes**
  - Reuses `shared_sandbox` only after an async health check; discards/kills stale or closed-loop E2B clients and creates a fresh sandbox. Adds tests and docs.

<sup>Written for commit 0fe381b30cfa9826c7ed293782b7a40e2eeeb00a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

