### PR TITLE
fix(mcp): full MCP server audit — security, correctness, RBAC, annotations, infra DRA-1318

### DIFF
--- a/ada_backend/routers/organization_router.py
+++ b/ada_backend/routers/organization_router.py
@@ -8,7 +8,11 @@ from sqlalchemy.orm import Session
 from ada_backend.database.setup_db import get_db
 from ada_backend.routers.auth_router import UserRights, user_has_access_to_organization_xor_verify_api_key
 from ada_backend.schemas.auth_schema import AuthenticatedEntity
-from ada_backend.schemas.organization_schema import OrganizationGetSecretKeysResponse, OrganizationSecretResponse
+from ada_backend.schemas.organization_schema import (
+    OrganizationGetSecretKeysResponse,
+    OrganizationSecretResponse,
+    OrganizationSecretUpsertRequest,
+)
 from ada_backend.services.organization_service import (
     delete_secret_to_org_service,
     get_secret_keys_service,
@@ -54,15 +58,24 @@ def get_secret_keys(
 async def add_or_update_secret_to_organization(
     organization_id: UUID,
     secret_key: str,
-    secret: str,
     auth: Annotated[
         AuthenticatedEntity,
         Depends(user_has_access_to_organization_xor_verify_api_key(allowed_roles=UserRights.ADMIN.value)),
     ],
+    body: OrganizationSecretUpsertRequest | None = None,
+    # Deprecated: query-string transport leaks secret values into access logs.
+    # Kept until all clients send the JSON body.
+    secret: str | None = None,
     sqlaclhemy_db_session: Session = Depends(get_db),
 ) -> OrganizationSecretResponse:
+    secret_value = body.value if body is not None else secret
+    if not secret_value:
+        raise HTTPException(
+            status_code=422,
+            detail='Provide the secret value in the JSON body: {"value": "..."}',
+        )
     try:
-        return await upsert_secret_to_org_service(sqlaclhemy_db_session, organization_id, secret_key, secret)
+        return await upsert_secret_to_org_service(sqlaclhemy_db_session, organization_id, secret_key, secret_value)
     except ValueError as e:
         LOGGER.error(
             f"Failed to upsert secret {secret_key} for organization {organization_id}: {str(e)}", exc_info=True

--- a/ada_backend/routers/organization_router.py
+++ b/ada_backend/routers/organization_router.py
@@ -58,24 +58,20 @@ def get_secret_keys(
 async def add_or_update_secret_to_organization(
     organization_id: UUID,
     secret_key: str,
+    body: OrganizationSecretUpsertRequest,
     auth: Annotated[
         AuthenticatedEntity,
         Depends(user_has_access_to_organization_xor_verify_api_key(allowed_roles=UserRights.ADMIN.value)),
     ],
-    body: OrganizationSecretUpsertRequest | None = None,
-    # Deprecated: query-string transport leaks secret values into access logs.
-    # Kept until all clients send the JSON body.
-    secret: str | None = None,
     sqlaclhemy_db_session: Session = Depends(get_db),
 ) -> OrganizationSecretResponse:
-    secret_value = body.value if body is not None else secret
-    if not secret_value:
+    if not body.value:
         raise HTTPException(
             status_code=422,
             detail='Provide the secret value in the JSON body: {"value": "..."}',
         )
     try:
-        return await upsert_secret_to_org_service(sqlaclhemy_db_session, organization_id, secret_key, secret_value)
+        return await upsert_secret_to_org_service(sqlaclhemy_db_session, organization_id, secret_key, body.value)
     except ValueError as e:
         LOGGER.error(
             f"Failed to upsert secret {secret_key} for organization {organization_id}: {str(e)}", exc_info=True

--- a/ada_backend/routers/trace_router.py
+++ b/ada_backend/routers/trace_router.py
@@ -87,19 +87,21 @@ async def get_span_trace(
 ):
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
-    await _check_user_access_to_trace(user, trace_id, session)
+    project_id = await _check_user_access_to_trace(user, trace_id, session)
     try:
-        response = get_span_trace_service(user.id, trace_id)
+        response = get_span_trace_service(user.id, trace_id, project_id)
         return response
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-async def _check_user_access_to_trace(user: SupabaseUser, trace_id: str, session: Session) -> None:
+async def _check_user_access_to_trace(user: SupabaseUser, trace_id: str, session: Session) -> UUID:
     """Verify the user belongs to the org owning the trace's project.
 
     The trace_id is not project-scoped in the URL, so tenancy must be resolved
-    from the trace's spans before returning span contents.
+    from the trace's spans before returning span contents. Returns the trace's
+    project_id so the span query can be scoped to it — spans from any other
+    project that happened to share a trace_id are never returned.
     """
     project_id = query_trace_project_id(trace_id)
     if project_id is None:
@@ -113,3 +115,4 @@ async def _check_user_access_to_trace(user: SupabaseUser, trace_id: str, session
         raise HTTPException(status_code=403, detail="You don't have access to this trace") from e
     if access.role not in UserRights.MEMBER.value:
         raise HTTPException(status_code=403, detail="You don't have access to this trace")
+    return project_id

--- a/ada_backend/routers/trace_router.py
+++ b/ada_backend/routers/trace_router.py
@@ -16,10 +16,12 @@ from ada_backend.routers.auth_router import (
 )
 from ada_backend.schemas.auth_schema import SupabaseUser
 from ada_backend.schemas.trace_schema import PaginatedRootTracesResponse, TraceSpan
+from ada_backend.services.metrics.utils import query_trace_project_ids
 from ada_backend.services.trace_service import (
     get_root_traces_by_project,
     get_span_trace_service,
 )
+from ada_backend.services.user_roles_service import get_user_access_to_organization
 
 LOGGER = logging.getLogger(__name__)
 
@@ -77,17 +79,38 @@ async def get_root_traces(
         raise HTTPException(status_code=400, detail=f"Invalid parameters for trace search on project {project_id}")
 
 
-# TODO: use user_has_access_to_project_dependency :
-# needs a change in frontend to give project_id in body or as url param
 @router.get("/traces/{trace_id}/tree", response_model=TraceSpan, tags=["Metrics"])
 async def get_span_trace(
     trace_id: str,
     user: Annotated[SupabaseUser, Depends(get_user_from_supabase_token)],
+    session: Session = Depends(get_db),
 ):
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
+    await _check_user_access_to_trace(user, trace_id, session)
     try:
         response = get_span_trace_service(user.id, trace_id)
         return response
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+async def _check_user_access_to_trace(user: SupabaseUser, trace_id: str, session: Session) -> None:
+    """Verify the user belongs to the org owning the trace's project.
+
+    The trace_id is not project-scoped in the URL, so tenancy must be resolved
+    from the trace's spans before returning span contents.
+    """
+    project_ids = query_trace_project_ids(trace_id)
+    if not project_ids:
+        raise HTTPException(status_code=404, detail="Trace not found")
+    for project_id in project_ids:
+        project = get_project(session, project_id)
+        if not project:
+            raise HTTPException(status_code=404, detail="Trace not found")
+        try:
+            access = await get_user_access_to_organization(user=user, organization_id=project.organization_id)
+        except ValueError as e:
+            raise HTTPException(status_code=403, detail="You don't have access to this trace") from e
+        if access.role not in UserRights.MEMBER.value:
+            raise HTTPException(status_code=403, detail="You don't have access to this trace")

--- a/ada_backend/routers/trace_router.py
+++ b/ada_backend/routers/trace_router.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from ada_backend.database.models import CallType, EnvType
-from ada_backend.database.setup_db import get_db
+from ada_backend.database.setup_db import get_db, get_db_session
 from ada_backend.repositories.project_repository import get_project
 from ada_backend.routers.auth_router import (
     UserRights,
@@ -83,11 +83,10 @@ async def get_root_traces(
 async def get_span_trace(
     trace_id: str,
     user: Annotated[SupabaseUser, Depends(get_user_from_supabase_token)],
-    session: Session = Depends(get_db),
 ):
     if not user.id:
         raise HTTPException(status_code=400, detail="User ID not found")
-    project_id = await _check_user_access_to_trace(user, trace_id, session)
+    project_id = await _check_user_access_to_trace(user, trace_id)
     try:
         response = get_span_trace_service(user.id, trace_id, project_id)
         return response
@@ -95,7 +94,7 @@ async def get_span_trace(
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-async def _check_user_access_to_trace(user: SupabaseUser, trace_id: str, session: Session) -> UUID:
+async def _check_user_access_to_trace(user: SupabaseUser, trace_id: str) -> UUID:
     """Verify the user belongs to the org owning the trace's project.
 
     The trace_id is not project-scoped in the URL, so tenancy must be resolved
@@ -106,7 +105,8 @@ async def _check_user_access_to_trace(user: SupabaseUser, trace_id: str, session
     project_id = query_trace_project_id(trace_id)
     if project_id is None:
         raise HTTPException(status_code=404, detail="Trace not found")
-    project = get_project(session, project_id)
+    with get_db_session() as session:
+        project = get_project(session, project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Trace not found")
     try:

--- a/ada_backend/routers/trace_router.py
+++ b/ada_backend/routers/trace_router.py
@@ -16,7 +16,7 @@ from ada_backend.routers.auth_router import (
 )
 from ada_backend.schemas.auth_schema import SupabaseUser
 from ada_backend.schemas.trace_schema import PaginatedRootTracesResponse, TraceSpan
-from ada_backend.services.metrics.utils import query_trace_project_ids
+from ada_backend.services.metrics.utils import query_trace_project_id
 from ada_backend.services.trace_service import (
     get_root_traces_by_project,
     get_span_trace_service,
@@ -101,16 +101,15 @@ async def _check_user_access_to_trace(user: SupabaseUser, trace_id: str, session
     The trace_id is not project-scoped in the URL, so tenancy must be resolved
     from the trace's spans before returning span contents.
     """
-    project_ids = query_trace_project_ids(trace_id)
-    if not project_ids:
+    project_id = query_trace_project_id(trace_id)
+    if project_id is None:
         raise HTTPException(status_code=404, detail="Trace not found")
-    for project_id in project_ids:
-        project = get_project(session, project_id)
-        if not project:
-            raise HTTPException(status_code=404, detail="Trace not found")
-        try:
-            access = await get_user_access_to_organization(user=user, organization_id=project.organization_id)
-        except ValueError as e:
-            raise HTTPException(status_code=403, detail="You don't have access to this trace") from e
-        if access.role not in UserRights.MEMBER.value:
-            raise HTTPException(status_code=403, detail="You don't have access to this trace")
+    project = get_project(session, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Trace not found")
+    try:
+        access = await get_user_access_to_organization(user=user, organization_id=project.organization_id)
+    except ValueError as e:
+        raise HTTPException(status_code=403, detail="You don't have access to this trace") from e
+    if access.role not in UserRights.MEMBER.value:
+        raise HTTPException(status_code=403, detail="You don't have access to this trace")

--- a/ada_backend/schemas/organization_schema.py
+++ b/ada_backend/schemas/organization_schema.py
@@ -8,6 +8,10 @@ class OrganizationSecretResponse(BaseModel):
     secret_key: str
 
 
+class OrganizationSecretUpsertRequest(BaseModel):
+    value: str
+
+
 class OrganizationGetSecretKeysResponse(BaseModel):
     organization_id: UUID
     secret_keys: list[str]

--- a/ada_backend/services/metrics/utils.py
+++ b/ada_backend/services/metrics/utils.py
@@ -254,7 +254,7 @@ def _safe_jsonb_first_element(raw_content: str | None) -> dict:
         return {}
 
 
-def query_trace_by_trace_id(trace_id: UUID) -> pd.DataFrame:
+def query_trace_by_trace_id(trace_id: str) -> pd.DataFrame:
     # TODO: add credits per unit
     query = (
         "WITH span_credits AS ("
@@ -264,7 +264,7 @@ def query_trace_by_trace_id(trace_id: UUID) -> pd.DataFrame:
         "        COALESCE(su.credits_per_call, 0))::numeric, 0) as credits "
         "  FROM credits.span_usages su "
         "  JOIN traces.spans s ON s.span_id = su.span_id "
-        f"  WHERE s.trace_rowid = '{trace_id}' "
+        "  WHERE s.trace_rowid = %(trace_id)s "
         "  GROUP BY su.span_id "
         ") "
         "SELECT s.*, m.input_content, m.output_content, "
@@ -275,15 +275,27 @@ def query_trace_by_trace_id(trace_id: UUID) -> pd.DataFrame:
         "FROM traces.spans s "
         "LEFT JOIN traces.span_messages m ON m.span_id = s.span_id "
         "LEFT JOIN span_credits sc ON sc.span_id = s.span_id "
-        f"WHERE s.trace_rowid = '{trace_id}' "
+        "WHERE s.trace_rowid = %(trace_id)s "
         "ORDER BY s.start_time ASC;"
     )
     session = get_session_trace()
-    df = pd.read_sql_query(query, session.bind)
+    df = pd.read_sql_query(query, session.bind, params={"trace_id": str(trace_id)})
     session.close()
     df["attributes"] = df["attributes"].apply(lambda x: json.loads(x) if isinstance(x, str) else x)
     df = df.replace({np.nan: None})
     return df
+
+
+def query_trace_project_ids(trace_id: str) -> List[UUID]:
+    """Return the distinct project IDs that the trace's spans belong to."""
+    session = get_session_trace()
+    result = session.execute(
+        text("SELECT DISTINCT project_id FROM traces.spans WHERE trace_rowid = :trace_id"),
+        {"trace_id": str(trace_id)},
+    )
+    rows = result.fetchall()
+    session.close()
+    return [UUID(str(row[0])) for row in rows if row[0] is not None]
 
 
 def calculate_calls_per_day(df: pd.DataFrame, all_dates_df: pd.DataFrame) -> pd.DataFrame:

--- a/ada_backend/services/metrics/utils.py
+++ b/ada_backend/services/metrics/utils.py
@@ -286,16 +286,14 @@ def query_trace_by_trace_id(trace_id: str) -> pd.DataFrame:
     return df
 
 
-def query_trace_project_ids(trace_id: str) -> List[UUID]:
-    """Return the distinct project IDs that the trace's spans belong to."""
-    session = get_session_trace()
-    result = session.execute(
-        text("SELECT DISTINCT project_id FROM traces.spans WHERE trace_rowid = :trace_id"),
-        {"trace_id": str(trace_id)},
-    )
-    rows = result.fetchall()
-    session.close()
-    return [UUID(str(row[0])) for row in rows if row[0] is not None]
+def query_trace_project_id(trace_id: str) -> Optional[UUID]:
+    """Return the project ID a trace belongs to, or None if the trace has no spans."""
+    with get_session_trace() as session:
+        row = session.execute(
+            text("SELECT project_id FROM traces.spans WHERE trace_rowid = :trace_id LIMIT 1"),
+            {"trace_id": str(trace_id)},
+        ).first()
+    return UUID(str(row[0])) if row and row[0] is not None else None
 
 
 def calculate_calls_per_day(df: pd.DataFrame, all_dates_df: pd.DataFrame) -> pd.DataFrame:

--- a/ada_backend/services/metrics/utils.py
+++ b/ada_backend/services/metrics/utils.py
@@ -344,8 +344,7 @@ def count_conversations_per_day(df: pd.DataFrame, all_dates_df: pd.DataFrame) ->
             lambda x: x.get("conversation_id")
         )
         conversation_id_usage_with_id = (
-            df_with_conversation_id
-            .groupby("date")["conversation_id"]
+            df_with_conversation_id.groupby("date")["conversation_id"]
             .nunique()
             .reset_index(name="unique_conversation_ids")
         )
@@ -355,8 +354,7 @@ def count_conversations_per_day(df: pd.DataFrame, all_dates_df: pd.DataFrame) ->
 
         if not df_without_conversation_id.empty:
             conversation_id_usage_without_id = (
-                df_without_conversation_id
-                .groupby("date")["trace_rowid"]
+                df_without_conversation_id.groupby("date")["trace_rowid"]
                 .nunique()
                 .reset_index(name="unique_conversation_ids")
             )

--- a/ada_backend/services/metrics/utils.py
+++ b/ada_backend/services/metrics/utils.py
@@ -254,8 +254,10 @@ def _safe_jsonb_first_element(raw_content: str | None) -> dict:
         return {}
 
 
-def query_trace_by_trace_id(trace_id: str) -> pd.DataFrame:
+def query_trace_by_trace_id(trace_id: str, project_id: UUID) -> pd.DataFrame:
     # TODO: add credits per unit
+    # Scoped to the authorized project so spans from another tenant that would
+    # share a trace_id are never returned.
     query = (
         "WITH span_credits AS ("
         "  SELECT "
@@ -264,7 +266,7 @@ def query_trace_by_trace_id(trace_id: str) -> pd.DataFrame:
         "        COALESCE(su.credits_per_call, 0))::numeric, 0) as credits "
         "  FROM credits.span_usages su "
         "  JOIN traces.spans s ON s.span_id = su.span_id "
-        "  WHERE s.trace_rowid = %(trace_id)s "
+        "  WHERE s.trace_rowid = %(trace_id)s AND s.project_id = %(project_id)s "
         "  GROUP BY su.span_id "
         ") "
         "SELECT s.*, m.input_content, m.output_content, "
@@ -275,11 +277,11 @@ def query_trace_by_trace_id(trace_id: str) -> pd.DataFrame:
         "FROM traces.spans s "
         "LEFT JOIN traces.span_messages m ON m.span_id = s.span_id "
         "LEFT JOIN span_credits sc ON sc.span_id = s.span_id "
-        "WHERE s.trace_rowid = %(trace_id)s "
+        "WHERE s.trace_rowid = %(trace_id)s AND s.project_id = %(project_id)s "
         "ORDER BY s.start_time ASC;"
     )
     session = get_session_trace()
-    df = pd.read_sql_query(query, session.bind, params={"trace_id": str(trace_id)})
+    df = pd.read_sql_query(query, session.bind, params={"trace_id": str(trace_id), "project_id": str(project_id)})
     session.close()
     df["attributes"] = df["attributes"].apply(lambda x: json.loads(x) if isinstance(x, str) else x)
     df = df.replace({np.nan: None})

--- a/ada_backend/services/trace_service.py
+++ b/ada_backend/services/trace_service.py
@@ -181,7 +181,7 @@ def build_root_spans(rows: List[dict]) -> List[RootTraceSpan]:
     ]
 
 
-def get_span_trace_service(user_id: UUID, trace_id: UUID) -> TraceSpan:
+def get_span_trace_service(user_id: UUID, trace_id: str) -> TraceSpan:
     df_span = query_trace_by_trace_id(trace_id)
     span_trees = build_span_trees(df_span)
     if len(span_trees) == 0:

--- a/ada_backend/services/trace_service.py
+++ b/ada_backend/services/trace_service.py
@@ -181,8 +181,8 @@ def build_root_spans(rows: List[dict]) -> List[RootTraceSpan]:
     ]
 
 
-def get_span_trace_service(user_id: UUID, trace_id: str) -> TraceSpan:
-    df_span = query_trace_by_trace_id(trace_id)
+def get_span_trace_service(user_id: UUID, trace_id: str, project_id: UUID) -> TraceSpan:
+    df_span = query_trace_by_trace_id(trace_id, project_id)
     span_trees = build_span_trees(df_span)
     if len(span_trees) == 0:
         raise ValueError(f"No spans found for trace_id {trace_id}")

--- a/frontend/src/api/organization.ts
+++ b/frontend/src/api/organization.ts
@@ -14,10 +14,8 @@ export const organizationSecretsApi = {
   addOrUpdate: (organizationId: string, secretKey: string, data: { value: string }) =>
     $api(`/org/${organizationId}/secrets/${secretKey}`, {
       method: 'PUT',
-      query: {
-        organization_id: organizationId,
-        secret: data.value,
-      },
+      query: { organization_id: organizationId },
+      body: { value: data.value },
     }),
 
   delete: (organizationId: string, secretKey: string) =>

--- a/infra/k8s/base/mcp-deployment.yaml
+++ b/infra/k8s/base/mcp-deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: ada-mcp
 spec:
+  # Keep replicas at 1: org-session state falls back to per-pod memory when
+  # Redis is unreachable, and there is no session affinity on the Service.
+  # Scaling up requires sticky sessions or removing the memory fallback first.
   replicas: 1
   strategy:
     type: RollingUpdate
@@ -38,8 +41,10 @@ spec:
           ports:
             - containerPort: 8090
           envFrom:
+            # Dedicated secret: the MCP pod must not receive the full backend
+            # credential set (DB URL, Fernet key, third-party API keys).
             - secretRef:
-                name: ada-secrets
+                name: ada-mcp-secrets
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/infra/k8s/prod/secrets.yaml.example
+++ b/infra/k8s/prod/secrets.yaml.example
@@ -39,3 +39,25 @@ stringData:
   WEBHOOK_API_KEY_HASHED: ""
   
   API_BASE_URL: "http://ada-api.ada-prod.svc.cluster.local"
+
+---
+# Dedicated secret for the MCP server pod (ada-mcp). Keep it minimal — the MCP
+# pod must NOT receive the full backend credential set from ada-secrets.
+# Create on cluster using:
+#   kubectl create secret generic ada-mcp-secrets --from-env-file=mcp.env -n ada-prod
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ada-mcp-secrets
+  namespace: ada-prod
+type: Opaque
+stringData:
+  SUPABASE_PROJECT_URL: "https://xyz.supabase.co"
+  SUPABASE_PROJECT_KEY: ""
+  MCP_BASE_URL: "https://mcp.draftnrun.com"
+  BACKEND_URL: "http://ada-api.ada-prod.svc.cluster.local"
+  REDIS_HOST: "redis-host"
+  REDIS_PORT: "6379"
+  REDIS_PASSWORD: ""
+  SENTRY_DSN: ""
+  SENTRY_ENVIRONMENT: "production"

--- a/infra/k8s/staging/secrets.yaml.example
+++ b/infra/k8s/staging/secrets.yaml.example
@@ -42,3 +42,25 @@ stringData:
   WEBHOOK_API_KEY_HASHED: "
   
   API_BASE_URL: "http://ada-api.ada-staging.svc.cluster.local"
+
+---
+# Dedicated secret for the MCP server pod (ada-mcp). Keep it minimal — the MCP
+# pod must NOT receive the full backend credential set from ada-secrets.
+# Create on cluster using:
+#   kubectl create secret generic ada-mcp-secrets --from-env-file=mcp.env -n ada-staging
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ada-mcp-secrets
+  namespace: ada-staging
+type: Opaque
+stringData:
+  SUPABASE_PROJECT_URL: "https://xyz.supabase.co"
+  SUPABASE_PROJECT_KEY: ""
+  MCP_BASE_URL: "https://mcp.draftnrun.com"
+  BACKEND_URL: "http://ada-api.ada-staging.svc.cluster.local"
+  REDIS_HOST: "redis-host"
+  REDIS_PORT: "6379"
+  REDIS_PASSWORD: ""
+  SENTRY_DSN: ""
+  SENTRY_ENVIRONMENT: "staging"

--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -6,11 +6,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir uv
+RUN pip install --no-cache-dir uv==0.7.12
 
 COPY pyproject.toml uv.lock README.md ./
 
-RUN uv sync --frozen --no-dev --group mcp-server --no-install-project
+# Only the mcp-server dependency group — the MCP server must not pull the
+# full backend dependency tree into its image.
+RUN uv sync --frozen --no-dev --only-group mcp-server --no-install-project
 
 # --- Runtime stage ---
 FROM python:3.11-slim
@@ -22,7 +24,6 @@ RUN groupadd --gid 1000 appuser && useradd --uid 1000 --gid appuser --create-hom
 COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
 
 COPY --chown=appuser:appuser mcp_server/ ./mcp_server/
-COPY --chown=appuser:appuser settings.py logger.py logging-config.yaml ./
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH="/app"

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -89,7 +89,7 @@ All domain content lives in `docs.py` (single source of truth).
 | API Keys | 6 | Project + org level keys |
 | Variables | 9 | Admin only — definitions, sets, secrets |
 | Knowledge | 9 | `create_source` (website/database), sources, documents, chunks |
-| QA | 20 | Datasets, entries, custom columns, CSV export/import, judges, evaluations |
+| QA | 20 | Datasets, entries, custom columns, CSV export/import, judges, evaluations — org-session-scoped (no `organization_id` parameter) |
 | Monitoring | 6 | Traces, charts, KPIs, credits, monthly token usage |
 | Crons | 9 | Create, pause/resume, manual trigger, execution history |
 | OAuth | 3 | List, check status, revoke |
@@ -130,13 +130,14 @@ Custom tools (validation, multi-step, client-side logic) are still defined as `@
 
 | Guard | Description |
 |---|---|
-| RBAC | Variables/secrets require admin. Deletions require developer+. `create_agent`, cron writes (create/update/delete/pause/resume), OAuth tools, `create_typeform_webhook`, and `update_document_chunks` require developer+. `trigger_cron` requires member role or above. `invite_org_member` checks admin/super_admin on the target org, not just the active org. |
+| RBAC | Variables/secrets and org API key create/revoke require admin. Org-scoped deletions (sources, documents, QA datasets/entries/judges, crons) require developer+. `create_agent`, `create_workflow`, cron writes, OAuth tools, git sync writes, and `update_document_chunks` require developer+. `trigger_cron` requires member role or above. `invite_org_member` checks admin on the target org, not just the active org. Project-scoped tools (graphs, alert emails, project API keys, `delete_project`) rely on the backend's per-project role checks — the MCP layer cannot know the project's org. Role tuples live in `tools/_roles.py`. |
+| Tool annotations | Every tool declares MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`), derived from the HTTP method in `_factory.derive_annotations` and overridable per spec; hand-written tools use the presets in `tools/_annotations.py`. |
 | Component search | `search_components` rejects blank or whitespace-only queries. |
 | Release stage | Component catalog auto-filtered by org tier. Cannot be overridden by the AI. |
 | Agent name | `create_agent` rejects empty/whitespace names. |
-| Pagination | `list_runs` caps page_size at 100. Org-scoped with optional filters: `project_id` (single, mapped to `project_ids`), `status` (single, mapped to `statuses`), `trigger`, `date_from`, `date_to`. |
+| Pagination | `list_runs` caps page_size at 100. Org-scoped with optional filters: `project_id` (single, mapped to `project_ids`), `status`, `trigger`, `env` (comma-separated for multiple, mapped to `statuses`/`triggers`/`envs`), `date_from`, `date_to`. |
 | Monitoring | Duration clamped 1–90 days. `list_traces` also accepts `start_time`/`end_time` (ISO 8601) for date range filtering. `get_org_token_usage` reads stored trace spans by monthly period; pass `years`/`months` as lists or `"all"`, with optional per-model rows. |
-| Response size | Responses > 50KB are trimmed by default. `ToolSpec.trim=False` disables trimming per tool (e.g. `get_graph`, `list_components` for round-trip safety). |
+| Response size | Responses > 50KB are trimmed by default. `ToolSpec.trim=False` disables trimming per tool (e.g. `get_graph`, `list_components` for round-trip safety). `export_dataset_csv` caps its output at ~200K chars (`#TRUNCATED` marker line); `import_dataset_csv` rejects CSVs over ~1MB. `run` caps its `timeout` at 600s. |
 | Session diagnostics | `get_current_context` includes `session.session_id` and `session.storage_backend` ("redis" or "memory"). |
 | Agent tools | `add_tool_to_agent` rejects non-`function_callable`, duplicate, or integration-backed tools that it cannot wire safely. Use the display name from `search_components()`, not hard-coded names. The AI Agent's `skip_tools_with_missing_oauth` parameter (default `True`) silently drops any tool whose OAuth connection is missing at agent startup. Neverdrop-branded Google tools use the `google-mail-neverdrop` and `google-calendar-neverdrop` provider filters. |
 | Model validation | `configure_agent` validates the requested model against the agent's available options and rejects unknown or deprecated names with a clear error listing valid choices. |
@@ -196,7 +197,9 @@ npx @modelcontextprotocol/inspector http://localhost:8090/mcp
 
 The MCP server runs as a standalone Kubernetes pod (`ada-mcp`) alongside the API. The `build-and-deploy-k8s.yml` workflow builds the Docker image, pushes it to GHCR, and rolls out the deployment in the same pipeline as the other services. MCP rollout failure is non-blocking — it will not fail the overall deploy.
 
-- **Dockerfile**: `mcp_server/Dockerfile`
+- **Dockerfile**: `mcp_server/Dockerfile` — installs only the `mcp-server` dependency group (`uv sync --only-group mcp-server`), not the backend tree
+- **Secrets**: the pod reads the dedicated `ada-mcp-secrets` K8s secret (see `infra/k8s/*/secrets.yaml.example`) — create it on the cluster before deploying; it must NOT reuse the full backend `ada-secrets`
+- **Replicas**: keep `replicas: 1` — org-session state falls back to per-pod memory when Redis is down and there is no session affinity
 - **Image**: `ghcr.io/scopeo/draftnrun-mcp-server`
 - **K8s manifests**: `infra/k8s/base/mcp-*.yaml`
 - **Ingress**: `mcp-staging.draftnrun.com` / `mcp.draftnrun.com`

--- a/mcp_server/client.py
+++ b/mcp_server/client.py
@@ -9,10 +9,20 @@ import logging
 from typing import Any
 
 import httpx
+from fastmcp.exceptions import ToolError as FastMCPToolError
 
 from mcp_server.settings import settings
 
 logger = logging.getLogger(__name__)
+
+
+class ToolError(FastMCPToolError):
+    """Backend/tool error whose message must reach the MCP client.
+
+    Subclasses FastMCP's ToolError so the actionable messages survive even if
+    ``mask_error_details`` is ever enabled on the server.
+    """
+
 
 _client: httpx.AsyncClient | None = None
 
@@ -41,24 +51,32 @@ def _trim_response(data: Any) -> Any:
     if isinstance(data, list):
         meta["_total_items"] = len(data)
         meta["_included_items"] = 0
+        envelope_size = len(json.dumps({**meta, "partial_data": []}, default=str))
+        budget = max_size - envelope_size
+        used = 0
         subset: list = []
         for item in data:
-            tentative = {**meta, "partial_data": subset + [item], "_included_items": len(subset) + 1}
-            if len(json.dumps(tentative, default=str)) > max_size:
+            item_size = len(json.dumps(item, default=str)) + 2  # ", " separator
+            if used + item_size > budget:
                 break
             subset.append(item)
+            used += item_size
         if subset:
             meta["partial_data"] = subset
             meta["_included_items"] = len(subset)
         return meta
 
     if isinstance(data, dict):
+        envelope_size = len(json.dumps({**meta, "partial_data": {}}, default=str))
+        budget = max_size - envelope_size
+        used = 0
         subset_dict: dict = {}
         for key, value in data.items():
-            tentative = {**meta, "partial_data": {**subset_dict, key: value}}
-            if len(json.dumps(tentative, default=str)) > max_size:
+            entry_size = len(json.dumps({key: value}, default=str))
+            if used + entry_size > budget:
                 break
             subset_dict[key] = value
+            used += entry_size
         if subset_dict:
             meta["partial_data"] = subset_dict
         return meta
@@ -136,15 +154,11 @@ async def _handle_response(response: httpx.Response, *, trim: bool = True) -> An
 
     if response.status_code == 502:
         raise ToolError(
-            f"The backend is temporarily unreachable (gateway error){request_context}. "
-            "Retry in a few seconds."
+            f"The backend is temporarily unreachable (gateway error){request_context}. Retry in a few seconds."
         )
 
     if response.status_code == 503:
-        raise ToolError(
-            f"The backend is temporarily unavailable{request_context}. "
-            "Retry in a few seconds."
-        )
+        raise ToolError(f"The backend is temporarily unavailable{request_context}. Retry in a few seconds.")
 
     if response.status_code >= 400:
         detail = ""
@@ -167,10 +181,6 @@ async def _handle_response(response: httpx.Response, *, trim: bool = True) -> An
     return _trim_response(data) if trim else data
 
 
-class ToolError(Exception):
-    pass
-
-
 class DraftnrunClient:
     async def get(self, path: str, token: str, *, trim: bool = True, **params: Any) -> Any:
         client = _get_client()
@@ -191,10 +201,16 @@ class DraftnrunClient:
         return await _handle_response(response, trim=trim)
 
     async def post_file(
-        self, path: str, token: str, *,
-        file_content: bytes, filename: str, field_name: str = "file",
+        self,
+        path: str,
+        token: str,
+        *,
+        file_content: bytes,
+        filename: str,
+        field_name: str = "file",
         content_type: str = "text/csv",
-        trim: bool = True, **params: Any,
+        trim: bool = True,
+        **params: Any,
     ) -> Any:
         """Upload a file via multipart form data (for CSV import, etc.)."""
         client = _get_client()
@@ -217,12 +233,20 @@ class DraftnrunClient:
         return await _handle_response(response, trim=trim)
 
     async def delete(
-        self, path: str, token: str, json: dict | list | None = None,
-        trim: bool = True, **params: Any,
+        self,
+        path: str,
+        token: str,
+        json: dict | list | None = None,
+        trim: bool = True,
+        **params: Any,
     ) -> Any:
         client = _get_client()
         response = await client.request(
-            "DELETE", path, headers=_make_headers(token), json=json, params=params or None,
+            "DELETE",
+            path,
+            headers=_make_headers(token),
+            json=json,
+            params=params or None,
         )
         return await _handle_response(response, trim=trim)
 

--- a/mcp_server/client.py
+++ b/mcp_server/client.py
@@ -20,8 +20,18 @@ class ToolError(FastMCPToolError):
     """Backend/tool error whose message must reach the MCP client.
 
     Subclasses FastMCP's ToolError so the actionable messages survive even if
-    ``mask_error_details`` is ever enabled on the server.
+    ``mask_error_details`` is ever enabled on the server. ``status_code``
+    carries the backend HTTP status so callers can tell transient 5xx errors
+    apart from non-transient 4xx ones (e.g. in polling loops).
     """
+
+    def __init__(self, message: str, *, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+    @property
+    def is_transient(self) -> bool:
+        return self.status_code is None or self.status_code >= 500 or self.status_code == 429
 
 
 _client: httpx.AsyncClient | None = None
@@ -118,7 +128,8 @@ async def _handle_response(response: httpx.Response, *, trim: bool = True) -> An
         raise ToolError(
             f"Authentication failed{request_context}. Your session may have expired — reconnect to refresh. "
             "Next step: check your MCP client's server status, then call get_current_context() "
-            "to verify your session."
+            "to verify your session.",
+            status_code=401,
         )
 
     if response.status_code == 403:
@@ -129,36 +140,41 @@ async def _handle_response(response: httpx.Response, *, trim: bool = True) -> An
             "then see docs://getting-started for the role hierarchy."
         )
         if detail:
-            raise ToolError(f"{base} {detail}{hint}")
-        raise ToolError(f"{base} You may lack the required role for this operation.{hint}")
+            raise ToolError(f"{base} {detail}{hint}", status_code=403)
+        raise ToolError(f"{base} You may lack the required role for this operation.{hint}", status_code=403)
 
     if response.status_code == 404:
         detail = _extract_error_detail(response)
         raise ToolError(
             f"Resource not found{request_context}.{f' {detail}' if detail else ''} "
             "Next step: verify the ID came from a list_*/get_* call in this session — "
-            "never reuse IDs across projects or orgs."
+            "never reuse IDs across projects or orgs.",
+            status_code=404,
         )
 
     if response.status_code == 429:
         retry_after = response.headers.get("Retry-After", "unknown")
-        raise ToolError(f"Rate limited by backend{request_context}. Retry after {retry_after}s.")
+        raise ToolError(f"Rate limited by backend{request_context}. Retry after {retry_after}s.", status_code=429)
 
     if response.status_code == 500:
         detail = _extract_error_detail(response)
         raise ToolError(
             f"The backend hit an unexpected error{request_context}. "
             "This is not caused by your input — retry the call. "
-            f"If it persists, the issue is server-side.{f' Detail: {detail}' if detail else ''}"
+            f"If it persists, the issue is server-side.{f' Detail: {detail}' if detail else ''}",
+            status_code=500,
         )
 
     if response.status_code == 502:
         raise ToolError(
-            f"The backend is temporarily unreachable (gateway error){request_context}. Retry in a few seconds."
+            f"The backend is temporarily unreachable (gateway error){request_context}. Retry in a few seconds.",
+            status_code=502,
         )
 
     if response.status_code == 503:
-        raise ToolError(f"The backend is temporarily unavailable{request_context}. Retry in a few seconds.")
+        raise ToolError(
+            f"The backend is temporarily unavailable{request_context}. Retry in a few seconds.", status_code=503
+        )
 
     if response.status_code >= 400:
         detail = ""
@@ -171,7 +187,9 @@ async def _handle_response(response: httpx.Response, *, trim: bool = True) -> An
             detail = detail.strip()
         if not detail:
             detail = f"No error detail returned by the server (HTTP {response.status_code})"
-        raise ToolError(f"Backend error {response.status_code}{request_context}: {detail}")
+        raise ToolError(
+            f"Backend error {response.status_code}{request_context}: {detail}", status_code=response.status_code
+        )
 
     try:
         data = response.json()

--- a/mcp_server/docs.py
+++ b/mcp_server/docs.py
@@ -11,6 +11,8 @@ from typing import Annotated
 from fastmcp import FastMCP
 from pydantic import Field
 
+from mcp_server.tools._annotations import READ_ONLY
+
 # Doc example UUIDs: never hand-write hex; generate with \
 # `uv run python -c "import uuid; print(uuid.uuid4())"`.
 _GRAPH_DOC_THREE_NODE_EXAMPLE_IDS: tuple[str, str, str] = (
@@ -58,9 +60,10 @@ See `docs://known-quirks` for details on the sequencing requirement.
 
 `SUPER_ADMIN > ADMIN > DEVELOPER > MEMBER`
 
-- **Member**: read-only access (list, get)
-- **Developer**: create/update/delete resources, run graphs, manage cron jobs, OAuth connections, knowledge mutations
-- **Admin**: manage variables, secrets, invite members
+- **Member**: read access (list, get), run agents, manually trigger existing crons
+- **Developer**: create/update/delete resources, run graphs, manage cron jobs, OAuth connections, \
+knowledge mutations, create project API keys
+- **Admin**: manage variables, secrets, invite members, create/revoke API keys (org keys and revocations)
 - **SuperAdmin**: org limits, cost management
 
 If a tool returns a role error, check with `get_current_context`.
@@ -122,7 +125,7 @@ not call providers or infer tokens from prompts. Use `years`/`months` lists or `
 model breakdowns depend on stored `model_id`
 - Batch deletions: `delete_datasets`, `delete_entries`, `delete_judges` accept lists of IDs
 - Graph updates send the full graph structure — always `get_graph` first, modify, then `update_graph`
-- Secrets values are write-only; `list_secrets` returns masked values
+- Secret values are write-only; `list_secrets` returns key names only
 - OAuth connections must be set up in the web UI with explicit user permission — use \
 `check_oauth_status` to verify
 - Fetch `docs://versioning` before saving, publishing, scheduling, or reasoning about live vs editable versions
@@ -948,7 +951,7 @@ Variable definitions can be global or project-scoped:
 
 1. `list_variable_definitions` → see all definitions
 2. `upsert_variable_definition(name, definition)` → create/update
-3. `delete_variable_definition(id)` → remove
+3. `delete_variable_definition(name)` → remove
 
 Frontend behavior to mirror mentally:
 
@@ -960,16 +963,16 @@ Frontend behavior to mirror mentally:
 Named overrides for variable definitions (e.g., per-environment or per-client):
 
 1. `list_variable_sets` → see all sets
-2. `upsert_variable_set(name, values)` → create/update
-3. `delete_variable_set(id)` → remove
+2. `upsert_variable_set(set_id, data)` → create/update
+3. `delete_variable_set(set_id)` → remove
 
 ## Secrets
 
 Encrypted key-value pairs (API keys, credentials):
 
-1. `list_secrets` → returns masked values
+1. `list_secrets` → returns key names only (never values)
 2. `upsert_secret(key, value)` → create/update (write-only)
-3. `delete_secret(id)` → remove
+3. `delete_secret(key)` → remove
 
 ## Resolution at Runtime
 
@@ -1143,14 +1146,17 @@ GRAPHS = (
 _QA_DOC = """\
 # QA & Evaluation
 
+Dataset, entry, custom-column, and judge tools operate on the **active organization** \
+(`select_organization` first). Only `run_qa`, `run_evaluation`, and `get_evaluations` take a `project_id`.
+
 ## Datasets
 
 Test case collections for evaluating agent quality:
 
-1. `list_datasets(project_id)` → find existing datasets
-2. `create_dataset(project_id, dataset_data)` → create one or more datasets (`dataset_data.datasets_name`)
-3. `update_dataset(project_id, dataset_id, dataset_name)` → rename a dataset
-4. `delete_datasets(project_id, dataset_ids)` → batch delete
+1. `list_datasets()` → find existing datasets (active organization)
+2. `create_dataset(dataset_data)` → create one or more datasets (`dataset_data.datasets_name`)
+3. `update_dataset(dataset_id, dataset_name)` → rename a dataset
+4. `delete_datasets(dataset_ids)` → batch delete (developer+)
 
 Dataset names are not unique — duplicates are allowed. Always call `list_datasets` first and \
 reuse an existing `dataset_id` instead of creating a new dataset with the same name.
@@ -1159,12 +1165,12 @@ reuse an existing `dataset_id` instead of creating a new dataset with the same n
 
 Individual test cases within a dataset:
 
-1. `list_entries(project_id, dataset_id)` → paginated response: \
+1. `list_entries(dataset_id)` → paginated response: \
 `{pagination: {...}, inputs_groundtruths: [...]}`
-2. `create_entries(project_id, dataset_id, inputs_groundtruths)` → batch create
-3. `update_entries(project_id, dataset_id, inputs_groundtruths)` → batch update
-4. `delete_entries(project_id, dataset_id, input_groundtruth_ids)` → batch delete
-5. `save_trace_to_qa(project_id, dataset_id, trace_id)` → save a trace as a test case
+2. `create_entries(dataset_id, inputs_groundtruths)` → batch create
+3. `update_entries(dataset_id, inputs_groundtruths)` → batch update
+4. `delete_entries(dataset_id, input_groundtruth_ids)` → batch delete (developer+)
+5. `save_trace_to_qa(dataset_id, trace_id)` → save a trace as a test case
 
 Entry shape for create:
 
@@ -1188,7 +1194,7 @@ store the data but it will NOT appear in the frontend.
 
 Safe workflow:
 
-1. `list_custom_columns(project_id, dataset_id)` → get `column_id` (UUID) and `column_name` \
+1. `list_custom_columns(dataset_id)` → get `column_id` (UUID) and `column_name` \
 (display label) for each column
 2. Use the `column_id` as the key in `custom_columns` dicts when creating or updating entries:
    `{"custom_columns": {"__GRAPH_DOC_QA_COL__": "my value"}}`
@@ -1203,9 +1209,10 @@ use `export_dataset_csv` instead.
 
 Round-trip dataset operations via CSV text:
 
-1. `export_dataset_csv(project_id, dataset_id)` → returns CSV text with columns: \
-`position`, `input` (JSON string), `expected_output`, plus custom column display names
-2. `import_dataset_csv(project_id, dataset_id, csv_content)` → imports CSV entries into a dataset
+1. `export_dataset_csv(dataset_id)` → returns CSV text with columns: \
+`position`, `input` (JSON string), `expected_output`, plus custom column display names. \
+Output is capped at ~200K chars — a truncated export ends with a `#TRUNCATED` line; never re-import it
+2. `import_dataset_csv(dataset_id, csv_content)` → imports CSV entries into a dataset (max ~1MB)
 
 CSV import rules:
 - Required columns: `input` (valid JSON), `expected_output`
@@ -1218,28 +1225,28 @@ CSV import rules:
 
 To reorganize, sort, or migrate entries between datasets:
 
-1. `export_dataset_csv(project_id, source_dataset_id)` → get all entries as CSV
+1. `export_dataset_csv(source_dataset_id)` → get all entries as CSV
 2. Process the CSV (sort rows, filter, edit values)
-3. `create_dataset(project_id, {"datasets_name": ["target"]})` → create destination (or reuse existing)
-4. `import_dataset_csv(project_id, target_dataset_id, modified_csv)` → import sorted entries
-5. Verify with `list_entries(project_id, target_dataset_id)` (check `total_items` in pagination)
+3. `create_dataset({"datasets_name": ["target"]})` → create destination (or reuse existing)
+4. `import_dataset_csv(target_dataset_id, modified_csv)` → import sorted entries
+5. Verify with `list_entries(target_dataset_id)` (check `total_items` in pagination)
 
 To replace entries in an existing dataset:
 
-1. `export_dataset_csv(project_id, dataset_id)` → snapshot current state
+1. `export_dataset_csv(dataset_id)` → snapshot current state
 2. `list_entries` → collect all entry IDs
-3. `delete_entries(project_id, dataset_id, all_ids)` → clear
-4. `import_dataset_csv(project_id, dataset_id, modified_csv)` → re-import
+3. `delete_entries(dataset_id, all_ids)` → clear
+4. `import_dataset_csv(dataset_id, modified_csv)` → re-import
 
 ## Judges
 
 LLM-based evaluators that score agent responses:
 
-1. `list_judges(project_id)` → see judges
+1. `list_judges()` → see judges (active organization)
 2. `get_judge_defaults` → default judge config template
-3. `create_judge(project_id, judge_data)` → new judge
-4. `update_judge(project_id, judge_id, judge_data)` → modify
-5. `delete_judges(project_id, judge_ids)` → batch delete
+3. `create_judge(judge_data)` → new judge
+4. `update_judge(judge_id, judge_data)` → modify
+5. `delete_judges(judge_ids)` → batch delete (developer+)
 
 Judge shape for create:
 
@@ -1593,8 +1600,8 @@ will often truncate.
 Workarounds:
 
 - Use smaller `page_size` (10–20) and paginate manually
-- Use `export_dataset_csv` for full dataset retrieval — it paginates internally and returns \
-CSV text that won't be truncated by the MCP response limiter
+- Use `export_dataset_csv` for bulk dataset retrieval — it paginates internally and returns \
+CSV text with its own ~200K char cap (a truncated export ends with a `#TRUNCATED` line)
 - Never assume a `_truncated` response contains all data
 
 ## Custom Column Keys Are UUIDs, Not Display Names
@@ -1717,13 +1724,14 @@ If the secret is lost, call again with `rotate_secret=true` and update the secre
 ## Git Sync
 
 One-way deploy from a GitHub repo to Draft'n Run. On each push to the watched branch, \
-the backend fetches `graph.json` and deploys it to production (the user's draft is never touched). \
-Requires the Draft'n Run GitHub App installed on the repo.
+changed graphs are deployed to production and changed prompts get new versions \
+(the user's draft is never touched). Requires the Draft'n Run GitHub App installed on the repo.
 
 - `configure_git_sync(github_owner, github_repo_name, branch?, github_installation_id, project_type?)` \
-→ scan the repo for all `graph.json` files, create a project + sync config for each. Developer+. \
-A single repo can contain multiple projects (one per subfolder). Folders already linked are skipped. \
-`project_type` defaults to "workflow". Returns 422 if no `graph.json` found.
+→ scan the repo's `draftnrun/` folder structure and import projects + prompts. Developer+. \
+Projects live under `draftnrun/projects/<name>/` (each with `graph.json` + component files); \
+prompts live under `draftnrun/prompts/` as `.md` files. Folders already linked are skipped. \
+`project_type` defaults to "workflow". Returns 422 if the repo has no `draftnrun/` root folder.
 - `list_git_sync_configs()` → list all git sync configs in the active org.
 - `get_git_sync_config(config_id)` → config details including last sync status/commit and `last_sync_error` \
   (human-readable error on failure, null on success).
@@ -1732,7 +1740,8 @@ A single repo can contain multiple projects (one per subfolder). Folders already
 Setup prerequisites:
 1. User installs the Draft'n Run GitHub App on their repo (via GitHub UI).
 2. User provides the `github_installation_id` from the GitHub App install page.
-3. The repo must contain at least one `graph.json` file in the write format (`GraphUpdateSchema`).
+3. The repo must contain a `draftnrun/` root folder with `projects/` (graph.json per project) \
+and/or `prompts/` content.
 
 ## Monitoring
 
@@ -1740,8 +1749,8 @@ Setup prerequisites:
 Also accepts `start_time`/`end_time` (ISO 8601) for precise date range filtering; \
 when provided, `duration` is ignored
 - `get_trace_tree(trace_id)` → full span tree with timings (`trace_id` is an OTel hex string, e.g. `0x6d4e...`)
-- `get_org_charts(duration_days)` → usage charts (1–90 days)
-- `get_org_kpis(duration_days)` → key metrics
+- `get_org_charts(duration)` → usage charts (days, clamped 1–90)
+- `get_org_kpis(duration)` → key metrics (days, clamped 1–90)
 - `get_credit_usage` → credit consumption
 - `get_org_token_usage(years?, months?, by_model=true)` → input/output token usage by \
 monthly period from stored trace spans. `years` and `months` accept lists or `"all"`; \
@@ -1811,7 +1820,7 @@ def register(mcp: FastMCP) -> None:
 
     available_domains = ", ".join(sorted(DOMAINS.keys()))
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_guide(
         domain: Annotated[
             str,

--- a/mcp_server/docs.py
+++ b/mcp_server/docs.py
@@ -1610,7 +1610,7 @@ QA dataset entries store custom column values keyed by column UUID, not by the h
 column name. Writing `{"my column": "value"}` will persist in the database but will NOT display \
 in the frontend (the frontend resolves columns by UUID).
 
-Always call `list_custom_columns(project_id, dataset_id)` first to get the `column_id` → \
+Always call `list_custom_columns(dataset_id)` first to get the `column_id` → \
 `column_name` mapping, then use `column_id` as the key in `custom_columns` dicts. See `docs://qa` \
 for the full workflow.
 

--- a/mcp_server/tools/_annotations.py
+++ b/mcp_server/tools/_annotations.py
@@ -1,0 +1,15 @@
+"""Shared MCP tool annotation presets.
+
+Annotations let MCP clients distinguish safe reads from destructive writes
+(auto-approval, confirmation UX). Kept in a dependency-free module so both
+the proxy factory and hand-written tools can import them without cycles.
+"""
+
+from mcp.types import ToolAnnotations
+
+READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
+NON_DESTRUCTIVE_WRITE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=False)
+IDEMPOTENT_WRITE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False)
+DESTRUCTIVE_WRITE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=False)
+# Runs agents/workflows whose components may reach external systems (email, CRM, web).
+EXECUTION = ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True)

--- a/mcp_server/tools/_factory.py
+++ b/mcp_server/tools/_factory.py
@@ -19,6 +19,7 @@ from urllib.parse import quote
 from uuid import UUID
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from mcp_server.client import api
@@ -50,6 +51,9 @@ class ToolSpec:
                         (keys = param names).
         body_org_key:   If set, inject ``org_id`` into the JSON body under this key.
         org_query_key:  If set, inject ``org_id`` as this query-string parameter.
+        annotations:    Explicit MCP tool annotation overrides (readOnlyHint,
+                        destructiveHint, idempotentHint, openWorldHint). Merged on
+                        top of the defaults derived from the HTTP method.
     """
 
     name: str
@@ -66,11 +70,13 @@ class ToolSpec:
     org_query_key: str | None = None
     return_annotation: type = dict
     trim: bool = True
+    annotations: dict[str, bool] | None = None
 
 
 def _validate_spec(spec: ToolSpec) -> None:
     """Fail fast on common ToolSpec misconfigurations."""
     import re
+
     placeholders = set(re.findall(r"\{(\w+)\}", spec.path))
     path_param_names = {p.name for p in spec.path_params}
     auto_resolved = set()
@@ -166,7 +172,24 @@ def _build_handler(spec: ToolSpec):
     return handler
 
 
+def derive_annotations(spec: ToolSpec) -> ToolAnnotations:
+    """Derive MCP tool annotations from the spec so clients can distinguish
+    safe reads from destructive writes (confirmation UX, auto-approval)."""
+    hints: dict[str, bool] = {"openWorldHint": False}
+    if spec.method == "get":
+        hints["readOnlyHint"] = True
+        hints["destructiveHint"] = False
+        hints["idempotentHint"] = True
+    else:
+        hints["readOnlyHint"] = False
+        hints["destructiveHint"] = spec.method == "delete" or spec.description.startswith("Destructive")
+        hints["idempotentHint"] = spec.method in ("put", "delete")
+    if spec.annotations:
+        hints.update(spec.annotations)
+    return ToolAnnotations(**hints)
+
+
 def register_proxy_tools(mcp: FastMCP, specs: list[ToolSpec]) -> None:
     for spec in specs:
         _validate_spec(spec)
-        mcp.tool()(_build_handler(spec))
+        mcp.tool(annotations=derive_annotations(spec))(_build_handler(spec))

--- a/mcp_server/tools/_roles.py
+++ b/mcp_server/tools/_roles.py
@@ -1,0 +1,15 @@
+"""Shared role tuples for MCP-level RBAC gates.
+
+These gates are advisory UX — the backend independently enforces membership
+and role on every route via the check-org-access edge function. Keeping the
+tuples here avoids drift between modules.
+
+The data layer stores roles from organization_members.role. Both underscore
+and hyphen spellings of super admin are accepted because the backend hierarchy
+uses "super-admin" while older MCP code matched "super_admin".
+"""
+
+SUPER_ADMIN_ROLES = ("super_admin", "super-admin")
+ADMIN_ROLES = ("admin", *SUPER_ADMIN_ROLES)
+DEVELOPER_ROLES = ("developer", *ADMIN_ROLES)
+MEMBER_ROLES = ("member", "user", *DEVELOPER_ROLES)

--- a/mcp_server/tools/agent_config.py
+++ b/mcp_server/tools/agent_config.py
@@ -17,6 +17,7 @@ from pydantic import Field
 
 from mcp_server.client import ToolError, api
 from mcp_server.context import require_org_context
+from mcp_server.tools._annotations import DESTRUCTIVE_WRITE, IDEMPOTENT_WRITE, NON_DESTRUCTIVE_WRITE
 from mcp_server.tools._defaults import ensure_provider_model_format
 from mcp_server.tools.context_tools import _get_auth
 
@@ -47,8 +48,7 @@ def _validate_model_choice(prefixed_model: str, existing_params: list[dict]) -> 
         return
     labels = [f"{opt.get('label', '?')} → {opt['value']}" for opt in options if "value" in opt]
     raise ValueError(
-        f"Model '{prefixed_model}' is not available on this agent. "
-        f"Pick one of:\n  " + "\n  ".join(labels)
+        f"Model '{prefixed_model}' is not available on this agent. Pick one of:\n  " + "\n  ".join(labels)
     )
 
 
@@ -67,7 +67,10 @@ def _merge_model_parameters(
 
     merged = []
     for param in existing_params:
-        p = {"name": param["name"], "value": param.get("value", param.get("default"))}
+        existing_value = param.get("value")
+        if existing_value is None:
+            existing_value = param.get("default")
+        p = {"name": param["name"], "value": existing_value}
         if param["name"] in backend_updates:
             p["value"] = backend_updates[param["name"]]
         merged.append(p)
@@ -92,15 +95,18 @@ async def _fetch_component_by_name(jwt: str, org_id: str, release_stage: str, co
 
     available = sorted({c.get("name", c.get("component_name", "?")) for c in components})
     raise ValueError(
-        f"Component '{component_name}' not found in the catalog. "
-        f"Available components: {', '.join(available[:30])}"
+        f"Component '{component_name}' not found in the catalog. Available components: {', '.join(available[:30])}"
     )
+
+
+def _component_version_id(component: dict) -> str | None:
+    return component.get("component_version_id") or component.get("version_id") or component.get("id")
 
 
 def _validate_agent_tool_component(component: dict, existing_tools: list[dict]) -> None:
     """Reject tool additions that the frontend or backend would not handle safely."""
     component_name = component.get("name") or component.get("component_name") or "unknown"
-    component_version_id = component.get("component_version_id") or component.get("id")
+    component_version_id = _component_version_id(component)
 
     if not component.get("function_callable", False):
         raise ValueError(
@@ -162,9 +168,9 @@ def _build_tool_entry(component: dict, tool_parameters: dict) -> dict:
         params.append(p)
 
     return {
-        "name": component.get("name", component.get("component_name")),
-        "component_id": component.get("component_id", component.get("id")),
-        "component_version_id": component.get("component_version_id") or component.get("version_id"),
+        "name": component.get("name") or component.get("component_name"),
+        "component_id": component.get("component_id") or component.get("id"),
+        "component_version_id": _component_version_id(component),
         "component_name": component.get("name", component.get("component_name")),
         "component_description": component.get("description"),
         "parameters": params,
@@ -174,37 +180,27 @@ def _build_tool_entry(component: dict, tool_parameters: dict) -> dict:
 
 
 def register(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=IDEMPOTENT_WRITE)
     async def configure_agent(
-        agent_id: Annotated[
-            UUID, Field(description="The agent (project) ID (from list_agents or create_agent).")
-        ],
+        agent_id: Annotated[UUID, Field(description="The agent (project) ID (from list_agents or create_agent).")],
         graph_runner_id: Annotated[
             UUID, Field(description="The graph runner version ID (from get_project_overview).")
         ],
-        system_prompt: Annotated[
-            Optional[str], Field(description="The agent's instructions / system prompt.")
-        ] = None,
+        system_prompt: Annotated[Optional[str], Field(description="The agent's instructions / system prompt.")] = None,
         model: Annotated[
             Optional[str],
             Field(
                 description="LLM model identifier exactly as listed in the agent's completion_model"
                 " options (e.g. 'gpt-4.1', 'anthropic:claude-sonnet-4-5')."
-                " Raises ValueError if not in the available options."
+                " Names outside the available options are rejected with the list of valid choices."
             ),
         ] = None,
         temperature: Annotated[
-            Optional[float], Field(description="Sampling temperature (0.0 - 2.0).")
+            Optional[float], Field(description="Sampling temperature (0.0 - 2.0).", ge=0.0, le=2.0)
         ] = None,
-        max_tokens: Annotated[
-            Optional[int], Field(description="Maximum response tokens.")
-        ] = None,
-        name: Annotated[
-            Optional[str], Field(description="Update the agent's display name.")
-        ] = None,
-        description: Annotated[
-            Optional[str], Field(description="Update the agent's description.")
-        ] = None,
+        max_tokens: Annotated[Optional[int], Field(description="Maximum response tokens.")] = None,
+        name: Annotated[Optional[str], Field(description="Update the agent's display name.")] = None,
+        description: Annotated[Optional[str], Field(description="Update the agent's description.")] = None,
     ) -> dict:
         """Configure an agent's model settings and system prompt.
 
@@ -241,11 +237,12 @@ def register(mcp: FastMCP) -> None:
         merged_params = _merge_model_parameters(existing_params, updates)
 
         initial_prompt_param = next((p for p in merged_params if p["name"] == "initial_prompt"), None)
-        final_prompt = (
-            initial_prompt_param["value"]
-            if initial_prompt_param
-            else (system_prompt or "")
-        )
+        if initial_prompt_param:
+            final_prompt = initial_prompt_param["value"]
+        elif system_prompt is not None:
+            final_prompt = system_prompt
+        else:
+            final_prompt = current.get("system_prompt", "")
 
         update_data = {
             "name": name if name is not None else current.get("name", ""),
@@ -280,11 +277,9 @@ def register(mcp: FastMCP) -> None:
             "hint": "Test with run, or add tools with add_tool_to_agent.",
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations=NON_DESTRUCTIVE_WRITE)
     async def add_tool_to_agent(
-        agent_id: Annotated[
-            UUID, Field(description="The agent (project) ID (from list_agents or create_agent).")
-        ],
+        agent_id: Annotated[UUID, Field(description="The agent (project) ID (from list_agents or create_agent).")],
         graph_runner_id: Annotated[
             UUID, Field(description="The graph runner version ID (from get_project_overview).")
         ],
@@ -350,11 +345,9 @@ def register(mcp: FastMCP) -> None:
             "total_tools": len(existing_tools),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations=DESTRUCTIVE_WRITE)
     async def remove_tool_from_agent(
-        agent_id: Annotated[
-            UUID, Field(description="The agent (project) ID (from list_agents or create_agent).")
-        ],
+        agent_id: Annotated[UUID, Field(description="The agent (project) ID (from list_agents or create_agent).")],
         graph_runner_id: Annotated[
             UUID, Field(description="The graph runner version ID (from get_project_overview).")
         ],
@@ -368,16 +361,13 @@ def register(mcp: FastMCP) -> None:
         existing_tools = current.get("tools", [])
         target = component_name.lower()
         filtered = [
-            t for t in existing_tools
-            if (t.get("component_name") or "").lower() != target
-            and (t.get("name") or "").lower() != target
+            t
+            for t in existing_tools
+            if (t.get("component_name") or "").lower() != target and (t.get("name") or "").lower() != target
         ]
         if len(filtered) == len(existing_tools):
             tool_names = [t.get("component_name") or t.get("name") for t in existing_tools]
-            raise ValueError(
-                f"Tool '{component_name}' not found on this agent. "
-                f"Current tools: {tool_names}"
-            )
+            raise ValueError(f"Tool '{component_name}' not found on this agent. Current tools: {tool_names}")
 
         update_data = {
             "name": current.get("name", ""),
@@ -391,5 +381,6 @@ def register(mcp: FastMCP) -> None:
         return {
             "status": "ok",
             "removed_tool": component_name,
+            "removed_count": len(existing_tools) - len(filtered),
             "remaining_tools": len(filtered),
         }

--- a/mcp_server/tools/agent_config.py
+++ b/mcp_server/tools/agent_config.py
@@ -67,9 +67,9 @@ def _merge_model_parameters(
 
     merged = []
     for param in existing_params:
-        existing_value = param.get("value")
-        if existing_value is None:
-            existing_value = param.get("default")
+        # Round-trip fidelity: an explicit value of None is preserved (it may be
+        # intentional, e.g. max_tokens unset); only a missing key falls back.
+        existing_value = param["value"] if "value" in param else param.get("default")
         p = {"name": param["name"], "value": existing_value}
         if param["name"] in backend_updates:
             p["value"] = backend_updates[param["name"]]
@@ -237,12 +237,12 @@ def register(mcp: FastMCP) -> None:
         merged_params = _merge_model_parameters(existing_params, updates)
 
         initial_prompt_param = next((p for p in merged_params if p["name"] == "initial_prompt"), None)
-        if initial_prompt_param:
+        if initial_prompt_param and initial_prompt_param["value"] is not None:
             final_prompt = initial_prompt_param["value"]
         elif system_prompt is not None:
             final_prompt = system_prompt
         else:
-            final_prompt = current.get("system_prompt", "")
+            final_prompt = current.get("system_prompt") or ""
 
         update_data = {
             "name": name if name is not None else current.get("name", ""),

--- a/mcp_server/tools/agents.py
+++ b/mcp_server/tools/agents.py
@@ -8,8 +8,10 @@ from pydantic import Field
 
 from mcp_server.client import api
 from mcp_server.context import require_role
+from mcp_server.tools._annotations import NON_DESTRUCTIVE_WRITE
 from mcp_server.tools._defaults import generate_entity_defaults
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
+from mcp_server.tools._roles import DEVELOPER_ROLES
 from mcp_server.tools.context_tools import _get_auth
 
 PROXY_SPECS: list[ToolSpec] = [
@@ -43,7 +45,7 @@ PROXY_SPECS: list[ToolSpec] = [
 def register(mcp: FastMCP) -> None:
     register_proxy_tools(mcp, PROXY_SPECS)
 
-    @mcp.tool()
+    @mcp.tool(annotations=NON_DESTRUCTIVE_WRITE)
     async def create_agent(
         name: Annotated[str, Field(description="Agent name. Must not be empty or whitespace-only.")],
         description: Annotated[str, Field(description="Optional description.")] = "",
@@ -64,7 +66,7 @@ def register(mcp: FastMCP) -> None:
             raise ValueError("Agent name must not be empty or whitespace-only.")
 
         jwt, user_id = _get_auth()
-        org = await require_role(user_id, "developer", "admin", "super_admin")
+        org = await require_role(user_id, *DEVELOPER_ROLES)
         defaults = generate_entity_defaults()
         return await api.post(
             f"/org/{org['org_id']}/agents",

--- a/mcp_server/tools/alert_emails.py
+++ b/mcp_server/tools/alert_emails.py
@@ -6,12 +6,8 @@ from fastmcp import FastMCP
 
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
 
-_PROJECT_ID = Param(
-    "project_id", UUID, description="The project ID (from list_projects or get_project_overview)."
-)
-_ALERT_EMAIL_ID = Param(
-    "alert_email_id", UUID, description="The alert email ID to delete (from list_alert_emails)."
-)
+_PROJECT_ID = Param("project_id", UUID, description="The project ID (from list_projects or get_project_overview).")
+_ALERT_EMAIL_ID = Param("alert_email_id", UUID, description="The alert email ID to delete (from list_alert_emails).")
 _EMAIL = Param("email", str, description="Email address to receive run failure alerts.")
 
 SPECS: list[ToolSpec] = [
@@ -26,28 +22,31 @@ SPECS: list[ToolSpec] = [
         path_params=(_PROJECT_ID,),
         return_annotation=list,
     ),
+    # Note: these are project-scoped, so the role is enforced by the backend in the
+    # project's own organization. An MCP-level scope="role" gate would check the
+    # session's active org instead, which may differ from the project's org.
     ToolSpec(
         name="create_alert_email",
         description=(
             "Add an email address to receive run failure alerts for a project. "
             "Alerts are sent via Resend when a webhook- or cron-triggered run fails. "
-            "Duplicate emails are rejected (409)."
+            "Duplicate emails are rejected (409). "
+            "The backend requires developer role or above in the project's organization."
         ),
         method="post",
         path="/projects/{project_id}/alert-emails",
         path_params=(_PROJECT_ID,),
         body_fields=(_EMAIL,),
-        scope="role",
-        roles=("developer", "admin", "super_admin"),
     ),
     ToolSpec(
         name="delete_alert_email",
-        description="Remove an email address from a project's run failure alert recipients.",
+        description=(
+            "Remove an email address from a project's run failure alert recipients. "
+            "The backend requires developer role or above in the project's organization."
+        ),
         method="delete",
         path="/projects/{project_id}/alert-emails/{alert_email_id}",
         path_params=(_PROJECT_ID, _ALERT_EMAIL_ID),
-        scope="role",
-        roles=("developer", "admin", "super_admin"),
     ),
 ]
 

--- a/mcp_server/tools/api_keys.py
+++ b/mcp_server/tools/api_keys.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from fastmcp import FastMCP
 
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
+from mcp_server.tools._roles import ADMIN_ROLES
 
 _PROJECT_ID = Param("project_id", UUID, description="The project ID (from list_projects or get_project_overview).")
 _KEY_ID = Param(
@@ -26,14 +27,21 @@ SPECS: list[ToolSpec] = [
     ),
     ToolSpec(
         name="create_project_api_key",
-        description="Create a new API key scoped to a project. The key is shown only once.",
+        description=(
+            "Create a new API key scoped to a project. The key is shown only once — "
+            "treat the returned value as a secret and never echo it back. "
+            "The backend requires developer role or above in the project's organization."
+        ),
         method="post",
         path="/auth/api-key",
         body_fields=(_PROJECT_ID, _KEY_NAME),
     ),
     ToolSpec(
         name="revoke_project_api_key",
-        description="Destructive. Revoke a specific API key for a project.",
+        description=(
+            "Destructive. Revoke a specific API key for a project. "
+            "The backend requires admin role in the project's organization."
+        ),
         method="delete",
         path="/auth/api-key",
         query_params=(_PROJECT_ID,),
@@ -51,19 +59,25 @@ SPECS: list[ToolSpec] = [
     ),
     ToolSpec(
         name="create_org_api_key",
-        description="Create a new API key scoped to the active organization. The key is shown only once.",
+        description=(
+            "Create a new API key scoped to the active organization. The key is shown "
+            "only once — treat the returned value as a secret and never echo it back. "
+            "Requires admin role."
+        ),
         method="post",
         path="/auth/org-api-key",
-        scope="org",
+        scope="role",
+        roles=ADMIN_ROLES,
         body_fields=(_KEY_NAME,),
         body_org_key="org_id",
     ),
     ToolSpec(
         name="revoke_org_api_key",
-        description="Destructive. Revoke an API key for the active organization.",
+        description="Destructive. Revoke an API key for the active organization. Requires admin role.",
         method="delete",
         path="/auth/org-api-key",
-        scope="org",
+        scope="role",
+        roles=ADMIN_ROLES,
         org_query_key="organization_id",
         body_fields=(_KEY_ID,),
     ),

--- a/mcp_server/tools/components.py
+++ b/mcp_server/tools/components.py
@@ -12,6 +12,7 @@ from pydantic import Field
 
 from mcp_server.client import api
 from mcp_server.context import require_org_context
+from mcp_server.tools._annotations import READ_ONLY
 from mcp_server.tools.context_tools import _get_auth
 
 logger = logging.getLogger(__name__)
@@ -46,7 +47,7 @@ def _extract_ports(comp: dict) -> dict:
 
 
 def register(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def list_components() -> dict:
         """List all available component types from the catalog.
 
@@ -60,7 +61,7 @@ def register(mcp: FastMCP) -> None:
         release_stage = org.get("release_stage") or "public"
         return await api.get(f"/components/{org['org_id']}", jwt, trim=False, release_stage=release_stage)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def search_components(
         query: Annotated[str, Field(description="Search term to match against component name or description.")],
         category: Annotated[
@@ -87,7 +88,10 @@ def register(mcp: FastMCP) -> None:
         org = await require_org_context(user_id)
         release_stage = org.get("release_stage") or "public"
         catalog = await api.get(
-            f"/components/{org['org_id']}", jwt, trim=False, release_stage=release_stage,
+            f"/components/{org['org_id']}",
+            jwt,
+            trim=False,
+            release_stage=release_stage,
         )
 
         components = catalog if isinstance(catalog, list) else catalog.get("components", [])

--- a/mcp_server/tools/context_tools.py
+++ b/mcp_server/tools/context_tools.py
@@ -19,6 +19,8 @@ from mcp_server.auth.supabase_client import (
     list_user_organizations,
 )
 from mcp_server.context import get_active_org, set_active_org
+from mcp_server.tools._annotations import IDEMPOTENT_WRITE, NON_DESTRUCTIVE_WRITE, READ_ONLY
+from mcp_server.tools._roles import ADMIN_ROLES, MEMBER_ROLES
 
 
 def _get_auth() -> tuple[str, str]:
@@ -45,28 +47,23 @@ async def _require_target_org_role(jwt: str, user_id: str, org_id: str, *allowed
         raise ValueError(f"Organization {org_id} not found in your memberships.")
     if match["role"] not in allowed_roles:
         context = f"{action} in organization {org_id}" if action else f"This operation on organization {org_id}"
-        raise ValueError(
-            f"{context} requires one of {allowed_roles} role, "
-            f"but your role there is '{match['role']}'."
-        )
+        raise ValueError(f"{context} requires one of {allowed_roles} role, but your role there is '{match['role']}'.")
     return match
 
 
 def register(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def list_my_organizations() -> list[dict]:
         """List all organizations you belong to, with your role in each."""
         jwt, user_id = _get_auth()
         return await list_user_organizations(jwt, user_id)
 
-    @mcp.tool()
+    @mcp.tool(annotations=IDEMPOTENT_WRITE)
     async def select_organization(
         organization_id: Annotated[
             UUID,
             Field(
-                description=(
-                    "The organization ID (from list_my_organizations). Never invent this value."
-                ),
+                description=("The organization ID (from list_my_organizations). Never invent this value."),
             ),
         ],
     ) -> dict:
@@ -90,7 +87,7 @@ def register(mcp: FastMCP) -> None:
             "release_stage": release_stage,
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_current_context() -> dict:
         """Show your current session: active organization, user info, and session diagnostics."""
         token_obj = get_access_token()
@@ -111,7 +108,7 @@ def register(mcp: FastMCP) -> None:
             },
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def list_org_members(
         organization_id: Annotated[UUID, Field(description="The organization ID (from list_my_organizations).")],
     ) -> list[dict]:
@@ -119,12 +116,15 @@ def register(mcp: FastMCP) -> None:
         jwt, user_id = _get_auth()
         org_id_str = str(organization_id)
         await _require_target_org_role(
-            jwt, user_id, org_id_str, "member", "developer", "admin", "super_admin",
+            jwt,
+            user_id,
+            org_id_str,
+            *MEMBER_ROLES,
             action="Listing members",
         )
         return await get_org_members(jwt, org_id_str)
 
-    @mcp.tool()
+    @mcp.tool(annotations=NON_DESTRUCTIVE_WRITE)
     async def invite_org_member(
         organization_id: Annotated[UUID, Field(description="Target organization ID (from list_my_organizations).")],
         email: Annotated[str, Field(description="Email address of the person to invite.")],
@@ -137,6 +137,10 @@ def register(mcp: FastMCP) -> None:
         jwt, user_id = _get_auth()
         org_id_str = str(organization_id)
         await _require_target_org_role(
-            jwt, user_id, org_id_str, "admin", "super_admin", action="Inviting members",
+            jwt,
+            user_id,
+            org_id_str,
+            *ADMIN_ROLES,
+            action="Inviting members",
         )
         return await invite_member(jwt, org_id_str, email, role)

--- a/mcp_server/tools/crons.py
+++ b/mcp_server/tools/crons.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from fastmcp import FastMCP
 
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
+from mcp_server.tools._roles import DEVELOPER_ROLES
 
 _BASE = "/organizations/{org_id}/crons"
 _ITEM = f"{_BASE}/{{cron_id}}"
@@ -41,7 +42,7 @@ SPECS: list[ToolSpec] = [
         method="post",
         path=_BASE,
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         body_param=Param(
             "cron_data",
             dict,
@@ -59,10 +60,11 @@ SPECS: list[ToolSpec] = [
         method="patch",
         path=_ITEM,
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         path_params=(_CRON_ID,),
         body_param=Param(
-            "cron_data", dict,
+            "cron_data",
+            dict,
             description="Updated cron fields. Use `payload`, not `input_data`, at the top level.",
         ),
     ),
@@ -72,7 +74,7 @@ SPECS: list[ToolSpec] = [
         method="delete",
         path=_ITEM,
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         path_params=(_CRON_ID,),
     ),
     ToolSpec(
@@ -81,7 +83,7 @@ SPECS: list[ToolSpec] = [
         method="post",
         path=f"{_ITEM}/pause",
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         path_params=(_CRON_ID,),
     ),
     ToolSpec(
@@ -90,7 +92,7 @@ SPECS: list[ToolSpec] = [
         method="post",
         path=f"{_ITEM}/resume",
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         path_params=(_CRON_ID,),
     ),
     ToolSpec(
@@ -112,6 +114,7 @@ SPECS: list[ToolSpec] = [
         path=f"{_ITEM}/trigger",
         scope="org",
         path_params=(_CRON_ID,),
+        annotations={"openWorldHint": True},
     ),
 ]
 

--- a/mcp_server/tools/git_sync.py
+++ b/mcp_server/tools/git_sync.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from fastmcp import FastMCP
 
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
+from mcp_server.tools._roles import DEVELOPER_ROLES
 
 _GITHUB_OWNER = Param("github_owner", str, description="GitHub repository owner (user or organization name).")
 _GITHUB_REPO_NAME = Param("github_repo_name", str, description="GitHub repository name.")
@@ -38,7 +39,7 @@ SPECS: list[ToolSpec] = [
         method="post",
         path="/organizations/{org_id}/git-sync",
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         body_fields=(_GITHUB_OWNER, _GITHUB_REPO_NAME, _BRANCH, _GITHUB_INSTALLATION_ID, _PROJECT_TYPE),
     ),
     ToolSpec(
@@ -66,7 +67,7 @@ SPECS: list[ToolSpec] = [
         method="delete",
         path="/organizations/{org_id}/git-sync/{config_id}",
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         path_params=(_CONFIG_ID,),
     ),
 ]

--- a/mcp_server/tools/graphs.py
+++ b/mcp_server/tools/graphs.py
@@ -4,14 +4,16 @@ Exposes the same operations as the front-end studio:
 edit draft, save a version snapshot, publish to production, view history.
 """
 
+import json
 import logging
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID, uuid4
 
 from fastmcp import FastMCP
 from pydantic import Field
 
 from mcp_server.client import ToolError, api
+from mcp_server.tools._annotations import DESTRUCTIVE_WRITE, IDEMPOTENT_WRITE, READ_ONLY
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
 from mcp_server.tools.context_tools import _get_auth
 
@@ -19,9 +21,7 @@ logger = logging.getLogger(__name__)
 
 _P_PROJECT = Param("project_id", UUID, description="The project ID (from list_projects or get_project_overview).")
 _P_RUNNER = Param("graph_runner_id", UUID, description="The graph runner version ID (from get_project_overview).")
-_P_INSTANCE = Param(
-    "instance_id", UUID, description="The component instance ID (from get_graph or get_graph_v2)."
-)
+_P_INSTANCE = Param("instance_id", UUID, description="The component instance ID (from get_graph or get_graph_v2).")
 _GRAPH_BASE = "/projects/{project_id}/graph/{graph_runner_id}"
 _GRAPH_BASE_V2 = "/v2/projects/{project_id}/graph/{graph_runner_id}"
 
@@ -57,7 +57,7 @@ PROXY_SPECS: list[ToolSpec] = [
     ToolSpec(
         name="save_graph_version",
         description=(
-            "Save the current graph state as a named version snapshot.\n\n"
+            "Save the current graph state as a version snapshot (auto-numbered tag).\n\n"
             "Creates an immutable tagged copy of the current draft that can be "
             "referenced later via get_graph_history. The current draft runner stays "
             "editable and keeps the same instance IDs."
@@ -83,7 +83,7 @@ PROXY_SPECS: list[ToolSpec] = [
         path_params=(
             _P_PROJECT,
             _P_RUNNER,
-            Param("env", str, description="Target environment: 'production' or 'draft'."),
+            Param("env", Literal["production", "draft"], description="Target environment."),
         ),
     ),
     ToolSpec(
@@ -144,8 +144,8 @@ PROXY_SPECS: list[ToolSpec] = [
         name="delete_component_v2",
         description=(
             "Delete a component instance from a graph (v2).\n\n"
-            "Removes the component, its node, and cascades deletion of edges "
-            "and relationships referencing it."
+            "Destructive. Removes the component, its node, and cascades deletion of "
+            "edges and relationships referencing it. Confirm user intent first."
         ),
         method="delete",
         path=f"{_GRAPH_BASE_V2}/components/{{instance_id}}",
@@ -229,7 +229,8 @@ def _warn_unknown_graph_keys(graph_data: dict) -> list[str]:
         suggestion = _LIKELY_TYPOS.get(key)
         if suggestion:
             warnings.append(
-                f"Unknown graph key '{key}' — did you mean '{suggestion}'? The key was ignored by the backend."
+                f"Unknown graph key '{key}' — did you mean '{suggestion}'? "
+                "The backend will likely ignore or reject it."
             )
         else:
             warnings.append(
@@ -294,12 +295,13 @@ def _convert_field_expressions_to_unified_params(instances: list[dict]) -> None:
             existing_param = next((p for p in params if p["name"] == field_name), None)
             if existing_param and existing_param.get("kind") == "input":
                 existing_param["field_expression"] = {"expression_json": expression_json}
-            elif field_name not in input_param_names:
+            elif existing_param is None and field_name not in input_param_names:
                 params.append({
                     "name": field_name,
                     "kind": "input",
                     "field_expression": {"expression_json": expression_json},
                 })
+                input_param_names.add(field_name)
 
 
 _OAUTH_KEYWORDS = ("access_token", "oauth", "integration", "credentials")
@@ -337,7 +339,7 @@ def _enrich_graph_update_error(message: str) -> str:
 def register(mcp: FastMCP) -> None:
     register_proxy_tools(mcp, PROXY_SPECS)
 
-    @mcp.tool()
+    @mcp.tool(annotations=DESTRUCTIVE_WRITE)
     async def publish_to_production(
         project_id: Annotated[UUID, Field(description="The project ID (from list_projects or get_project_overview).")],
         graph_runner_id: Annotated[
@@ -346,6 +348,7 @@ def register(mcp: FastMCP) -> None:
     ) -> dict:
         """Publish the current draft to production (full deploy).
 
+        Affects live behavior — confirm user intent before calling.
         Tags the current draft with an auto-incremented version, promotes it to the
         live production environment, and creates a brand-new draft runner for continued
         editing.
@@ -360,7 +363,7 @@ def register(mcp: FastMCP) -> None:
         jwt, _ = _get_auth()
         return await api.post(f"/projects/{project_id}/graph/{graph_runner_id}/deploy", jwt)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_draft_graph(
         project_id: Annotated[UUID, Field(description="The project ID (from list_projects or get_project_overview).")],
     ) -> dict:
@@ -398,7 +401,7 @@ def register(mcp: FastMCP) -> None:
             "graph": graph,
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations=DESTRUCTIVE_WRITE)
     async def update_graph(
         project_id: Annotated[UUID, Field(description="The project ID (from list_projects or get_project_overview).")],
         graph_runner_id: Annotated[
@@ -468,7 +471,7 @@ def register(mcp: FastMCP) -> None:
                 result = {"_mcp_response": result, "_mcp_warnings": warnings}
         return result
 
-    @mcp.tool()
+    @mcp.tool(annotations=IDEMPOTENT_WRITE)
     async def update_component_parameters(
         project_id: Annotated[UUID, Field(description="The project ID (from list_projects or get_project_overview).")],
         graph_runner_id: Annotated[
@@ -552,15 +555,18 @@ def register(mcp: FastMCP) -> None:
                 non_literal_conflicts.append((field_name, existing_type))
                 continue
             if new_value is not None:
-                expr = {"type": "literal", "value": str(new_value)}
+                # The engine's LiteralNode holds a string; non-string values must be
+                # serialized as JSON (not Python repr) so JSON-typed inputs parse them.
+                expression_text = new_value if isinstance(new_value, str) else json.dumps(new_value)
+                expr = {"type": "literal", "value": expression_text}
                 if existing_fe:
                     existing_fe["expression_json"] = expr
-                    existing_fe["expression_text"] = str(new_value)
+                    existing_fe["expression_text"] = expression_text
                 else:
                     field_expr_list.append({
                         "field_name": field_name,
                         "expression_json": expr,
-                        "expression_text": str(new_value),
+                        "expression_text": expression_text,
                     })
             elif existing_fe:
                 field_expr_list.remove(existing_fe)
@@ -581,10 +587,7 @@ def register(mcp: FastMCP) -> None:
             "parameters": existing_params,
         }
 
-        v2_path = (
-            f"/v2/projects/{project_id}/graph/{graph_runner_id}"
-            f"/components/{component_instance_id}"
-        )
+        v2_path = f"/v2/projects/{project_id}/graph/{graph_runner_id}/components/{component_instance_id}"
         try:
             await api.put(v2_path, jwt, json=component_data)
         except ToolError as exc:

--- a/mcp_server/tools/knowledge.py
+++ b/mcp_server/tools/knowledge.py
@@ -15,7 +15,9 @@ from pydantic import Field
 
 from mcp_server.client import api
 from mcp_server.context import require_role
+from mcp_server.tools._annotations import DESTRUCTIVE_WRITE, NON_DESTRUCTIVE_WRITE
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
+from mcp_server.tools._roles import DEVELOPER_ROLES
 from mcp_server.tools.context_tools import _get_auth
 
 _WEBSITE_REQUIRED = ("url",)
@@ -48,7 +50,12 @@ PROXY_SPECS: list[ToolSpec] = [
         path="/sources/{org_id}/{source_id}",
         scope="org",
         path_params=(_SOURCE_ID,),
-        body_param=Param("source_data", dict, description="Ignored by backend. Kept for API compatibility."),
+        body_param=Param(
+            "source_data",
+            dict,
+            default=None,
+            description="Deprecated, ignored by the backend — omit this parameter.",
+        ),
     ),
     ToolSpec(
         name="delete_source",
@@ -59,7 +66,7 @@ PROXY_SPECS: list[ToolSpec] = [
         method="delete",
         path="/sources/{org_id}/{source_id}",
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         path_params=(_SOURCE_ID,),
     ),
     ToolSpec(
@@ -107,7 +114,7 @@ PROXY_SPECS: list[ToolSpec] = [
         method="delete",
         path="/knowledge/organizations/{org_id}/sources/{source_id}/documents/{document_id}",
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         path_params=(_SOURCE_ID, _DOC_ID),
     ),
 ]
@@ -164,7 +171,7 @@ _CONFIG_VALIDATORS = {
 def register(mcp: FastMCP) -> None:
     register_proxy_tools(mcp, PROXY_SPECS)
 
-    @mcp.tool()
+    @mcp.tool(annotations=NON_DESTRUCTIVE_WRITE)
     async def create_source(
         source_type: Annotated[
             Literal["website", "database"],
@@ -203,7 +210,7 @@ def register(mcp: FastMCP) -> None:
                 name = f"Database: {config['source_table_name']}"
 
         jwt, user_id = _get_auth()
-        org = await require_role(user_id, "developer", "admin", "super_admin")
+        org = await require_role(user_id, *DEVELOPER_ROLES)
 
         payload = {
             "source_name": name,
@@ -220,30 +227,24 @@ def register(mcp: FastMCP) -> None:
             "source_type": source_type,
             "source_name": name,
             "message": (
-                "Ingestion task created. The source will appear in list_sources "
-                "once ingestion starts processing."
+                "Ingestion task created. The source will appear in list_sources once ingestion starts processing."
             ),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations=DESTRUCTIVE_WRITE)
     async def update_document_chunks(
         source_id: Annotated[UUID, Field(description="The source ID (from list_sources).")],
         document_id: Annotated[UUID, Field(description="The document ID (from list_documents).")],
         chunks: Annotated[
             list[dict],
             Field(
-                description=(
-                    "List of chunk objects. Each chunk: content (str, required), "
-                    "metadata (dict, optional)."
-                ),
+                description=("List of chunk objects. Each chunk: content (str, required), metadata (dict, optional)."),
             ),
         ],
         confirm_full_replacement: Annotated[
             bool,
             Field(
-                description=(
-                    "Explicit acknowledgement that this is a risky full replacement operation."
-                ),
+                description=("Explicit acknowledgement that this is a risky full replacement operation."),
             ),
         ] = False,
     ) -> dict:
@@ -261,7 +262,7 @@ def register(mcp: FastMCP) -> None:
                 "Retry only if the user explicitly wants a full replacement and pass confirm_full_replacement=True."
             )
         jwt, user_id = _get_auth()
-        org = await require_role(user_id, "developer", "admin", "super_admin")
+        org = await require_role(user_id, *DEVELOPER_ROLES)
         return await api.put(
             f"/knowledge/organizations/{org['org_id']}/sources/{source_id}/documents/{document_id}",
             jwt,

--- a/mcp_server/tools/monitoring.py
+++ b/mcp_server/tools/monitoring.py
@@ -9,6 +9,7 @@ from pydantic import Field
 
 from mcp_server.client import api
 from mcp_server.context import require_org_context
+from mcp_server.tools._annotations import READ_ONLY
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
 from mcp_server.tools.context_tools import _get_auth
 
@@ -78,7 +79,7 @@ def _normalize_duration(duration: int) -> int:
 def register(mcp: FastMCP) -> None:
     register_proxy_tools(mcp, PROXY_SPECS)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def list_traces(
         project_id: Annotated[UUID, Field(description="The project ID (from list_projects or get_project_overview).")],
         duration: Annotated[
@@ -119,7 +120,7 @@ def register(mcp: FastMCP) -> None:
         jwt, _ = _get_auth()
         return await api.get(f"/projects/{project_id}/traces", jwt, **params)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_org_charts(
         duration: Annotated[
             int,
@@ -132,7 +133,7 @@ def register(mcp: FastMCP) -> None:
         org = await require_org_context(user_id)
         return await api.get(f"/monitor/org/{org['org_id']}/charts", jwt, duration=duration)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_org_kpis(
         duration: Annotated[
             int,

--- a/mcp_server/tools/oauth_connections.py
+++ b/mcp_server/tools/oauth_connections.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from fastmcp import FastMCP
 
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
+from mcp_server.tools._roles import DEVELOPER_ROLES
 
 _BASE = "/organizations/{org_id}/oauth-connections"
 
@@ -20,7 +21,7 @@ SPECS: list[ToolSpec] = [
         method="get",
         path=_BASE,
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         query_params=(
             Param(
                 "provider_config_key",
@@ -37,7 +38,7 @@ SPECS: list[ToolSpec] = [
         method="get",
         path=f"{_BASE}/status",
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         query_params=(
             Param("provider_config_key", str, description="Provider key (e.g. 'google-mail', 'slack')."),
             Param(
@@ -54,7 +55,7 @@ SPECS: list[ToolSpec] = [
         method="delete",
         path=f"{_BASE}/{{connection_id}}",
         scope="role",
-        roles=("developer", "admin", "super_admin"),
+        roles=DEVELOPER_ROLES,
         path_params=(Param("connection_id", UUID, description="The connection ID (from list_oauth_connections)."),),
         query_params=(Param("provider_config_key", str, description="Provider key (e.g. 'google-mail', 'slack')."),),
     ),

--- a/mcp_server/tools/projects.py
+++ b/mcp_server/tools/projects.py
@@ -8,8 +8,10 @@ from pydantic import Field
 
 from mcp_server.client import api
 from mcp_server.context import require_org_context, require_role
+from mcp_server.tools._annotations import IDEMPOTENT_WRITE, NON_DESTRUCTIVE_WRITE, READ_ONLY
 from mcp_server.tools._defaults import generate_entity_defaults
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
+from mcp_server.tools._roles import DEVELOPER_ROLES
 from mcp_server.tools.context_tools import _get_auth
 
 PROXY_SPECS: list[ToolSpec] = [
@@ -60,7 +62,7 @@ PROXY_SPECS: list[ToolSpec] = [
 def register(mcp: FastMCP) -> None:
     register_proxy_tools(mcp, PROXY_SPECS)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def list_projects(
         project_type: Annotated[
             Literal["WORKFLOW", "AGENT"],
@@ -73,7 +75,10 @@ def register(mcp: FastMCP) -> None:
             ),
         ] = False,
     ) -> list[dict]:
-        """List all projects in the active organization.
+        """List projects of one type in the active organization.
+
+        Defaults to WORKFLOW projects — call again with project_type="AGENT"
+        to see agent projects.
 
         ⚠️ When ``include_templates`` is True, the response includes global
         template projects from **other organizations** (e.g. the platform
@@ -89,7 +94,7 @@ def register(mcp: FastMCP) -> None:
             include_templates=str(include_templates).lower(),
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=NON_DESTRUCTIVE_WRITE)
     async def create_workflow(
         name: Annotated[str, Field(description="Project name.")],
         description: Annotated[str, Field(description="Optional description.")] = "",
@@ -111,7 +116,7 @@ def register(mcp: FastMCP) -> None:
             raise ValueError("name must not be empty")
 
         jwt, user_id = _get_auth()
-        org = await require_role(user_id, "developer", "admin", "super_admin")
+        org = await require_role(user_id, *DEVELOPER_ROLES)
         defaults = generate_entity_defaults()
         return await api.post(
             f"/projects/{org['org_id']}",
@@ -125,7 +130,7 @@ def register(mcp: FastMCP) -> None:
             },
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=IDEMPOTENT_WRITE)
     async def update_project(
         project_id: Annotated[
             UUID,
@@ -150,7 +155,7 @@ def register(mcp: FastMCP) -> None:
             raise ValueError("At least one field must be provided")
         return await api.patch(f"/projects/{project_id}", jwt, json=body)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_project_overview(
         project_id: Annotated[
             UUID,

--- a/mcp_server/tools/qa.py
+++ b/mcp_server/tools/qa.py
@@ -10,15 +10,17 @@ from fastmcp import FastMCP
 from pydantic import Field
 
 from mcp_server.client import api
+from mcp_server.context import require_org_context
+from mcp_server.tools._annotations import NON_DESTRUCTIVE_WRITE, READ_ONLY
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
+from mcp_server.tools._roles import DEVELOPER_ROLES
 from mcp_server.tools.context_tools import _get_auth
 
-_P_ORG = Param("organization_id", UUID, description="The organization ID (from select_organization).")
 _P_PROJECT = Param("project_id", UUID, description="The project ID (from list_projects or get_project_overview).")
 _P_DATASET = Param("dataset_id", UUID, description="The dataset ID (from list_datasets or create_dataset).")
 _P_JUDGE = Param("judge_id", UUID, description="The judge ID (from list_judges or create_judge).")
 
-_ORG_QA = "/organizations/{organization_id}/qa"
+_ORG_QA = "/organizations/{org_id}/qa"
 _DS = f"{_ORG_QA}/datasets"
 _DS_ITEM = f"{_DS}/{{dataset_id}}"
 _ENTRIES = f"{_DS_ITEM}/entries"
@@ -28,6 +30,10 @@ _JUDGE_ITEM = f"{_JUDGES}/{{judge_id}}"
 
 _PROJ_QA = "/projects/{project_id}/qa"
 
+MAX_CSV_EXPORT_CHARS = 200_000
+MAX_CSV_EXPORT_PAGES = 100
+MAX_CSV_IMPORT_CHARS = 1_000_000
+
 SPECS: list[ToolSpec] = [
     # --- Datasets (org-scoped) ---
     ToolSpec(
@@ -35,7 +41,7 @@ SPECS: list[ToolSpec] = [
         description="List QA datasets for an organization.",
         method="get",
         path=_DS,
-        path_params=(_P_ORG,),
+        scope="org",
         return_annotation=list,
     ),
     ToolSpec(
@@ -47,9 +53,10 @@ SPECS: list[ToolSpec] = [
         ),
         method="post",
         path=_DS,
-        path_params=(_P_ORG,),
+        scope="org",
         body_param=Param(
-            "dataset_data", dict,
+            "dataset_data",
+            dict,
             description="Dataset configuration. Required fields: datasets_name (list[str]).",
         ),
     ),
@@ -58,7 +65,8 @@ SPECS: list[ToolSpec] = [
         description="Rename a QA dataset.",
         method="patch",
         path=_DS_ITEM,
-        path_params=(_P_ORG, _P_DATASET),
+        scope="org",
+        path_params=(_P_DATASET,),
         query_params=(Param("dataset_name", str, description="New name for the dataset."),),
     ),
     ToolSpec(
@@ -66,7 +74,8 @@ SPECS: list[ToolSpec] = [
         description="Destructive. Delete one or more QA datasets.",
         method="delete",
         path=_DS,
-        path_params=(_P_ORG,),
+        scope="role",
+        roles=DEVELOPER_ROLES,
         body_fields=(Param("dataset_ids", list, description="List of dataset IDs to delete."),),
     ),
     ToolSpec(
@@ -74,7 +83,8 @@ SPECS: list[ToolSpec] = [
         description="Set which projects a dataset is associated with (replaces existing associations).",
         method="put",
         path=f"{_DS_ITEM}/projects",
-        path_params=(_P_ORG, _P_DATASET),
+        scope="org",
+        path_params=(_P_DATASET,),
         body_fields=(Param("project_ids", list, description="List of project IDs to associate."),),
     ),
     # --- Entries (org-scoped) ---
@@ -92,7 +102,8 @@ SPECS: list[ToolSpec] = [
         ),
         method="get",
         path=_ENTRIES,
-        path_params=(_P_ORG, _P_DATASET),
+        scope="org",
+        path_params=(_P_DATASET,),
         query_params=(
             Param("page", int, default=1, description="Page number (1-based)."),
             Param("page_size", int, default=100, description="Items per page (max 1000)."),
@@ -102,20 +113,24 @@ SPECS: list[ToolSpec] = [
         name="create_entries",
         description=(
             "Add entries to a QA dataset.\n\n"
-            "Each entry requires `input` (dict, e.g. {\"role\": \"user\", \"content\": \"hello\"}) "
+            'Each entry requires `input` (dict, e.g. {"role": "user", "content": "hello"}) '
             "and optionally `groundtruth` (str), `position` (int >= 1), "
             "and `custom_columns` (dict).\n\n"
             "Custom columns: keys MUST be the column UUID (not the display name). "
             "Call `list_custom_columns` first to get the `column_id` → `column_name` mapping. "
-            "Example: `{\"1b39fa0b-...\": \"my value\"}`, NOT `{\"my column\": \"my value\"}`."
+            'Example: `{"1b39fa0b-...": "my value"}`, NOT `{"my column": "my value"}`.'
         ),
         method="post",
         path=_ENTRIES,
-        path_params=(_P_ORG, _P_DATASET),
-        body_fields=(Param(
-            "inputs_groundtruths", list,
-            description="List of input/groundtruth objects.",
-        ),),
+        scope="org",
+        path_params=(_P_DATASET,),
+        body_fields=(
+            Param(
+                "inputs_groundtruths",
+                list,
+                description="List of input/groundtruth objects.",
+            ),
+        ),
     ),
     ToolSpec(
         name="update_entries",
@@ -130,21 +145,28 @@ SPECS: list[ToolSpec] = [
         ),
         method="patch",
         path=_ENTRIES,
-        path_params=(_P_ORG, _P_DATASET),
-        body_fields=(Param(
-            "inputs_groundtruths", list,
-            description="List of input/groundtruth objects with their IDs and updated fields.",
-        ),),
+        scope="org",
+        path_params=(_P_DATASET,),
+        body_fields=(
+            Param(
+                "inputs_groundtruths",
+                list,
+                description="List of input/groundtruth objects with their IDs and updated fields.",
+            ),
+        ),
     ),
     ToolSpec(
         name="delete_entries",
         description="Destructive. Delete entries from a QA dataset.",
         method="delete",
         path=_ENTRIES,
-        path_params=(_P_ORG, _P_DATASET),
+        scope="role",
+        roles=DEVELOPER_ROLES,
+        path_params=(_P_DATASET,),
         body_fields=(
             Param(
-                "input_groundtruth_ids", list,
+                "input_groundtruth_ids",
+                list,
                 description="List of input/groundtruth pair IDs to delete (as returned by list_entries).",
             ),
         ),
@@ -154,7 +176,8 @@ SPECS: list[ToolSpec] = [
         description="Save a trace execution as a QA dataset entry.",
         method="post",
         path=f"{_ENTRIES}/from-history",
-        path_params=(_P_ORG, _P_DATASET),
+        scope="org",
+        path_params=(_P_DATASET,),
         query_params=(Param("trace_id", UUID, description="The trace ID to save as a QA entry (from list_traces)."),),
     ),
     # --- Custom Columns (org-scoped) ---
@@ -170,7 +193,8 @@ SPECS: list[ToolSpec] = [
         ),
         method="get",
         path=_CUSTOM_COLS,
-        path_params=(_P_ORG, _P_DATASET),
+        scope="org",
+        path_params=(_P_DATASET,),
         return_annotation=list,
     ),
     # --- QA Runs (project-scoped) ---
@@ -184,8 +208,10 @@ SPECS: list[ToolSpec] = [
         method="post",
         path=f"{_PROJ_QA}/datasets/{{dataset_id}}/run",
         path_params=(_P_PROJECT, _P_DATASET),
+        annotations={"openWorldHint": True},
         body_param=Param(
-            "run_config", dict,
+            "run_config",
+            dict,
             description=(
                 "Run configuration. Required: graph_runner_id (str). "
                 "Plus either input_ids (list[str]) or run_all (bool)."
@@ -198,7 +224,7 @@ SPECS: list[ToolSpec] = [
         description="List LLM judges for an organization.",
         method="get",
         path=_JUDGES,
-        path_params=(_P_ORG,),
+        scope="org",
         return_annotation=list,
     ),
     ToolSpec(
@@ -209,15 +235,13 @@ SPECS: list[ToolSpec] = [
     ),
     ToolSpec(
         name="create_judge",
-        description=(
-            "Create a new LLM judge.\n\n"
-            "Use get_judge_defaults to see available types and prompt templates."
-        ),
+        description=("Create a new LLM judge.\n\nUse get_judge_defaults to see available types and prompt templates."),
         method="post",
         path=_JUDGES,
-        path_params=(_P_ORG,),
+        scope="org",
         body_param=Param(
-            "judge_data", dict,
+            "judge_data",
+            dict,
             description=(
                 "Judge configuration. Required: name (str), "
                 "evaluation_type ('boolean', 'score', 'free_text', or 'json_equality'), "
@@ -231,7 +255,8 @@ SPECS: list[ToolSpec] = [
         description="Update an LLM judge.",
         method="patch",
         path=_JUDGE_ITEM,
-        path_params=(_P_ORG, _P_JUDGE),
+        scope="org",
+        path_params=(_P_JUDGE,),
         body_param=Param("judge_data", dict, description="Updated judge fields."),
     ),
     ToolSpec(
@@ -239,7 +264,8 @@ SPECS: list[ToolSpec] = [
         description="Destructive. Delete one or more LLM judges.",
         method="delete",
         path=_JUDGES,
-        path_params=(_P_ORG,),
+        scope="role",
+        roles=DEVELOPER_ROLES,
         body_param=Param("judge_ids", list, description="List of judge IDs to delete."),
     ),
     ToolSpec(
@@ -247,7 +273,8 @@ SPECS: list[ToolSpec] = [
         description="Set which projects a judge is associated with (replaces existing associations).",
         method="put",
         path=f"{_JUDGE_ITEM}/projects",
-        path_params=(_P_ORG, _P_JUDGE),
+        scope="org",
+        path_params=(_P_JUDGE,),
         body_fields=(Param("project_ids", list, description="List of project IDs to associate."),),
     ),
     # --- Evaluations (project-scoped) ---
@@ -262,6 +289,7 @@ SPECS: list[ToolSpec] = [
         method="post",
         path=f"{_PROJ_QA}/llm-judges/{{judge_id}}/evaluations/run",
         path_params=(_P_PROJECT, _P_JUDGE),
+        annotations={"openWorldHint": True},
         body_fields=(
             Param(
                 "version_output_id",
@@ -287,68 +315,84 @@ SPECS: list[ToolSpec] = [
 def register(mcp: FastMCP) -> None:
     register_proxy_tools(mcp, SPECS)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def export_dataset_csv(
-        organization_id: Annotated[UUID, Field(description="The organization ID (from select_organization).")],
         dataset_id: Annotated[UUID, Field(description="The dataset ID (from list_datasets or create_dataset).")],
     ) -> str:
-        """Export all entries in a QA dataset as CSV text.
+        """Export entries of a QA dataset (active organization) as CSV text.
 
         Returns CSV with columns: position, input (JSON string), expected_output,
         plus custom columns (using display names as headers). Compatible with
         `import_dataset_csv` for round-trip workflows (sort, filter, migrate).
+
+        Output is capped at ~200K characters. A truncated export ends with a
+        `#TRUNCATED` line stating how many entries were included — never re-import
+        a truncated export; narrow the dataset or page with `list_entries` instead.
         """
-        jwt, _ = _get_auth()
+        jwt, user_id = _get_auth()
+        organization_id = (await require_org_context(user_id))["org_id"]
 
         columns = await api.get(
             f"/organizations/{organization_id}/qa/datasets/{dataset_id}/custom-columns",
-            jwt, trim=False,
+            jwt,
+            trim=False,
         )
         sorted_cols = sorted(columns, key=lambda c: c.get("column_display_position", 0))
 
         all_entries: list[dict] = []
+        total_items = 0
         page = 1
-        while True:
+        while page <= MAX_CSV_EXPORT_PAGES:
             resp = await api.get(
                 f"/organizations/{organization_id}/qa/datasets/{dataset_id}/entries",
-                jwt, page=page, page_size=100, trim=False,
+                jwt,
+                page=page,
+                page_size=100,
+                trim=False,
             )
+            pagination = resp.get("pagination", {})
+            total_items = pagination.get("total_items", 0)
             all_entries.extend(resp.get("inputs_groundtruths", []))
-            if page >= resp.get("pagination", {}).get("total_pages", 1):
+            if page >= pagination.get("total_pages", 1):
                 break
             page += 1
 
         headers = ["position", "input", "expected_output"]
         headers.extend(c["column_name"] for c in sorted_cols)
 
-        if not all_entries:
-            output = io.StringIO()
-            csv.writer(output).writerow(headers)
-            return output.getvalue()
-
         output = io.StringIO()
         writer = csv.writer(output)
         writer.writerow(headers)
 
+        included = 0
         for entry in sorted(all_entries, key=lambda e: e.get("position") or 0):
             custom = entry.get("custom_columns") or {}
             row = [
                 entry.get("position", ""),
-                json.dumps(entry.get("input", {})),
+                json.dumps(entry.get("input", {}), ensure_ascii=False),
                 entry.get("groundtruth", ""),
             ]
             row.extend(custom.get(c["column_id"], "") for c in sorted_cols)
             writer.writerow(row)
+            included += 1
+            if output.tell() > MAX_CSV_EXPORT_CHARS:
+                break
 
+        total = max(total_items, len(all_entries))
+        if included < total:
+            output.write(
+                f"#TRUNCATED: exported {included} of {total} entries "
+                f"(size cap {MAX_CSV_EXPORT_CHARS} chars). Do not re-import this CSV; "
+                "use list_entries with pagination for the rest.\n"
+            )
         return output.getvalue()
 
-    @mcp.tool()
+    @mcp.tool(annotations=NON_DESTRUCTIVE_WRITE)
     async def import_dataset_csv(
-        organization_id: Annotated[UUID, Field(description="The organization ID (from select_organization).")],
         dataset_id: Annotated[UUID, Field(description="The dataset ID (from list_datasets or create_dataset).")],
-        csv_content: Annotated[str, Field(description="The full CSV text to import.")],
+        csv_content: Annotated[str, Field(description="The full CSV text to import (max ~1MB).")],
     ) -> dict:
-        """Import entries into a QA dataset from CSV text.
+        """Import entries into a QA dataset (active organization) from CSV text.
 
         Required CSV columns: `input` (valid JSON string), `expected_output`.
         Optional: `position` (int >= 1). Any other column headers are treated as
@@ -360,7 +404,12 @@ def register(mcp: FastMCP) -> None:
         This appends entries. To replace all entries, delete existing ones first
         with `delete_entries`, then import.
         """
-        jwt, _ = _get_auth()
+        if len(csv_content) > MAX_CSV_IMPORT_CHARS:
+            raise ValueError(
+                f"csv_content exceeds the {MAX_CSV_IMPORT_CHARS} character limit. Split the CSV and import in batches."
+            )
+        jwt, user_id = _get_auth()
+        organization_id = (await require_org_context(user_id))["org_id"]
 
         return await api.post_file(
             f"/organizations/{organization_id}/qa/datasets/{dataset_id}/import",

--- a/mcp_server/tools/runs.py
+++ b/mcp_server/tools/runs.py
@@ -14,8 +14,9 @@ import httpx
 from fastmcp import FastMCP
 from pydantic import Field
 
-from mcp_server.client import api
+from mcp_server.client import ToolError, api
 from mcp_server.context import require_org_context
+from mcp_server.tools._annotations import EXECUTION, READ_ONLY
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
 from mcp_server.tools.context_tools import _get_auth
 
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_POLL_INTERVAL = 2
 MAX_POLL_INTERVAL = 10
+MAX_RUN_TIMEOUT = 600
 
 _P_PROJECT = Param("project_id", UUID, description="The project ID (from list_projects or get_project_overview).")
 _P_RUN = Param("run_id", UUID, description="The run ID (from list_runs or run).")
@@ -61,7 +63,7 @@ PROXY_SPECS: list[ToolSpec] = [
 def register(mcp: FastMCP) -> None:
     register_proxy_tools(mcp, PROXY_SPECS)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def list_runs(
         project_id: Annotated[
             Optional[UUID],
@@ -69,7 +71,11 @@ def register(mcp: FastMCP) -> None:
         ] = None,
         status: Annotated[
             Optional[str],
-            Field(description="Filter by status: 'pending', 'running', 'completed', or 'failed'."),
+            Field(
+                description=(
+                    "Filter by status: 'pending', 'running', 'completed', or 'failed'. Comma-separated for multiple."
+                )
+            ),
         ] = None,
         trigger: Annotated[
             Optional[str],
@@ -111,7 +117,7 @@ def register(mcp: FastMCP) -> None:
         if project_id is not None:
             params["project_ids"] = str(project_id)
         if status is not None:
-            params["statuses"] = status
+            params["statuses"] = [s for s in (s.strip() for s in status.split(",")) if s]
         if trigger is not None:
             params["triggers"] = [t for t in (t.strip() for t in trigger.split(",")) if t]
         if env is not None:
@@ -122,7 +128,7 @@ def register(mcp: FastMCP) -> None:
             params["date_to"] = date_to
         return await api.get(f"/org/{org['org_id']}/runs", jwt, **params)
 
-    @mcp.tool()
+    @mcp.tool(annotations=EXECUTION)
     async def retry_run(
         project_id: Annotated[
             UUID,
@@ -154,7 +160,7 @@ def register(mcp: FastMCP) -> None:
             json=body,
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=EXECUTION)
     async def run(
         project_id: Annotated[
             UUID,
@@ -170,7 +176,10 @@ def register(mcp: FastMCP) -> None:
                 description=('Request body dict — must contain "messages", may contain additional Start-node fields.'),
             ),
         ],
-        timeout: Annotated[int, Field(description="Max seconds to wait for completion.")] = 60,
+        timeout: Annotated[
+            int,
+            Field(description=f"Max seconds to wait for completion (capped at {MAX_RUN_TIMEOUT})."),
+        ] = 60,
     ) -> dict:
         """Run an agent or workflow and wait for the result.
 
@@ -196,6 +205,7 @@ def register(mcp: FastMCP) -> None:
         """
         if not isinstance(timeout, int) or timeout <= 0:
             raise ValueError("timeout must be a positive integer")
+        timeout = min(timeout, MAX_RUN_TIMEOUT)
         if "messages" not in payload:
             raise ValueError(
                 "payload must contain a 'messages' key. "
@@ -227,7 +237,7 @@ def register(mcp: FastMCP) -> None:
 
             try:
                 run_status = await api.get(f"/projects/{project_id}/runs/{run_id}", jwt)
-            except httpx.HTTPError as exc:
+            except (httpx.HTTPError, ToolError) as exc:
                 logger.warning("Transient error polling run %s: %s", run_id, exc)
                 interval = min(interval + 1, MAX_POLL_INTERVAL)
                 continue
@@ -237,7 +247,7 @@ def register(mcp: FastMCP) -> None:
             if status == "completed":
                 try:
                     return await api.get(f"/projects/{project_id}/runs/{run_id}/result", jwt)
-                except httpx.HTTPError:
+                except (httpx.HTTPError, ToolError):
                     return {
                         "status": "completed",
                         "run_id": run_id,

--- a/mcp_server/tools/runs.py
+++ b/mcp_server/tools/runs.py
@@ -237,7 +237,13 @@ def register(mcp: FastMCP) -> None:
 
             try:
                 run_status = await api.get(f"/projects/{project_id}/runs/{run_id}", jwt)
-            except (httpx.HTTPError, ToolError) as exc:
+            except ToolError as exc:
+                if not exc.is_transient:
+                    raise
+                logger.warning("Transient error polling run %s: %s", run_id, exc)
+                interval = min(interval + 1, MAX_POLL_INTERVAL)
+                continue
+            except httpx.HTTPError as exc:
                 logger.warning("Transient error polling run %s: %s", run_id, exc)
                 interval = min(interval + 1, MAX_POLL_INTERVAL)
                 continue

--- a/mcp_server/tools/variables.py
+++ b/mcp_server/tools/variables.py
@@ -6,8 +6,7 @@ All tools in this module require admin or super_admin role.
 from fastmcp import FastMCP
 
 from mcp_server.tools._factory import Param, ToolSpec, register_proxy_tools
-
-ADMIN_ROLES = ("admin", "super_admin")
+from mcp_server.tools._roles import ADMIN_ROLES
 
 _VAR_NAME = Param("name", str, description="Variable name (unique within org).")
 _SET_ID = Param("set_id", str, description="Variable set ID (from list_variable_sets).")
@@ -33,7 +32,8 @@ SPECS: list[ToolSpec] = [
         roles=ADMIN_ROLES,
         path_params=(_VAR_NAME,),
         body_param=Param(
-            "definition", dict,
+            "definition",
+            dict,
             description="Variable definition (type, default_value, description, etc.).",
         ),
     ),
@@ -78,25 +78,24 @@ SPECS: list[ToolSpec] = [
     # --- Secrets ---
     ToolSpec(
         name="list_secrets",
-        description="List all secrets in the active organization (values are masked). Requires admin role.",
+        description=(
+            "List secret key names in the active organization. "
+            "Returns {organization_id, secret_keys} — values are never returned. Requires admin role."
+        ),
         method="get",
         path="/org/{org_id}/secrets",
         scope="role",
         roles=ADMIN_ROLES,
-        return_annotation=list,
     ),
     ToolSpec(
         name="upsert_secret",
-        description="Create or update a secret. Requires admin role.",
+        description="Create or update a secret (sent in the request body, stored encrypted). Requires admin role.",
         method="put",
         path="/org/{org_id}/secrets/{key}",
         scope="role",
         roles=ADMIN_ROLES,
         path_params=(_SECRET_KEY,),
-        body_fields=(
-            Param("value", str, description="Secret value (stored encrypted)."),
-            Param("description", str, default="", description="Optional description."),
-        ),
+        body_fields=(Param("value", str, description="Secret value (stored encrypted)."),),
     ),
     ToolSpec(
         name="delete_secret",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,15 @@ tracing = [
     "openinference-semantic-conventions>=0.1.9,<0.2",
 ]
 api = ["gunicorn>=22.0.0,<23"]
-mcp-server = []
+# Self-contained dependency set for the standalone MCP server image
+# (installed with `uv sync --only-group mcp-server` in mcp_server/Dockerfile).
+mcp-server = [
+    "fastmcp>=3.2.0,<4",
+    "httpx>=0.28.1",
+    "redis>=5.2.1,<6",
+    "sentry-sdk>=2.54.0,<3",
+    "pydantic-settings>=2.6.1",
+]
 docx = ["pypandoc==1.14"]
 google_drive = [
     "google-api-python-client==2.119.0",

--- a/tests/mcp_server/conftest.py
+++ b/tests/mcp_server/conftest.py
@@ -24,11 +24,13 @@ FAKE_OTEL_TRACE_ID = "0x6d4e58f8ef17eae5436d8577814f6e60"
 class FakeMCP:
     def __init__(self):
         self.tools = {}
+        self.tool_annotations = {}
         self.resources = {}
 
-    def tool(self):
+    def tool(self, annotations=None):
         def decorator(func):
             self.tools[func.__name__] = func
+            self.tool_annotations[func.__name__] = annotations
             return func
 
         return decorator

--- a/tests/mcp_server/test_alert_emails.py
+++ b/tests/mcp_server/test_alert_emails.py
@@ -29,13 +29,13 @@ async def test_list_alert_emails(monkeypatch, fake_mcp):
 
 
 @pytest.mark.asyncio
-async def test_create_alert_email(monkeypatch, fake_mcp):
+async def test_create_alert_email_relies_on_backend_role_check(monkeypatch, fake_mcp):
+    """Project-scoped: the backend enforces the role in the project's own org,
+    so no MCP-level role gate (the session's active org may differ)."""
     mcp = fake_mcp
-    role_mock = AsyncMock(return_value={"org_id": "org-123"})
     post_mock = AsyncMock(return_value={"id": FAKE_ALERT_EMAIL_ID, "email": "dev@test.com"})
 
     monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-123"))
-    monkeypatch.setattr(_factory, "require_role", role_mock)
     monkeypatch.setattr(_factory.api, "post", post_mock)
 
     alert_emails.register(mcp)
@@ -43,7 +43,6 @@ async def test_create_alert_email(monkeypatch, fake_mcp):
     result = await mcp.tools["create_alert_email"](FAKE_PROJECT_ID, "dev@test.com")
 
     assert result == {"id": FAKE_ALERT_EMAIL_ID, "email": "dev@test.com"}
-    role_mock.assert_awaited_once_with("user-123", "developer", "admin", "super_admin")
     post_mock.assert_awaited_once_with(
         f"/projects/{FAKE_PROJECT_ID}/alert-emails",
         "jwt-token",
@@ -53,13 +52,11 @@ async def test_create_alert_email(monkeypatch, fake_mcp):
 
 
 @pytest.mark.asyncio
-async def test_delete_alert_email(monkeypatch, fake_mcp):
+async def test_delete_alert_email_relies_on_backend_role_check(monkeypatch, fake_mcp):
     mcp = fake_mcp
-    role_mock = AsyncMock(return_value={"org_id": "org-123"})
     delete_mock = AsyncMock(return_value={"status": "ok"})
 
     monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-123"))
-    monkeypatch.setattr(_factory, "require_role", role_mock)
     monkeypatch.setattr(_factory.api, "delete", delete_mock)
 
     alert_emails.register(mcp)
@@ -67,7 +64,6 @@ async def test_delete_alert_email(monkeypatch, fake_mcp):
     result = await mcp.tools["delete_alert_email"](FAKE_PROJECT_ID, FAKE_ALERT_EMAIL_ID)
 
     assert result == {"status": "ok"}
-    role_mock.assert_awaited_once_with("user-123", "developer", "admin", "super_admin")
     delete_mock.assert_awaited_once_with(
         f"/projects/{FAKE_PROJECT_ID}/alert-emails/{FAKE_ALERT_EMAIL_ID}",
         "jwt-token",

--- a/tests/mcp_server/test_api_keys.py
+++ b/tests/mcp_server/test_api_keys.py
@@ -3,17 +3,18 @@ from unittest.mock import AsyncMock
 import pytest
 
 from mcp_server.tools import _factory, api_keys
+from mcp_server.tools._roles import ADMIN_ROLES
 from tests.mcp_server.conftest import FAKE_KEY_ID, FAKE_PROJECT_ID
 
 
 @pytest.mark.asyncio
-async def test_revoke_org_api_key_sends_delete_body(monkeypatch, fake_mcp):
+async def test_revoke_org_api_key_requires_admin_and_sends_delete_body(monkeypatch, fake_mcp):
     mcp = fake_mcp
     delete_mock = AsyncMock(return_value={"status": "ok"})
-    require_org_context_mock = AsyncMock(return_value={"org_id": "org-123"})
+    require_role_mock = AsyncMock(return_value={"org_id": "org-123"})
 
     monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-123"))
-    monkeypatch.setattr(_factory, "require_org_context", require_org_context_mock)
+    monkeypatch.setattr(_factory, "require_role", require_role_mock)
     monkeypatch.setattr(_factory.api, "delete", delete_mock)
 
     api_keys.register(mcp)
@@ -21,7 +22,7 @@ async def test_revoke_org_api_key_sends_delete_body(monkeypatch, fake_mcp):
     result = await mcp.tools["revoke_org_api_key"](FAKE_KEY_ID)
 
     assert result == {"status": "ok"}
-    require_org_context_mock.assert_awaited_once_with("user-123")
+    require_role_mock.assert_awaited_once_with("user-123", *ADMIN_ROLES)
     delete_mock.assert_awaited_once_with(
         "/auth/org-api-key",
         "jwt-token",
@@ -53,13 +54,13 @@ async def test_create_project_api_key_sends_correct_body(monkeypatch, fake_mcp):
 
 
 @pytest.mark.asyncio
-async def test_create_org_api_key_sends_correct_body(monkeypatch, fake_mcp):
+async def test_create_org_api_key_requires_admin_and_sends_correct_body(monkeypatch, fake_mcp):
     mcp = fake_mcp
     post_mock = AsyncMock(return_value={"api_key": "sk-org"})
-    require_org_context_mock = AsyncMock(return_value={"org_id": "org-123"})
+    require_role_mock = AsyncMock(return_value={"org_id": "org-123"})
 
     monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-123"))
-    monkeypatch.setattr(_factory, "require_org_context", require_org_context_mock)
+    monkeypatch.setattr(_factory, "require_role", require_role_mock)
     monkeypatch.setattr(_factory.api, "post", post_mock)
 
     api_keys.register(mcp)
@@ -67,7 +68,7 @@ async def test_create_org_api_key_sends_correct_body(monkeypatch, fake_mcp):
     result = await mcp.tools["create_org_api_key"]("my-key")
 
     assert result == {"api_key": "sk-org"}
-    require_org_context_mock.assert_awaited_once_with("user-123")
+    require_role_mock.assert_awaited_once_with("user-123", *ADMIN_ROLES)
     post_mock.assert_awaited_once_with(
         "/auth/org-api-key",
         "jwt-token",

--- a/tests/mcp_server/test_client.py
+++ b/tests/mcp_server/test_client.py
@@ -181,3 +181,15 @@ def test_tool_error_is_fastmcp_tool_error():
     from fastmcp.exceptions import ToolError as FastMCPToolError
 
     assert issubclass(ToolError, FastMCPToolError)
+
+
+@pytest.mark.asyncio
+async def test_tool_errors_carry_status_code_and_transience():
+    for status, transient in [(401, False), (403, False), (404, False), (429, True), (500, True), (503, True)]:
+        response = httpx.Response(status, text="")
+        with pytest.raises(ToolError) as exc_info:
+            await _handle_response(response)
+        assert exc_info.value.status_code == status
+        assert exc_info.value.is_transient is transient
+
+    assert ToolError("no status").is_transient is True

--- a/tests/mcp_server/test_client.py
+++ b/tests/mcp_server/test_client.py
@@ -119,3 +119,65 @@ async def test_handle_generic_4xx_with_whitespace_only_detail():
 
     with pytest.raises(ToolError, match="No error detail returned"):
         await _handle_response(response)
+
+
+# --- _trim_response (the 50KB guardrail) ---
+
+from mcp_server.client import _trim_response  # noqa: E402
+from mcp_server.settings import settings  # noqa: E402
+
+
+@pytest.fixture
+def small_max_size(monkeypatch):
+    monkeypatch.setattr(settings, "MCP_RESPONSE_MAX_SIZE", 400)
+
+
+def test_trim_passes_small_responses_through(small_max_size):
+    data = {"a": 1}
+    assert _trim_response(data) is data
+
+
+def test_trim_list_keeps_prefix_and_reports_counts(small_max_size):
+    data = [{"i": i, "pad": "x" * 50} for i in range(20)]
+
+    result = _trim_response(data)
+
+    assert result["_truncated"] is True
+    assert result["_total_items"] == 20
+    assert 0 < result["_included_items"] < 20
+    assert result["partial_data"] == data[: result["_included_items"]]
+    assert len(json.dumps(result, default=str)) <= settings.MCP_RESPONSE_MAX_SIZE + 100
+
+
+def test_trim_list_first_item_too_big_returns_meta_only(small_max_size):
+    data = [{"huge": "x" * 1000}, {"small": 1}]
+
+    result = _trim_response(data)
+
+    assert result["_truncated"] is True
+    assert result["_included_items"] == 0
+    assert "partial_data" not in result
+
+
+def test_trim_dict_keeps_prefix_of_keys(small_max_size):
+    data = {f"key_{i}": "v" * 50 for i in range(20)}
+
+    result = _trim_response(data)
+
+    assert result["_truncated"] is True
+    keys = list(result["partial_data"].keys())
+    assert 0 < len(keys) < 20
+    assert keys == [f"key_{i}" for i in range(len(keys))]
+
+
+def test_trim_oversized_scalar_returns_meta(small_max_size):
+    result = _trim_response("y" * 1000)
+
+    assert result["_truncated"] is True
+    assert "partial_data" not in result
+
+
+def test_tool_error_is_fastmcp_tool_error():
+    from fastmcp.exceptions import ToolError as FastMCPToolError
+
+    assert issubclass(ToolError, FastMCPToolError)

--- a/tests/mcp_server/test_context.py
+++ b/tests/mcp_server/test_context.py
@@ -138,3 +138,51 @@ async def test_redis_recovery_after_retry_interval(monkeypatch):
 
     await context.set_active_org("user-1", "org-1", "Test Org", "admin", "public")
     assert not context._using_memory
+
+
+@pytest.mark.asyncio
+async def test_require_org_context_raises_without_selected_org(monkeypatch):
+    async def no_org(user_id):
+        return None
+
+    monkeypatch.setattr(context, "get_active_org", no_org)
+
+    with pytest.raises(ValueError, match="No organization selected"):
+        await context.require_org_context("user-123")
+
+
+@pytest.mark.asyncio
+async def test_require_role_allows_matching_role(monkeypatch):
+    async def org_with_role(user_id):
+        return {"org_id": "org-123", "role": "developer"}
+
+    monkeypatch.setattr(context, "get_active_org", org_with_role)
+
+    org = await context.require_role("user-123", "developer", "admin")
+
+    assert org["org_id"] == "org-123"
+
+
+@pytest.mark.asyncio
+async def test_require_role_rejects_insufficient_role(monkeypatch):
+    async def org_with_role(user_id):
+        return {"org_id": "org-123", "role": "member"}
+
+    monkeypatch.setattr(context, "get_active_org", org_with_role)
+
+    with pytest.raises(ValueError, match="your role is 'member'"):
+        await context.require_role("user-123", "developer", "admin")
+
+
+@pytest.mark.asyncio
+async def test_require_role_accepts_both_super_admin_spellings(monkeypatch):
+    from mcp_server.tools._roles import ADMIN_ROLES
+
+    for spelling in ("super_admin", "super-admin"):
+
+        async def org_with_role(user_id, _spelling=spelling):
+            return {"org_id": "org-123", "role": _spelling}
+
+        monkeypatch.setattr(context, "get_active_org", org_with_role)
+        org = await context.require_role("user-123", *ADMIN_ROLES)
+        assert org["role"] == spelling

--- a/tests/mcp_server/test_context_tools.py
+++ b/tests/mcp_server/test_context_tools.py
@@ -9,10 +9,12 @@ from tests.mcp_server.conftest import FAKE_ORG_ID
 class FakeMCP:
     def __init__(self):
         self.tools = {}
+        self.tool_annotations = {}
 
-    def tool(self):
+    def tool(self, annotations=None):
         def decorator(func):
             self.tools[func.__name__] = func
+            self.tool_annotations[func.__name__] = annotations
             return func
 
         return decorator
@@ -61,3 +63,82 @@ async def test_invite_org_member_invites_when_target_org_role_is_admin(monkeypat
 
     assert result == {"status": "ok"}
     invite_mock.assert_awaited_once_with("jwt-token", FAKE_ORG_ID, "person@example.com", "developer")
+
+
+@pytest.mark.asyncio
+async def test_select_organization_stores_org_with_release_stage(monkeypatch):
+    mcp = FakeMCP()
+    list_orgs_mock = AsyncMock(return_value=[{"id": FAKE_ORG_ID, "name": "Acme", "role": "developer"}])
+    stage_mock = AsyncMock(return_value="beta")
+    set_org_mock = AsyncMock()
+
+    monkeypatch.setattr(context_tools, "_get_auth", lambda: ("jwt-token", "user-123"))
+    monkeypatch.setattr(context_tools, "list_user_organizations", list_orgs_mock)
+    monkeypatch.setattr(context_tools, "fetch_org_release_stage", stage_mock)
+    monkeypatch.setattr(context_tools, "set_active_org", set_org_mock)
+
+    context_tools.register(mcp)
+
+    result = await mcp.tools["select_organization"](FAKE_ORG_ID)
+
+    assert result == {
+        "status": "ok",
+        "org_id": FAKE_ORG_ID,
+        "org_name": "Acme",
+        "role": "developer",
+        "release_stage": "beta",
+    }
+    set_org_mock.assert_awaited_once_with("user-123", FAKE_ORG_ID, "Acme", "developer", "beta")
+
+
+@pytest.mark.asyncio
+async def test_select_organization_rejects_unknown_org(monkeypatch):
+    mcp = FakeMCP()
+    list_orgs_mock = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(context_tools, "_get_auth", lambda: ("jwt-token", "user-123"))
+    monkeypatch.setattr(context_tools, "list_user_organizations", list_orgs_mock)
+
+    context_tools.register(mcp)
+
+    with pytest.raises(ValueError, match="not found in your memberships"):
+        await mcp.tools["select_organization"](FAKE_ORG_ID)
+
+
+@pytest.mark.asyncio
+async def test_list_my_organizations_returns_memberships(monkeypatch):
+    mcp = FakeMCP()
+    orgs = [{"id": FAKE_ORG_ID, "name": "Acme", "role": "admin"}]
+    list_orgs_mock = AsyncMock(return_value=orgs)
+
+    monkeypatch.setattr(context_tools, "_get_auth", lambda: ("jwt-token", "user-123"))
+    monkeypatch.setattr(context_tools, "list_user_organizations", list_orgs_mock)
+
+    context_tools.register(mcp)
+
+    assert await mcp.tools["list_my_organizations"]() == orgs
+
+
+@pytest.mark.asyncio
+async def test_get_current_context_reports_session_state(monkeypatch):
+    mcp = FakeMCP()
+
+    class FakeToken:
+        token = "jwt-token"
+        claims = {"sub": "user-123", "email": "dev@test.com"}
+
+    get_org_mock = AsyncMock(return_value={"org_id": FAKE_ORG_ID, "role": "member"})
+
+    monkeypatch.setattr(context_tools, "get_access_token", lambda: FakeToken())
+    monkeypatch.setattr(context_tools, "get_active_org", get_org_mock)
+    monkeypatch.setattr(context_tools._ctx, "_current_session_id", lambda: "session-abc")
+    monkeypatch.setattr(context_tools._ctx, "_using_memory", False)
+
+    context_tools.register(mcp)
+
+    result = await mcp.tools["get_current_context"]()
+
+    assert result["user_id"] == "user-123"
+    assert result["email"] == "dev@test.com"
+    assert result["active_organization"] == {"org_id": FAKE_ORG_ID, "role": "member"}
+    assert result["session"] == {"session_id": "session-abc", "storage_backend": "redis"}

--- a/tests/mcp_server/test_crons.py
+++ b/tests/mcp_server/test_crons.py
@@ -8,10 +8,12 @@ from mcp_server.tools import _factory, crons
 class FakeMCP:
     def __init__(self):
         self.tools = {}
+        self.tool_annotations = {}
 
-    def tool(self):
+    def tool(self, annotations=None):
         def decorator(func):
             self.tools[func.__name__] = func
+            self.tool_annotations[func.__name__] = annotations
             return func
 
         return decorator
@@ -40,9 +42,7 @@ async def test_cron_tools_interpolate_cron_ids(monkeypatch):
 
     encoded = "cron%2Fwith%20spaces%3F%23"
     get_mock.assert_awaited_once_with(f"/organizations/org-123/crons/{encoded}", "jwt-token", trim=True)
-    post_mock.assert_has_awaits(
-        [
-            call(f"/organizations/org-123/crons/{encoded}/pause", "jwt-token", trim=True),
-            call(f"/organizations/org-123/crons/{encoded}/trigger", "jwt-token", trim=True),
-        ]
-    )
+    post_mock.assert_has_awaits([
+        call(f"/organizations/org-123/crons/{encoded}/pause", "jwt-token", trim=True),
+        call(f"/organizations/org-123/crons/{encoded}/trigger", "jwt-token", trim=True),
+    ])

--- a/tests/mcp_server/test_factory.py
+++ b/tests/mcp_server/test_factory.py
@@ -13,10 +13,12 @@ from tests.mcp_server.conftest import FAKE_KEY_ID, FAKE_PROJECT_ID
 class FakeMCP:
     def __init__(self):
         self.tools = {}
+        self.tool_annotations = {}
 
-    def tool(self):
+    def tool(self, annotations=None):
         def decorator(func):
             self.tools[func.__name__] = func
+            self.tool_annotations[func.__name__] = annotations
             return func
 
         return decorator
@@ -40,15 +42,18 @@ async def test_auth_only_get(monkeypatch, mcp):
     get_mock = AsyncMock(return_value={"ok": True})
     monkeypatch.setattr(_factory.api, "get", get_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="get_thing",
-            description="Get a thing.",
-            method="get",
-            path="/things/{thing_id}",
-            path_params=(Param("thing_id", str),),
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="get_thing",
+                description="Get a thing.",
+                method="get",
+                path="/things/{thing_id}",
+                path_params=(Param("thing_id", str),),
+            ),
+        ],
+    )
 
     result = await mcp.tools["get_thing"](FAKE_PROJECT_ID)
 
@@ -66,16 +71,19 @@ async def test_org_scoped_get(monkeypatch, mcp):
     monkeypatch.setattr(_factory, "require_org_context", org_mock)
     monkeypatch.setattr(_factory.api, "get", get_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="list_things",
-            description="List things.",
-            method="get",
-            path="/orgs/{org_id}/things",
-            scope="org",
-            return_annotation=list,
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="list_things",
+                description="List things.",
+                method="get",
+                path="/orgs/{org_id}/things",
+                scope="org",
+                return_annotation=list,
+            ),
+        ],
+    )
 
     result = await mcp.tools["list_things"]()
 
@@ -94,17 +102,20 @@ async def test_role_scoped_delete(monkeypatch, mcp):
     monkeypatch.setattr(_factory, "require_role", role_mock)
     monkeypatch.setattr(_factory.api, "delete", del_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="delete_thing",
-            description="Delete.",
-            method="delete",
-            path="/orgs/{org_id}/things/{tid}",
-            scope="role",
-            roles=("admin",),
-            path_params=(Param("tid", str),),
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="delete_thing",
+                description="Delete.",
+                method="delete",
+                path="/orgs/{org_id}/things/{tid}",
+                scope="role",
+                roles=("admin",),
+                path_params=(Param("tid", str),),
+            ),
+        ],
+    )
 
     await mcp.tools["delete_thing"]("t-99")
 
@@ -120,15 +131,18 @@ async def test_path_params_are_url_encoded(monkeypatch, mcp):
     get_mock = AsyncMock(return_value={})
     monkeypatch.setattr(_factory.api, "get", get_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="get_item",
-            description="Get.",
-            method="get",
-            path="/items/{name}",
-            path_params=(Param("name", str),),
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="get_item",
+                description="Get.",
+                method="get",
+                path="/items/{name}",
+                path_params=(Param("name", str),),
+            ),
+        ],
+    )
 
     await mcp.tools["get_item"]("a/b c?d=1")
 
@@ -143,15 +157,18 @@ async def test_body_param_passthrough(monkeypatch, mcp):
     post_mock = AsyncMock(return_value={"id": "new"})
     monkeypatch.setattr(_factory.api, "post", post_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="create_thing",
-            description="Create.",
-            method="post",
-            path="/things",
-            body_param=Param("data", dict),
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="create_thing",
+                description="Create.",
+                method="post",
+                path="/things",
+                body_param=Param("data", dict),
+            ),
+        ],
+    )
 
     await mcp.tools["create_thing"]({"name": "X"})
 
@@ -166,15 +183,18 @@ async def test_body_fields_assembled(monkeypatch, mcp):
     del_mock = AsyncMock(return_value={"status": "ok"})
     monkeypatch.setattr(_factory.api, "delete", del_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="revoke_key",
-            description="Revoke.",
-            method="delete",
-            path="/keys",
-            body_fields=(Param("key_id", str),),
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="revoke_key",
+                description="Revoke.",
+                method="delete",
+                path="/keys",
+                body_fields=(Param("key_id", str),),
+            ),
+        ],
+    )
 
     await mcp.tools["revoke_key"](FAKE_KEY_ID)
 
@@ -191,22 +211,27 @@ async def test_body_org_key_injects_org_id(monkeypatch, mcp):
     monkeypatch.setattr(_factory, "require_org_context", org_mock)
     monkeypatch.setattr(_factory.api, "post", post_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="create_org_key",
-            description="Create.",
-            method="post",
-            path="/org-keys",
-            scope="org",
-            body_fields=(Param("name", str, default=""),),
-            body_org_key="organization_id",
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="create_org_key",
+                description="Create.",
+                method="post",
+                path="/org-keys",
+                scope="org",
+                body_fields=(Param("name", str, default=""),),
+                body_org_key="organization_id",
+            ),
+        ],
+    )
 
     await mcp.tools["create_org_key"](name="my-key")
 
     post_mock.assert_awaited_once_with(
-        "/org-keys", "jwt-tok", trim=True,
+        "/org-keys",
+        "jwt-tok",
+        trim=True,
         json={"name": "my-key", "organization_id": "org-5"},
     )
 
@@ -221,17 +246,20 @@ async def test_org_query_key_injects_org_id_as_param(monkeypatch, mcp):
     monkeypatch.setattr(_factory, "require_org_context", org_mock)
     monkeypatch.setattr(_factory.api, "get", get_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="list_org_keys",
-            description="List.",
-            method="get",
-            path="/org-keys",
-            scope="org",
-            org_query_key="organization_id",
-            return_annotation=list,
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="list_org_keys",
+                description="List.",
+                method="get",
+                path="/org-keys",
+                scope="org",
+                org_query_key="organization_id",
+                return_annotation=list,
+            ),
+        ],
+    )
 
     await mcp.tools["list_org_keys"]()
 
@@ -246,16 +274,19 @@ async def test_query_params_forwarded(monkeypatch, mcp):
     get_mock = AsyncMock(return_value=[])
     monkeypatch.setattr(_factory.api, "get", get_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="list_filtered",
-            description="List.",
-            method="get",
-            path="/items",
-            query_params=(Param("status", str, default=None),),
-            return_annotation=list,
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="list_filtered",
+                description="List.",
+                method="get",
+                path="/items",
+                query_params=(Param("status", str, default=None),),
+                return_annotation=list,
+            ),
+        ],
+    )
 
     await mcp.tools["list_filtered"](status="active")
     get_mock.assert_awaited_once_with("/items", "jwt-tok", trim=True, status="active")
@@ -266,16 +297,19 @@ async def test_query_params_none_skipped(monkeypatch, mcp):
     get_mock = AsyncMock(return_value=[])
     monkeypatch.setattr(_factory.api, "get", get_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="list_maybe",
-            description="List.",
-            method="get",
-            path="/items",
-            query_params=(Param("filter", str, default=None),),
-            return_annotation=list,
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="list_maybe",
+                description="List.",
+                method="get",
+                path="/items",
+                query_params=(Param("filter", str, default=None),),
+                return_annotation=list,
+            ),
+        ],
+    )
 
     await mcp.tools["list_maybe"]()
     get_mock.assert_awaited_once_with("/items", "jwt-tok", trim=True)
@@ -289,41 +323,50 @@ async def test_query_params_none_skipped(monkeypatch, mcp):
 
 def test_validate_spec_rejects_unresolved_placeholder(mcp):
     with pytest.raises(ValueError, match="unresolved placeholders"):
-        register_proxy_tools(mcp, [
-            ToolSpec(
-                name="bad_tool",
-                description="Bad.",
-                method="get",
-                path="/things/{thing_id}",
-            ),
-        ])
+        register_proxy_tools(
+            mcp,
+            [
+                ToolSpec(
+                    name="bad_tool",
+                    description="Bad.",
+                    method="get",
+                    path="/things/{thing_id}",
+                ),
+            ],
+        )
 
 
 def test_validate_spec_rejects_body_org_key_without_org_scope(mcp):
     with pytest.raises(ValueError, match="body_org_key.*requires scope"):
-        register_proxy_tools(mcp, [
-            ToolSpec(
-                name="bad_tool",
-                description="Bad.",
-                method="post",
-                path="/things",
-                scope="auth",
-                body_org_key="org_id",
-            ),
-        ])
+        register_proxy_tools(
+            mcp,
+            [
+                ToolSpec(
+                    name="bad_tool",
+                    description="Bad.",
+                    method="post",
+                    path="/things",
+                    scope="auth",
+                    body_org_key="org_id",
+                ),
+            ],
+        )
 
 
 def test_validate_spec_rejects_role_scope_without_roles(mcp):
     with pytest.raises(ValueError, match="scope='role' requires"):
-        register_proxy_tools(mcp, [
-            ToolSpec(
-                name="bad_tool",
-                description="Bad.",
-                method="get",
-                path="/things",
-                scope="role",
-            ),
-        ])
+        register_proxy_tools(
+            mcp,
+            [
+                ToolSpec(
+                    name="bad_tool",
+                    description="Bad.",
+                    method="get",
+                    path="/things",
+                    scope="role",
+                ),
+            ],
+        )
 
 
 # --- UUID type annotation ---
@@ -331,15 +374,19 @@ def test_validate_spec_rejects_role_scope_without_roles(mcp):
 
 def test_uuid_param_annotation_propagated(mcp):
     from uuid import UUID
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="get_widget",
-            description="Get.",
-            method="get",
-            path="/widgets/{widget_id}",
-            path_params=(Param("widget_id", UUID),),
-        ),
-    ])
+
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="get_widget",
+                description="Get.",
+                method="get",
+                path="/widgets/{widget_id}",
+                path_params=(Param("widget_id", UUID),),
+            ),
+        ],
+    )
 
     fn = mcp.tools["get_widget"]
     assert fn.__annotations__["widget_id"] is UUID
@@ -353,18 +400,21 @@ async def test_body_fields_none_values_omitted(monkeypatch, mcp):
     post_mock = AsyncMock(return_value={"id": "new"})
     monkeypatch.setattr(_factory.api, "post", post_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="create_with_optional",
-            description="Create.",
-            method="post",
-            path="/things",
-            body_fields=(
-                Param("name", str),
-                Param("tag", str, default=None),
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="create_with_optional",
+                description="Create.",
+                method="post",
+                path="/things",
+                body_fields=(
+                    Param("name", str),
+                    Param("tag", str, default=None),
+                ),
             ),
-        ),
-    ])
+        ],
+    )
 
     await mcp.tools["create_with_optional"](name="X")
     post_mock.assert_awaited_once_with("/things", "jwt-tok", trim=True, json={"name": "X"})
@@ -374,15 +424,18 @@ async def test_body_fields_none_values_omitted(monkeypatch, mcp):
 
 
 def test_handler_has_correct_name_and_doc(mcp):
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="my_tool",
-            description="Does something useful.",
-            method="get",
-            path="/x",
-            path_params=(Param("x_id", str, description="The X ID."),),
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="my_tool",
+                description="Does something useful.",
+                method="get",
+                path="/x",
+                path_params=(Param("x_id", str, description="The X ID."),),
+            ),
+        ],
+    )
 
     fn = mcp.tools["my_tool"]
     assert fn.__name__ == "my_tool"
@@ -403,16 +456,69 @@ async def test_trim_false_passed_to_api(monkeypatch, mcp):
     get_mock = AsyncMock(return_value={"big": "data"})
     monkeypatch.setattr(_factory.api, "get", get_mock)
 
-    register_proxy_tools(mcp, [
-        ToolSpec(
-            name="get_full",
-            description="Get.",
-            method="get",
-            path="/things/{thing_id}",
-            path_params=(Param("thing_id", str),),
-            trim=False,
-        ),
-    ])
+    register_proxy_tools(
+        mcp,
+        [
+            ToolSpec(
+                name="get_full",
+                description="Get.",
+                method="get",
+                path="/things/{thing_id}",
+                path_params=(Param("thing_id", str),),
+                trim=False,
+            ),
+        ],
+    )
 
     await mcp.tools["get_full"](FAKE_PROJECT_ID)
     get_mock.assert_awaited_once_with(f"/things/{FAKE_PROJECT_ID}", "jwt-tok", trim=False)
+
+
+# --- derive_annotations ---
+
+from mcp_server.tools._factory import derive_annotations  # noqa: E402
+
+
+def _minimal_spec(**kwargs):
+    defaults = dict(name="t", description="Test tool.", method="get", path="/x")
+    defaults.update(kwargs)
+    return ToolSpec(**defaults)
+
+
+def test_get_specs_are_read_only():
+    ann = derive_annotations(_minimal_spec(method="get"))
+    assert ann.readOnlyHint is True
+    assert ann.destructiveHint is False
+    assert ann.idempotentHint is True
+    assert ann.openWorldHint is False
+
+
+def test_delete_specs_are_destructive_and_idempotent():
+    ann = derive_annotations(_minimal_spec(method="delete"))
+    assert ann.readOnlyHint is False
+    assert ann.destructiveHint is True
+    assert ann.idempotentHint is True
+
+
+def test_destructive_description_marks_post_as_destructive():
+    ann = derive_annotations(_minimal_spec(method="post", description="Destructive. Drop it."))
+    assert ann.destructiveHint is True
+
+
+def test_plain_post_is_not_destructive():
+    ann = derive_annotations(_minimal_spec(method="post"))
+    assert ann.destructiveHint is False
+    assert ann.idempotentHint is False
+
+
+def test_explicit_annotations_override_derived():
+    ann = derive_annotations(_minimal_spec(method="post", annotations={"openWorldHint": True}))
+    assert ann.openWorldHint is True
+
+
+def test_registered_proxy_tools_carry_annotations(monkeypatch):
+    mcp = FakeMCP()
+    register_proxy_tools(mcp, [_minimal_spec(name="anno_probe")])
+    ann = mcp.tool_annotations["anno_probe"]
+    assert ann is not None
+    assert ann.readOnlyHint is True

--- a/tests/mcp_server/test_git_sync.py
+++ b/tests/mcp_server/test_git_sync.py
@@ -1,0 +1,51 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_server.tools import _factory, git_sync
+from mcp_server.tools._roles import DEVELOPER_ROLES
+from tests.mcp_server.conftest import FAKE_ORG_ID
+
+
+def _spec(name: str):
+    return next(s for s in git_sync.SPECS if s.name == name)
+
+
+def test_write_tools_require_developer_role():
+    for name in ("configure_git_sync", "disconnect_git_sync"):
+        spec = _spec(name)
+        assert spec.scope == "role"
+        assert spec.roles == DEVELOPER_ROLES
+
+
+def test_read_tools_are_org_scoped():
+    for name in ("list_git_sync_configs", "get_git_sync_config"):
+        assert _spec(name).scope == "org"
+
+
+@pytest.mark.asyncio
+async def test_configure_git_sync_sends_body_with_defaults(monkeypatch, fake_mcp):
+    post_mock = AsyncMock(return_value={"status": "ok"})
+    role_mock = AsyncMock(return_value={"org_id": FAKE_ORG_ID})
+
+    monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-123"))
+    monkeypatch.setattr(_factory, "require_role", role_mock)
+    monkeypatch.setattr(_factory.api, "post", post_mock)
+
+    git_sync.register(fake_mcp)
+
+    await fake_mcp.tools["configure_git_sync"]("acme", "agents-repo", github_installation_id=42)
+
+    role_mock.assert_awaited_once_with("user-123", *DEVELOPER_ROLES)
+    post_mock.assert_awaited_once_with(
+        f"/organizations/{FAKE_ORG_ID}/git-sync",
+        "jwt-token",
+        trim=True,
+        json={
+            "github_owner": "acme",
+            "github_repo_name": "agents-repo",
+            "branch": "main",
+            "github_installation_id": 42,
+            "project_type": "workflow",
+        },
+    )

--- a/tests/mcp_server/test_knowledge.py
+++ b/tests/mcp_server/test_knowledge.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from mcp_server.tools import knowledge
+from mcp_server.tools._roles import DEVELOPER_ROLES
 from tests.mcp_server.conftest import FAKE_DOC_ID, FAKE_SOURCE_ID
 
 
@@ -37,7 +38,7 @@ async def test_update_document_chunks_calls_backend_when_explicitly_confirmed(mo
     )
 
     assert result == {"status": "ok"}
-    require_role_mock.assert_awaited_once_with("user-123", "developer", "admin", "super_admin")
+    require_role_mock.assert_awaited_once_with("user-123", *DEVELOPER_ROLES)
     put_mock.assert_awaited_once_with(
         f"/knowledge/organizations/org-123/sources/{FAKE_SOURCE_ID}/documents/{FAKE_DOC_ID}",
         "jwt-token",
@@ -62,4 +63,4 @@ async def test_update_document_chunks_requires_developer_role(monkeypatch, fake_
             confirm_full_replacement=True,
         )
 
-    require_role_mock.assert_awaited_once_with("user-123", "developer", "admin", "super_admin")
+    require_role_mock.assert_awaited_once_with("user-123", *DEVELOPER_ROLES)

--- a/tests/mcp_server/test_oauth_connections.py
+++ b/tests/mcp_server/test_oauth_connections.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from mcp_server.tools import _factory, oauth_connections
+from mcp_server.tools._roles import DEVELOPER_ROLES
 from tests.mcp_server.conftest import FAKE_CONN_ID
 
 
@@ -20,7 +21,7 @@ async def test_list_oauth_connections_requires_role(monkeypatch, fake_mcp):
     result = await fake_mcp.tools["list_oauth_connections"]()
 
     assert result == [{"id": "c1"}]
-    role_mock.assert_awaited_once_with("user-123", "developer", "admin", "super_admin")
+    role_mock.assert_awaited_once_with("user-123", *DEVELOPER_ROLES)
     get_mock.assert_awaited_once_with("/organizations/org-123/oauth-connections", "jwt-token", trim=True)
 
 
@@ -38,7 +39,7 @@ async def test_check_oauth_status_sends_query_params(monkeypatch, fake_mcp):
     result = await fake_mcp.tools["check_oauth_status"]("google-mail", FAKE_CONN_ID)
 
     assert result == {"status": "active"}
-    role_mock.assert_awaited_once_with("user-123", "developer", "admin", "super_admin")
+    role_mock.assert_awaited_once_with("user-123", *DEVELOPER_ROLES)
     get_mock.assert_awaited_once_with(
         "/organizations/org-123/oauth-connections/status",
         "jwt-token",
@@ -62,7 +63,7 @@ async def test_revoke_oauth_sends_provider_query_param(monkeypatch, fake_mcp):
     result = await fake_mcp.tools["revoke_oauth"](FAKE_CONN_ID, "slack")
 
     assert result == {"status": "ok"}
-    role_mock.assert_awaited_once_with("user-123", "developer", "admin", "super_admin")
+    role_mock.assert_awaited_once_with("user-123", *DEVELOPER_ROLES)
     delete_mock.assert_awaited_once_with(
         f"/organizations/org-123/oauth-connections/{FAKE_CONN_ID}",
         "jwt-token",

--- a/tests/mcp_server/test_qa.py
+++ b/tests/mcp_server/test_qa.py
@@ -15,16 +15,17 @@ from tests.mcp_server.conftest import (
 @pytest.fixture
 def mcp(fake_mcp, monkeypatch):
     monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt-token", "user-1"))
+    monkeypatch.setattr(_factory, "require_org_context", AsyncMock(return_value={"org_id": FAKE_ORG_ID}))
     qa.register(fake_mcp)
     return fake_mcp
 
 
 @pytest.mark.asyncio
-async def test_update_dataset_sends_name_as_query_param(mcp, monkeypatch):
+async def test_update_dataset_uses_session_org_and_sends_name_as_query_param(mcp, monkeypatch):
     patch_mock = AsyncMock(return_value={"ok": True})
     monkeypatch.setattr(_factory.api, "patch", patch_mock)
 
-    await mcp.tools["update_dataset"](FAKE_ORG_ID, FAKE_DATASET_ID, "New Name")
+    await mcp.tools["update_dataset"](FAKE_DATASET_ID, "New Name")
 
     patch_mock.assert_awaited_once_with(
         f"/organizations/{FAKE_ORG_ID}/qa/datasets/{FAKE_DATASET_ID}",

--- a/tests/mcp_server/test_runs.py
+++ b/tests/mcp_server/test_runs.py
@@ -84,3 +84,55 @@ async def test_retry_run_posts_body(fake_mcp, monkeypatch):
 
     assert post_mock.call_args.args[0] == f"/projects/{FAKE_PROJECT_ID}/runs/{FAKE_RUN_ID}/retry"
     assert post_mock.call_args.kwargs["json"] == {"env": "draft"}
+
+
+@pytest.mark.asyncio
+async def test_run_polling_raises_on_non_transient_error(fake_mcp, monkeypatch):
+    """A 404 while polling means the run/project ID is wrong — surface it, don't retry."""
+    from mcp_server.client import ToolError
+
+    post_mock = AsyncMock(return_value={"run_id": str(FAKE_RUN_ID)})
+    get_mock = AsyncMock(side_effect=ToolError("Resource not found", status_code=404))
+    sleep_mock = AsyncMock()
+
+    monkeypatch.setattr(runs, "_get_auth", lambda: ("jwt", "uid-1"))
+    monkeypatch.setattr(runs, "api", type("API", (), {"post": post_mock, "get": get_mock})())
+    monkeypatch.setattr(runs.asyncio, "sleep", sleep_mock)
+
+    runs.register(fake_mcp)
+
+    with pytest.raises(ToolError, match="not found"):
+        await fake_mcp.tools["run"](
+            FAKE_PROJECT_ID, FAKE_RUNNER_ID, {"messages": [{"role": "user", "content": "hi"}]}, timeout=10
+        )
+
+    assert get_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_polling_retries_transient_backend_errors(fake_mcp, monkeypatch):
+    """A 503 while polling is transient — keep polling until the run completes."""
+    from mcp_server.client import ToolError
+
+    post_mock = AsyncMock(return_value={"run_id": str(FAKE_RUN_ID)})
+    get_mock = AsyncMock(
+        side_effect=[
+            ToolError("Backend temporarily unavailable", status_code=503),
+            {"status": "completed"},
+            {"result": "done"},
+        ]
+    )
+    sleep_mock = AsyncMock()
+
+    monkeypatch.setattr(runs, "_get_auth", lambda: ("jwt", "uid-1"))
+    monkeypatch.setattr(runs, "api", type("API", (), {"post": post_mock, "get": get_mock})())
+    monkeypatch.setattr(runs.asyncio, "sleep", sleep_mock)
+
+    runs.register(fake_mcp)
+
+    result = await fake_mcp.tools["run"](
+        FAKE_PROJECT_ID, FAKE_RUNNER_ID, {"messages": [{"role": "user", "content": "hi"}]}, timeout=30
+    )
+
+    assert result == {"result": "done"}
+    assert get_mock.await_count == 3

--- a/tests/mcp_server/test_server.py
+++ b/tests/mcp_server/test_server.py
@@ -1,0 +1,61 @@
+"""Tests for the Sentry scrubbers — security-critical redaction logic."""
+
+from mcp_server.server import _before_send, _scrub_sentry_value
+
+
+def test_scrubs_bearer_tokens_in_strings():
+    value = "Request failed: Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"
+    assert "eyJhbGciOiJIUzI1NiJ9" not in _scrub_sentry_value(value)
+    assert "Bearer [REDACTED]" in _scrub_sentry_value(value)
+
+
+def test_scrubs_sensitive_keys_case_insensitively():
+    event = {
+        "Authorization": "Bearer abc",
+        "api_key": "sk-123",
+        "PASSWORD": "hunter2",
+        "X-Cookie": "session=42",
+        "jwt_token": "ey...",
+        "safe_field": "keep me",
+    }
+    scrubbed = _scrub_sentry_value(event)
+    assert scrubbed["Authorization"] == "[REDACTED]"
+    assert scrubbed["api_key"] == "[REDACTED]"
+    assert scrubbed["PASSWORD"] == "[REDACTED]"
+    assert scrubbed["X-Cookie"] == "[REDACTED]"
+    assert scrubbed["jwt_token"] == "[REDACTED]"
+    assert scrubbed["safe_field"] == "keep me"
+
+
+def test_scrubs_user_id_fields_including_x_prefixed():
+    event = {"user": {"id": "u-1"}, "user_id": "u-1", "x_user_id": "u-1", "username": "keep"}
+    scrubbed = _scrub_sentry_value(event)
+    assert scrubbed["user"] == "[REDACTED]"
+    assert scrubbed["user_id"] == "[REDACTED]"
+    assert scrubbed["x_user_id"] == "[REDACTED]"
+    assert scrubbed["username"] == "keep"
+
+
+def test_scrubs_nested_structures():
+    event = {
+        "request": {
+            "headers": {"authorization": "Bearer abc"},
+            "breadcrumbs": [{"message": "sent Bearer xyz to backend"}],
+        }
+    }
+    scrubbed = _scrub_sentry_value(event)
+    assert scrubbed["request"]["headers"]["authorization"] == "[REDACTED]"
+    assert "xyz" not in scrubbed["request"]["breadcrumbs"][0]["message"]
+
+
+def test_before_send_returns_scrubbed_event():
+    event = {"extra": {"token": "secret-token", "detail": "Bearer abc123"}}
+    result = _before_send(event, {})
+    assert result["extra"]["token"] == "[REDACTED]"
+    assert "abc123" not in result["extra"]["detail"]
+
+
+def test_non_sensitive_scalars_pass_through():
+    assert _scrub_sentry_value(42) == 42
+    assert _scrub_sentry_value(None) is None
+    assert _scrub_sentry_value("plain message") == "plain message"

--- a/tests/mcp_server/test_variables.py
+++ b/tests/mcp_server/test_variables.py
@@ -5,9 +5,15 @@ import pytest
 from mcp_server.tools import variables
 
 ALL_TOOL_NAMES = [
-    "list_variable_definitions", "upsert_variable_definition", "delete_variable_definition",
-    "list_variable_sets", "upsert_variable_set", "delete_variable_set",
-    "list_secrets", "upsert_secret", "delete_secret",
+    "list_variable_definitions",
+    "upsert_variable_definition",
+    "delete_variable_definition",
+    "list_variable_sets",
+    "upsert_variable_set",
+    "delete_variable_set",
+    "list_secrets",
+    "upsert_secret",
+    "delete_secret",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -115,6 +115,13 @@ hubspot = [
 load-testing = [
     { name = "locust" },
 ]
+mcp-server = [
+    { name = "fastmcp" },
+    { name = "httpx" },
+    { name = "pydantic-settings" },
+    { name = "redis" },
+    { name = "sentry-sdk" },
+]
 mistralai = [
     { name = "mistralai" },
 ]
@@ -226,7 +233,13 @@ google-drive = [
 ]
 hubspot = [{ name = "fuzzywuzzy", specifier = ">=0.18.0,<0.19" }]
 load-testing = [{ name = "locust", specifier = ">=2.32.2,<3" }]
-mcp-server = []
+mcp-server = [
+    { name = "fastmcp", specifier = ">=3.2.0,<4" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pydantic-settings", specifier = ">=2.6.1" },
+    { name = "redis", specifier = ">=5.2.1,<6" },
+    { name = "sentry-sdk", specifier = ">=2.54.0,<3" },
+]
 mistralai = [{ name = "mistralai", specifier = ">=1.2.2,<2" }]
 postgres = [{ name = "psycopg2-binary", specifier = "==2.9.9" }]
 tracing = [


### PR DESCRIPTION
Linear: [DRA-1318](https://linear.app/draftnrun/issue/DRA-1318/full-mcp-server-audit-security-correctness-rbac-annotations-infra)

## What

Applies every finding from a full audit of the Draft'n Run MCP server (`mcp_server/`), plus the two backend issues the audit surfaced. 48 files, ~94 tools affected.

### Security
- **Cross-tenant IDOR on `GET /traces/{trace_id}/tree`**: the route only validated the JWT — any authenticated user could read any org's full span tree (LLM prompts, tool I/O) given a trace_id. It now resolves the trace's project(s) and checks org membership. Same change parameterizes the trace SQL queries: `trace_id` (a path **string**) was interpolated into raw SQL via f-string — an injection vector, also fixed in `query_trace_by_trace_id`.
- **`upsert_secret` was broken and leaky**: the MCP sent a JSON body while the backend expected the secret as a *query parameter* (every call 422'd, and the contract put plaintext secrets in access logs). The backend now accepts `{"value": ...}` in the body (query param kept temporarily for compat), the frontend sends the body, and the MCP drops its fabricated `description` parameter.
- **K8s blast radius**: the MCP pod consumed the entire `ada-secrets` (DB URL, Fernet key, all third-party keys). It now reads a dedicated `ada-mcp-secrets` (~9 vars); examples added to `infra/k8s/*/secrets.yaml.example`. A guard comment explains why `replicas: 1` is load-bearing (in-memory session fallback, no session affinity).
- **Slim image**: the `mcp-server` dependency group was empty, so the image installed the full backend tree (openai, pandas, llama-index, snowflake…). The group is now real and the Dockerfile uses `uv sync --only-group mcp-server` — venv goes from 836MB to **85MB**. `uv` is pinned; backend `settings.py`/`logger.py` no longer copied in.

### Correctness
- `run` polling caught `httpx.HTTPError` but the client raises `ToolError` for 5xx — a transient 502 aborted the whole call and lost the `run_id`. Now catches both; `timeout` capped at 600s; `list_runs` `status` filter accepts comma-separated values like `trigger`/`env`.
- `export_dataset_csv` paginated *all* entries with `trim=False` (unbounded output into LLM context). Now capped at ~200K chars with a `#TRUNCATED` marker; `import_dataset_csv` rejects >1MB.
- `configure_agent` could silently wipe an agent's system prompt when updating only e.g. `temperature`; it now falls back to the current prompt.
- `update_component_parameters` coerced values with `str()` (`True`→`"True"`, dicts→Python repr); non-string literals are serialized as JSON, matching the engine's `LiteralNode` contract.
- `_trim_response` rewritten from O(n²) to linear.

### MCP design
- **Tool annotations** (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`) on all ~94 tools — derived from the HTTP method in the proxy factory, shared presets in `tools/_annotations.py` for hand-written tools. Clients can now auto-approve reads and require confirmation for destructive calls.
- **RBAC unified** in `tools/_roles.py` (accepts both `super_admin` and `super-admin` — the data layer uses the hyphenated form, so the old tuples never matched). QA tools now use the session org (`organization_id` parameter removed), QA/knowledge deletions gated developer+, org API key create/revoke gated admin (matching the backend), and the `alert_emails` role gate — which checked the *active* org instead of the project's org — is removed in favor of the backend's per-project check.
- `client.ToolError` subclasses `fastmcp.exceptions.ToolError` so actionable error messages survive error masking; `update_source`'s required-but-ignored `source_data` is optional; `promote_version_to_env` `env` is a `Literal`.
- `docs.py` resynced with reality (variables guide had four wrong signatures, git-sync section contradicted the tool's own docstring, role table, QA scoping, CSV caps); README guardrails updated.

### Tests
+29 tests covering previously untested security seams: Sentry scrubbers, `_trim_response`, real `require_role`/`require_org_context` logic, `select_organization`/`get_current_context`, `git_sync`, and annotation derivation. Suite: **197 passed**.

## Reviewer notes

- ⚠️ **Before deploying: create `ada-mcp-secrets` on staging/prod clusters** (see `infra/k8s/*/secrets.yaml.example`), or the MCP pod won't start after this merges.
- The Docker build could not be run locally (no daemon); the `--only-group` resolution and a server import on the slim venv were verified directly — CI build will confirm.
- Breaking for in-flight MCP sessions only: QA tools no longer take `organization_id` (session org instead). New sessions are unaffected.
- The backend `upsert_secret` query param is kept as a deprecated fallback until the frontend change ships; it can be removed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down trace reads and the MCP server (tenant checks + scoped queries), fixes secret handling (JSON body only), adds tool annotations and unified RBAC, and slims the MCP image; requires creating the `ada-mcp-secrets` secret in staging and prod. Aligns with DRA-1318.

- New Features
  - Tool annotations on all tools (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`), derived in the proxy factory with presets in `mcp_server/tools/_annotations.py`.
  - Unified MCP RBAC in `mcp_server/tools/_roles.py`; QA tools use the session org, destructive actions require developer+, project API key create requires developer while org key create/revoke require admin.
  - `client.ToolError` subclasses `fastmcp.exceptions.ToolError` and carries `status_code` so clients can detect transient errors.

- Bug Fixes
  - Secured traces: `GET /traces/{trace_id}/tree` checks org membership via a single-project lookup, uses parameterized SQL, and the span-tree query is scoped to that authorized `project_id`; the route manages its own DB session.
  - Secrets: backend now requires a JSON body `{"value": ...}`; frontend sends the body; the old query param is removed to stop plaintext in logs.
  - Infra: MCP pod uses dedicated `ada-mcp-secrets`; `replicas: 1` guard; slimmer image via `uv sync --only-group mcp-server` with pinned `uv` (new `mcp-server` group in `pyproject.toml`).
  - Correctness: run polling only retries transient errors (`5xx`/`429`/transport) and surfaces `401/403/404`; 600s max timeout; `list_runs` accepts comma-separated `status`; CSV export/import capped; non-string literals JSON-serialized; agent updates keep prompts and preserve explicit `null`; response trimming is linear.
  - Docs/Tests: docs resynced (RBAC, QA session scoping, CSV caps, git-sync); added tests for security (Sentry scrubbers), RBAC, context, git-sync, annotations.

<sup>Written for commit 60db5c4e11051482baa0763197f7b425b516d4d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

