### PR TITLE
fix(engine): cap agent history by token budget to avoid context overflow

### DIFF
--- a/engine/components/history_message_handling.py
+++ b/engine/components/history_message_handling.py
@@ -1,7 +1,34 @@
+import json
+
 from engine.components.types import ChatMessage
 
 MINIMAL_FIRST_MESSAGE_RETAINED = 1  # To retain the prompt system message
 MINIMAL_LAST_MESSAGE_RETAINED = 50
+APPROXIMATE_CHARS_PER_TOKEN = 3.5
+# Conservative budget: keeps the estimated prompt size below the smallest context
+# windows of the supported providers (Anthropic 200k, OpenAI 128k), leaving room
+# for tool descriptions and the model response.
+DEFAULT_MAX_HISTORY_TOKENS = 100_000
+TRUNCATED_CONTENT_NOTICE = "\n\n[Content truncated because the conversation exceeded the model context window]"
+
+
+def _estimate_text_tokens(text: str) -> int:
+    return int(len(text) / APPROXIMATE_CHARS_PER_TOKEN)
+
+
+def estimate_message_tokens(message: ChatMessage) -> int:
+    char_count = 0
+    if isinstance(message.content, str):
+        char_count += len(message.content)
+    elif isinstance(message.content, list):
+        char_count += sum(len(str(item)) for item in message.content if item)
+    if message.tool_calls:
+        char_count += len(json.dumps([tool_call.model_dump() for tool_call in message.tool_calls], default=str))
+    return int(char_count / APPROXIMATE_CHARS_PER_TOKEN)
+
+
+def _estimate_total_tokens(messages: list[ChatMessage]) -> int:
+    return sum(estimate_message_tokens(message) for message in messages)
 
 
 class HistoryMessageHandler:
@@ -9,11 +36,17 @@ class HistoryMessageHandler:
         self,
         number_first_messages: int = MINIMAL_FIRST_MESSAGE_RETAINED,
         number_last_messages: int = MINIMAL_LAST_MESSAGE_RETAINED,
+        max_history_tokens: int | None = DEFAULT_MAX_HISTORY_TOKENS,
     ):
         self.number_first_messages = number_first_messages
         self.number_last_messages = number_last_messages
+        self.max_history_tokens = max_history_tokens
 
     def get_truncated_messages_history(self, messages: list[ChatMessage]) -> list[ChatMessage]:
+        truncated_by_count = self._truncate_by_message_count(messages)
+        return self._truncate_by_token_budget(truncated_by_count)
+
+    def _truncate_by_message_count(self, messages: list[ChatMessage]) -> list[ChatMessage]:
         if self.number_first_messages is None or self.number_last_messages is None:
             raise ValueError("No numbers of messages to find initial context and end of history were provided.")
 
@@ -31,3 +64,49 @@ class HistoryMessageHandler:
             # We still assume there is an alternating pattern of role and that last messages
             # have more than one message
             return first_part + last_part[1:]
+
+    def _truncate_by_token_budget(self, messages: list[ChatMessage]) -> list[ChatMessage]:
+        if self.max_history_tokens is None:
+            return messages
+        if _estimate_total_tokens(messages) <= self.max_history_tokens:
+            return messages
+
+        first_part = list(messages[: self.number_first_messages])
+        tail = list(messages[self.number_first_messages :])
+        while len(tail) > 1 and _estimate_total_tokens(first_part + tail) > self.max_history_tokens:
+            tail.pop(0)
+            self._drop_orphaned_tool_results(tail)
+        return self._shrink_oversized_contents(first_part + tail)
+
+    @staticmethod
+    def _drop_orphaned_tool_results(tail: list[ChatMessage]) -> None:
+        # A tool result without its preceding assistant tool_calls message is an invalid request
+        while len(tail) > 1 and tail[0].role == "tool":
+            tail.pop(0)
+
+    def _shrink_oversized_contents(self, messages: list[ChatMessage]) -> list[ChatMessage]:
+        excess_tokens = _estimate_total_tokens(messages) - self.max_history_tokens
+        if excess_tokens <= 0:
+            return messages
+
+        shrunk = list(messages)
+        indices_largest_first = sorted(
+            range(len(shrunk)), key=lambda index: estimate_message_tokens(shrunk[index]), reverse=True
+        )
+        notice_tokens = _estimate_text_tokens(TRUNCATED_CONTENT_NOTICE)
+        for index in indices_largest_first:
+            if excess_tokens <= 0:
+                break
+            message = shrunk[index]
+            if not isinstance(message.content, str):
+                continue
+            content_tokens = _estimate_text_tokens(message.content)
+            tokens_to_remove = min(excess_tokens + notice_tokens, content_tokens)
+            if tokens_to_remove <= 0:
+                continue
+            chars_to_keep = int((content_tokens - tokens_to_remove) * APPROXIMATE_CHARS_PER_TOKEN)
+            shrunk[index] = message.model_copy(
+                update={"content": message.content[:chars_to_keep] + TRUNCATED_CONTENT_NOTICE}
+            )
+            excess_tokens -= tokens_to_remove - notice_tokens
+        return shrunk

--- a/engine/components/history_message_handling.py
+++ b/engine/components/history_message_handling.py
@@ -31,6 +31,10 @@ def _estimate_total_tokens(messages: list[ChatMessage]) -> int:
     return sum(estimate_message_tokens(message) for message in messages)
 
 
+def _flatten(units: list[list[ChatMessage]]) -> list[ChatMessage]:
+    return [message for unit in units for message in unit]
+
+
 class HistoryMessageHandler:
     def __init__(
         self,
@@ -72,17 +76,25 @@ class HistoryMessageHandler:
             return messages
 
         first_part = list(messages[: self.number_first_messages])
-        tail = list(messages[self.number_first_messages :])
-        while len(tail) > 1 and _estimate_total_tokens(first_part + tail) > self.max_history_tokens:
-            tail.pop(0)
-            self._drop_orphaned_tool_results(tail)
-        return self._shrink_oversized_contents(first_part + tail)
+        tail_units = self._group_into_tool_call_units(messages[self.number_first_messages :])
+        while len(tail_units) > 1 and (
+            _estimate_total_tokens(first_part + _flatten(tail_units)) > self.max_history_tokens
+            or tail_units[0][0].role == "tool"
+        ):
+            tail_units.pop(0)
+        return self._shrink_oversized_contents(first_part + _flatten(tail_units))
 
     @staticmethod
-    def _drop_orphaned_tool_results(tail: list[ChatMessage]) -> None:
-        # A tool result without its preceding assistant tool_calls message is an invalid request
-        while len(tail) > 1 and tail[0].role == "tool":
-            tail.pop(0)
+    def _group_into_tool_call_units(messages: list[ChatMessage]) -> list[list[ChatMessage]]:
+        # A tool result without its preceding assistant tool_calls message is an invalid
+        # request, so an assistant message and its tool results are dropped as one unit
+        units: list[list[ChatMessage]] = []
+        for message in messages:
+            if message.role == "tool" and units:
+                units[-1].append(message)
+            else:
+                units.append([message])
+        return units
 
     def _shrink_oversized_contents(self, messages: list[ChatMessage]) -> list[ChatMessage]:
         excess_tokens = _estimate_total_tokens(messages) - self.max_history_tokens

--- a/tests/components/test_history_message_handling.py
+++ b/tests/components/test_history_message_handling.py
@@ -1,0 +1,102 @@
+from openai.types.chat import ChatCompletionMessageToolCall
+from openai.types.chat.chat_completion_message_tool_call import Function
+
+from engine.components.history_message_handling import (
+    TRUNCATED_CONTENT_NOTICE,
+    HistoryMessageHandler,
+    estimate_message_tokens,
+)
+from engine.components.types import ChatMessage
+
+
+def make_message(role: str, content: str, tool_call_id: str | None = None) -> ChatMessage:
+    return ChatMessage(role=role, content=content, tool_call_id=tool_call_id)
+
+
+def make_tool_call_message(tool_call_id: str) -> ChatMessage:
+    return ChatMessage(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            ChatCompletionMessageToolCall(
+                id=tool_call_id,
+                type="function",
+                function=Function(name="search", arguments="{}"),
+            )
+        ],
+    )
+
+
+def test_count_truncation_keeps_all_messages_when_short():
+    handler = HistoryMessageHandler(number_first_messages=1, number_last_messages=5)
+    messages = [make_message("system", "prompt")] + [make_message("user", f"q{i}") for i in range(3)]
+    assert handler.get_truncated_messages_history(messages) == messages
+
+
+def test_count_truncation_keeps_first_and_last_messages():
+    handler = HistoryMessageHandler(number_first_messages=1, number_last_messages=2)
+    messages = [
+        make_message("system", "prompt"),
+        make_message("user", "old question"),
+        make_message("assistant", "old answer"),
+        make_message("user", "new question"),
+        make_message("assistant", "new answer"),
+    ]
+    truncated = handler.get_truncated_messages_history(messages)
+    assert truncated == [messages[0], messages[3], messages[4]]
+
+
+def test_token_budget_drops_oldest_messages_first():
+    handler = HistoryMessageHandler(number_first_messages=1, number_last_messages=50, max_history_tokens=2_000)
+    big_content = "x" * 3_000  # ~857 estimated tokens each
+    messages = [
+        make_message("system", "prompt"),
+        make_message("user", big_content),
+        make_message("assistant", big_content),
+        make_message("user", big_content),
+    ]
+    truncated = handler.get_truncated_messages_history(messages)
+    assert truncated[0] is messages[0]
+    assert truncated[-1] is messages[-1]
+    assert len(truncated) < len(messages)
+    assert sum(estimate_message_tokens(message) for message in truncated) <= 2_000
+
+
+def test_token_budget_drops_orphaned_tool_results():
+    handler = HistoryMessageHandler(number_first_messages=1, number_last_messages=50, max_history_tokens=1_500)
+    big_tool_output = "x" * 4_000
+    messages = [
+        make_message("system", "prompt"),
+        make_message("user", "question"),
+        make_tool_call_message("call_1"),
+        make_message("tool", big_tool_output, tool_call_id="call_1"),
+        make_message("assistant", "answer"),
+        make_message("user", "follow-up"),
+    ]
+    truncated = handler.get_truncated_messages_history(messages)
+    roles = [message.role for message in truncated]
+    if "tool" in roles:
+        assert truncated[roles.index("tool") - 1].tool_calls is not None
+    assert truncated[-1] is messages[-1]
+
+
+def test_token_budget_shrinks_single_oversized_message():
+    handler = HistoryMessageHandler(number_first_messages=1, number_last_messages=50, max_history_tokens=1_000)
+    messages = [
+        make_message("system", "prompt"),
+        make_message("user", "x" * 100_000),
+    ]
+    truncated = handler.get_truncated_messages_history(messages)
+    assert len(truncated) == 2
+    assert truncated[1].content.endswith(TRUNCATED_CONTENT_NOTICE)
+    assert sum(estimate_message_tokens(message) for message in truncated) <= 1_000
+    assert messages[1].content == "x" * 100_000  # Input messages are not mutated
+
+
+def test_token_budget_disabled_returns_messages_unchanged():
+    handler = HistoryMessageHandler(number_first_messages=1, number_last_messages=50, max_history_tokens=None)
+    messages = [
+        make_message("system", "prompt"),
+        make_message("user", "x" * 1_000_000),
+    ]
+    assert handler.get_truncated_messages_history(messages) == messages

--- a/tests/components/test_history_message_handling.py
+++ b/tests/components/test_history_message_handling.py
@@ -62,7 +62,7 @@ def test_token_budget_drops_oldest_messages_first():
     assert sum(estimate_message_tokens(message) for message in truncated) <= 2_000
 
 
-def test_token_budget_drops_orphaned_tool_results():
+def test_token_budget_drops_tool_call_turns_as_a_unit():
     handler = HistoryMessageHandler(number_first_messages=1, number_last_messages=50, max_history_tokens=1_500)
     big_tool_output = "x" * 4_000
     messages = [
@@ -74,10 +74,29 @@ def test_token_budget_drops_orphaned_tool_results():
         make_message("user", "follow-up"),
     ]
     truncated = handler.get_truncated_messages_history(messages)
-    roles = [message.role for message in truncated]
-    if "tool" in roles:
-        assert truncated[roles.index("tool") - 1].tool_calls is not None
+    for index, message in enumerate(truncated):
+        if message.role == "tool":
+            assert truncated[index - 1].role in ("assistant", "tool")
+            assert any(prior.tool_calls for prior in truncated[:index])
     assert truncated[-1] is messages[-1]
+
+
+def test_token_budget_shrinks_last_turn_with_huge_parallel_tool_results():
+    # Production shape: one agent iteration with 4 parallel retriever calls,
+    # each returning more content than the whole budget allows
+    handler = HistoryMessageHandler(number_first_messages=1, number_last_messages=50, max_history_tokens=10_000)
+    messages = [
+        make_message("system", "prompt"),
+        make_message("user", "old question"),
+        make_message("assistant", "old answer"),
+        make_message("user", "new question"),
+        make_tool_call_message("call_1"),
+    ] + [make_message("tool", "x" * 50_000, tool_call_id=f"call_{i}") for i in range(4)]
+    truncated = handler.get_truncated_messages_history(messages)
+    roles = [message.role for message in truncated]
+    assert roles.count("tool") == 4
+    assert truncated[roles.index("tool") - 1].tool_calls is not None
+    assert sum(estimate_message_tokens(message) for message in truncated) <= 10_000
 
 
 def test_token_budget_shrinks_single_oversized_message():


### PR DESCRIPTION
## Context

Production issue 127220481 on ada-api (project `c4a57f65`, actu-environnement assistant): runs fail with `LLMProviderError: Anthropic error (400): prompt is too long: 204980 tokens > 200000 maximum`.

The AI agent's history truncation is purely message-count based (keep first 1 + last 50 messages). A multi-turn conversation where each turn includes large RAG tool outputs easily exceeds the model context window while staying well under 51 messages, so nothing was ever trimmed and the provider call failed hard.

## Fix

`HistoryMessageHandler` now enforces an estimated token budget (chars / 3.5, default 100k tokens) after the existing count-based truncation:

1. Drop oldest messages after the retained head until under budget, always keeping the last message.
2. Skip orphaned tool results when dropping, so a `tool` message never appears without its preceding assistant `tool_calls` message (which would itself be an invalid request).
3. As a last resort (a single oversized message), truncate the largest message contents with an explicit `[Content truncated…]` notice. Multimodal list contents are never altered.

Input messages are not mutated; truncation only affects what is sent to the LLM, not the stored history.

## Testing

- New unit tests in `tests/components/test_history_message_handling.py` covering count truncation, oldest-first dropping, orphaned tool-result handling, single-oversized-message shrinking, non-mutation, and the disabled-budget path.
- `pytest -k 'agent or history'` over `tests/components` and `tests/engine`: 24 passed.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent LLM context overflow by capping agent history with an estimated token budget after count-based truncation. Drops whole tool-call turns atomically to avoid orphaned `tool` messages while keeping the latest turn within provider limits.

- **Bug Fixes**
  - Enforce a budget (default 100k tokens; approx chars/3.5 including `tool_calls` JSON) after count truncation.
  - Drop oldest tail first as units (assistant `tool_calls` + `tool` results); never leave a standalone `tool` message; always keep the last message.
  - If still over budget, shrink the largest text content and add “[Content truncated because the conversation exceeded the model context window]”; multimodal contents are not altered.
  - Stored history is not mutated; only the outbound prompt is truncated. Unit tests cover unit-dropping, shrinking, disabled budget, and non-mutation.

<sup>Written for commit cded8bf9b231d5ea60574144e780c2bee38cef26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

