### PR TITLE
fix(ci): fix staging migration detection after force pushes dra-1286

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -92,7 +92,7 @@ Org-scoped, independently versioned prompts (`prompt_definitions`, `prompt_versi
 
 Alembic migrations are auto-classified by `scripts/classify_migration.py` (AST-based) to determine CD deploy order: `migrate-first` (additive), `code-first` (destructive), or `breaking` (rename / mixed / scale-to-zero). Migrations using `op.execute()` or `op.get_bind()` must set `deploy_strategy` in the file. See `ada_backend/docs/migration-deploy-strategy.md`.
 
-Staging migration detection must be force-push-safe: validate `github.event.before` before diffing and use `scripts/detect_changed_migrations.py` rather than calling `git diff` on the push base directly.
+Staging migration detection must be force-push-safe: validate `github.event.before` before diffing and use `scripts/detect_changed_migrations.py` rather than calling `git diff` on the push base directly. If `github.event.before` is missing, NULL, unavailable locally, or not an ancestor of `HEAD`, push detection must fall back to `origin/main...HEAD`.
 
 Migration-private backup tables used for downgrade safety should be prefixed with `_alembic_`; Alembic autogenerate ignores those tables. Downgrades that restore from backup tables should raise explicitly when the expected backup is missing.
 

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -92,6 +92,8 @@ Org-scoped, independently versioned prompts (`prompt_definitions`, `prompt_versi
 
 Alembic migrations are auto-classified by `scripts/classify_migration.py` (AST-based) to determine CD deploy order: `migrate-first` (additive), `code-first` (destructive), or `breaking` (rename / mixed / scale-to-zero). Migrations using `op.execute()` or `op.get_bind()` must set `deploy_strategy` in the file. See `ada_backend/docs/migration-deploy-strategy.md`.
 
+Staging migration detection must be force-push-safe: validate `github.event.before` before diffing and use `scripts/detect_changed_migrations.py` rather than calling `git diff` on the push base directly.
+
 Migration-private backup tables used for downgrade safety should be prefixed with `_alembic_`; Alembic autogenerate ignores those tables. Downgrades that restore from backup tables should raise explicitly when the expected backup is missing.
 
 ### Documentation

--- a/.github/workflows/build-and-deploy-k8s.yml
+++ b/.github/workflows/build-and-deploy-k8s.yml
@@ -88,14 +88,10 @@ jobs:
       - name: Check for alembic migrations
         id: migration
         run: |
-          NULL_SHA="0000000000000000000000000000000000000000"
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.event.before }}" != "${NULL_SHA}" ]; then
-            DIFF_BASE="${{ github.event.before }}"
-          else
-            DIFF_BASE="HEAD~1"
-          fi
-          CHANGED=$(git diff "${DIFF_BASE}" HEAD --name-only -- \
-            'ada_backend/database/alembic/versions/*.py')
+          CHANGED=$(python scripts/detect_changed_migrations.py \
+            --event-name "${{ github.event_name }}" \
+            --before "${{ github.event.before }}" \
+            --fallback-base origin/main)
           if [ -n "$CHANGED" ]; then
             echo "has_migration=true" >> $GITHUB_OUTPUT
             echo "migration_files<<EOF" >> $GITHUB_OUTPUT

--- a/ada_backend/docs/migration-deploy-strategy.md
+++ b/ada_backend/docs/migration-deploy-strategy.md
@@ -80,8 +80,9 @@ The `setup` job in `build-and-deploy-k8s.yml` first detects changed migration
 files with `scripts/detect_changed_migrations.py`, then runs the same
 classifier and passes `migration_strategy` to the `deploy` job. Push detection
 uses `github.event.before` only when that commit exists and is an ancestor of
-`HEAD`; force-pushed staging branches fall back to `origin/main...HEAD` so the
-workflow does not fail with `fatal: bad object` before classification.
+`HEAD`; missing, NULL, or force-pushed staging bases fall back to
+`origin/main...HEAD` so rewritten branch history is classified without failing
+with `fatal: bad object`.
 
 The deploy step branches:
 

--- a/ada_backend/docs/migration-deploy-strategy.md
+++ b/ada_backend/docs/migration-deploy-strategy.md
@@ -76,8 +76,14 @@ migration files and:
 
 ## CD behaviour
 
-The `setup` job in `build-and-deploy-k8s.yml` runs the same classifier and
-passes `migration_strategy` to the `deploy` job. The deploy step branches:
+The `setup` job in `build-and-deploy-k8s.yml` first detects changed migration
+files with `scripts/detect_changed_migrations.py`, then runs the same
+classifier and passes `migration_strategy` to the `deploy` job. Push detection
+uses `github.event.before` only when that commit exists and is an ancestor of
+`HEAD`; force-pushed staging branches fall back to `origin/main...HEAD` so the
+workflow does not fail with `fatal: bad object` before classification.
+
+The deploy step branches:
 
 - **migrate-first**: run `db-migrate` and `db-seed` pods (using the new image)
   *before* updating deployment images, then roll out all deployments.

--- a/scripts/detect_changed_migrations.py
+++ b/scripts/detect_changed_migrations.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+NULL_SHA = "0000000000000000000000000000000000000000"
+MIGRATION_PATHSPEC = "ada_backend/database/alembic/versions/*.py"
+
+
+@dataclass(frozen=True)
+class MigrationDiff:
+    files: list[str]
+    diff_base: str | None
+    mode: str
+
+
+def _run_git(repo: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=repo, text=True, capture_output=True, check=False)
+
+
+def _commit_exists(repo: Path, rev: str) -> bool:
+    return _run_git(repo, ["cat-file", "-e", f"{rev}^{{commit}}"]).returncode == 0
+
+
+def _is_ancestor(repo: Path, maybe_ancestor: str, head: str) -> bool:
+    return _run_git(repo, ["merge-base", "--is-ancestor", maybe_ancestor, head]).returncode == 0
+
+
+def _changed_files(repo: Path, diff_args: list[str]) -> list[str]:
+    result = _run_git(repo, ["diff", "--name-only", *diff_args, "--", MIGRATION_PATHSPEC])
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"git diff failed with exit code {result.returncode}")
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def detect_changed_migrations(
+    *,
+    repo: Path,
+    event_name: str,
+    before: str | None,
+    head: str = "HEAD",
+    fallback_base: str = "origin/main",
+) -> MigrationDiff:
+    normalized_before = before.strip() if before else ""
+
+    if event_name == "push" and normalized_before and normalized_before != NULL_SHA:
+        if _commit_exists(repo, normalized_before) and _is_ancestor(repo, normalized_before, head):
+            return MigrationDiff(
+                files=_changed_files(repo, [normalized_before, head]),
+                diff_base=normalized_before,
+                mode="before",
+            )
+
+        if _commit_exists(repo, fallback_base):
+            return MigrationDiff(
+                files=_changed_files(repo, [f"{fallback_base}...{head}"]),
+                diff_base=fallback_base,
+                mode="fallback",
+            )
+
+        if _commit_exists(repo, f"{head}~1"):
+            return MigrationDiff(
+                files=_changed_files(repo, [f"{head}~1", head]),
+                diff_base=f"{head}~1",
+                mode="head-parent",
+            )
+
+        return MigrationDiff(files=[], diff_base=None, mode="empty")
+
+    if _commit_exists(repo, f"{head}~1"):
+        return MigrationDiff(
+            files=_changed_files(repo, [f"{head}~1", head]),
+            diff_base=f"{head}~1",
+            mode="head-parent",
+        )
+
+    return MigrationDiff(files=[], diff_base=None, mode="empty")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Detect changed Alembic migration files in CI.")
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--before", default="")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--fallback-base", default="origin/main")
+    parser.add_argument("--repo", default=".")
+    args = parser.parse_args(argv)
+
+    try:
+        diff = detect_changed_migrations(
+            repo=Path(args.repo),
+            event_name=args.event_name,
+            before=args.before,
+            head=args.head,
+            fallback_base=args.fallback_base,
+        )
+    except RuntimeError as exc:
+        print(f"Failed to detect changed migrations: {exc}", file=sys.stderr)
+        return 1
+
+    if diff.diff_base:
+        print(f"Using migration diff base {diff.diff_base} ({diff.mode})", file=sys.stderr)
+    else:
+        print("No migration diff base available", file=sys.stderr)
+
+    for file in diff.files:
+        print(file)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/detect_changed_migrations.py
+++ b/scripts/detect_changed_migrations.py
@@ -46,8 +46,13 @@ def detect_changed_migrations(
 ) -> MigrationDiff:
     normalized_before = before.strip() if before else ""
 
-    if event_name == "push" and normalized_before and normalized_before != NULL_SHA:
-        if _commit_exists(repo, normalized_before) and _is_ancestor(repo, normalized_before, head):
+    if event_name == "push":
+        if (
+            normalized_before
+            and normalized_before != NULL_SHA
+            and _commit_exists(repo, normalized_before)
+            and _is_ancestor(repo, normalized_before, head)
+        ):
             return MigrationDiff(
                 files=_changed_files(repo, [normalized_before, head]),
                 diff_base=normalized_before,

--- a/tests/test_detect_changed_migrations.py
+++ b/tests/test_detect_changed_migrations.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from scripts.detect_changed_migrations import detect_changed_migrations
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git executable is required")
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -92,3 +97,26 @@ def test_missing_before_object_falls_back_without_bad_object(tmp_path: Path):
 
     assert diff.mode == "fallback"
     assert diff.files == ["ada_backend/database/alembic/versions/new_branch.py"]
+
+
+def test_null_before_falls_back_to_branch_diff(tmp_path: Path):
+    repo = _init_repo(tmp_path)
+    fallback_base = _git(repo, "rev-parse", "HEAD")
+
+    _write(repo, "ada_backend/database/alembic/versions/first_branch.py")
+    _commit(repo, "first branch migration")
+    _write(repo, "ada_backend/database/alembic/versions/second_branch.py")
+    _commit(repo, "second branch migration")
+    diff = detect_changed_migrations(
+        repo=repo,
+        event_name="push",
+        before="0000000000000000000000000000000000000000",
+        fallback_base=fallback_base,
+    )
+
+    assert diff.mode == "fallback"
+    assert diff.diff_base == fallback_base
+    assert diff.files == [
+        "ada_backend/database/alembic/versions/first_branch.py",
+        "ada_backend/database/alembic/versions/second_branch.py",
+    ]

--- a/tests/test_detect_changed_migrations.py
+++ b/tests/test_detect_changed_migrations.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.detect_changed_migrations import detect_changed_migrations
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", ".")
+    _git(repo, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _write(repo: Path, relative_path: str, content: str = "revision = 'abc'\ndown_revision = None\n") -> None:
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "checkout", "-b", "main")
+    _write(repo, "README.md", "test\n")
+    _commit(repo, "initial")
+    return repo
+
+
+def test_normal_push_uses_before_as_diff_base(tmp_path: Path):
+    repo = _init_repo(tmp_path)
+    _write(repo, "ada_backend/database/alembic/versions/old.py")
+    before = _commit(repo, "old migration")
+
+    _write(repo, "ada_backend/database/alembic/versions/new.py")
+    _commit(repo, "new migration")
+    diff = detect_changed_migrations(repo=repo, event_name="push", before=before)
+
+    assert diff.mode == "before"
+    assert diff.diff_base == before
+    assert diff.files == ["ada_backend/database/alembic/versions/new.py"]
+
+
+def test_force_push_non_ancestor_before_falls_back(tmp_path: Path):
+    repo = _init_repo(tmp_path)
+    fallback_base = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "checkout", "-b", "old-staging")
+    _write(repo, "ada_backend/database/alembic/versions/old_branch.py")
+    old_before = _commit(repo, "old staging migration")
+
+    _git(repo, "checkout", "main")
+    _write(repo, "ada_backend/database/alembic/versions/new_branch.py")
+    _commit(repo, "new staging migration")
+    diff = detect_changed_migrations(
+        repo=repo,
+        event_name="push",
+        before=old_before,
+        fallback_base=fallback_base,
+    )
+
+    assert diff.mode == "fallback"
+    assert diff.diff_base == fallback_base
+    assert diff.files == ["ada_backend/database/alembic/versions/new_branch.py"]
+
+
+def test_missing_before_object_falls_back_without_bad_object(tmp_path: Path):
+    repo = _init_repo(tmp_path)
+    fallback_base = _git(repo, "rev-parse", "HEAD")
+    missing_before = "2ed6379291ccf8594877885269b827a6f4b7fa5a"
+
+    _write(repo, "ada_backend/database/alembic/versions/new_branch.py")
+    _commit(repo, "new staging migration")
+    diff = detect_changed_migrations(
+        repo=repo,
+        event_name="push",
+        before=missing_before,
+        fallback_base=fallback_base,
+    )
+
+    assert diff.mode == "fallback"
+    assert diff.files == ["ada_backend/database/alembic/versions/new_branch.py"]


### PR DESCRIPTION
# fix staging migration detection after force pushes

## Summary
- Added force-push-safe Alembic migration detection for the K8s staging deploy workflow.
- Replaced direct git diff `github.event.before` usage with `scripts/detect_changed_migrations.py`, which validates the push base and falls back to `origin/main...HEAD` when the old SHA is unavailable.
- Added regression tests for normal pushes, non-ancestor force-pushes, and missing before commits.
- Updated migration deploy docs and architecture rules to document the force-push-safe detection invariant.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes staging Alembic migration detection in the K8s deploy workflow to handle force pushes safely and prevent git “bad object” errors. Addresses Linear DRA-1286.

- **Bug Fixes**
  - Added `scripts/detect_changed_migrations.py` to use `github.event.before` only if it exists and is an ancestor; otherwise diff `origin/main...HEAD`, then `HEAD~1`.
  - Updated `.github/workflows/build-and-deploy-k8s.yml` to call the script with `--event-name`, `--before`, and `--fallback-base origin/main`.
  - Added tests for normal pushes, non-ancestor force pushes, and missing/NULL `before` SHAs; updated docs and architecture rules to document the fallback behavior.

<sup>Written for commit 41f1302e6a427cc4f6fcdfc92fe3d679f5e24ee8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

