### PR TITLE
feat(component): fic outlook sender parameters UI dra-1325

### DIFF
--- a/ada_backend/database/seed/integrations/seed_outlook.py
+++ b/ada_backend/database/seed/integrations/seed_outlook.py
@@ -104,7 +104,7 @@ def seed_outlook_components(session: Session):
         id=COMPONENT_VERSION_UUIDS["outlook_sender_v2"],
         component_id=COMPONENT_UUIDS["outlook_sender"],
         version_tag="0.0.2",
-        release_stage=db.ReleaseStage.INTERNAL,
+        release_stage=db.ReleaseStage.BETA,
         description="A component to send emails using Microsoft Outlook with named URL attachments.",
         default_tool_description_id=TOOL_DESCRIPTION_UUIDS["outlook_sender_v2_tool_description"],
     )

--- a/engine/integrations/outlook/outlook_sender.py
+++ b/engine/integrations/outlook/outlook_sender.py
@@ -7,6 +7,7 @@ from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttribu
 from opentelemetry.trace import get_current_span
 from pydantic import BaseModel, Field, SecretStr, field_validator
 
+from ada_backend.database.models import UIComponent, UIComponentProperties
 from engine.components.component import Component
 from engine.components.types import ComponentAttributes, ToolDescription
 from engine.integrations.outlook.errors import OutlookAPIError
@@ -69,9 +70,7 @@ OUTLOOK_SENDER_TOOL_DESCRIPTION = ToolDescription(
                 "minProperties": 2,
                 "maxProperties": 2,
             },
-            "description": (
-                "List of attachment objects. Each item must include filename and either url or path."
-            ),
+            "description": ("List of attachment objects. Each item must include filename and either url or path."),
         },
     },
     required_tool_properties=["mail_subject"],
@@ -93,6 +92,11 @@ class OutlookSenderInputs(BaseModel):
         description="The body of the email to be sent.",
         json_schema_extra={
             "is_tool_input": True,
+            "ui_component": UIComponent.TEXTAREA,
+            "ui_component_properties": UIComponentProperties(
+                label="Body",
+                description="The body of the email to be sent. Don't support HTML formatting, use HTML body instead.",
+            ).model_dump(exclude_unset=True, exclude_none=True),
             "display_order": 2,
             "parameter_group_id": OUTLOOK_GROUP_EMAIL_CONTENT_ID,
             "parameter_order_within_group": 2,
@@ -103,6 +107,11 @@ class OutlookSenderInputs(BaseModel):
         description="Optional HTML body of the email. When provided, used instead of mail_body.",
         json_schema_extra={
             "is_tool_input": True,
+            "ui_component": UIComponent.TEXTAREA,
+            "ui_component_properties": UIComponentProperties(
+                label="HTML Body",
+                description="Optional HTML body of the email. When provided, used instead of mail_body.",
+            ).model_dump(exclude_unset=True, exclude_none=True),
             "display_order": 3,
             "parameter_group_id": OUTLOOK_GROUP_EMAIL_CONTENT_ID,
             "parameter_order_within_group": 3,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves the Outlook Sender parameter UI by adding textarea inputs with clear labels and help for email bodies, and makes attachments optional; also sets `outlook_sender_v2` v0.0.2 to BETA (DRA-1325).

- **New Features**
  - Adds `TEXTAREA` UI for `mail_body` (“Body”) and `html_body` (“HTML Body”) with help text.
  - Makes `email_attachments` optional (defaults to `None`) to avoid empty lists.
  - Sets `outlook_sender_v2` (v0.0.2) release stage to BETA in seeding.

<sup>Written for commit 295df871fcce31dba7f6bb601b53305e94963f5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

