### PR TITLE
feat(monitoring): monthly token usage dra-1331

### DIFF
--- a/.cursor/rules/mcp.mdc
+++ b/.cursor/rules/mcp.mdc
@@ -32,6 +32,9 @@ globs:
 - Body fields with `None` values are omitted from the JSON payload (not serialized as JSON `null`).
 - Redis fallback is recoverable: after a connection failure, the client retries automatically after 60 s.
 - Treat `_truncated` responses as partial data, never as complete truth.
+- `get_org_token_usage` reports monthly input/output tokens from stored trace spans only; `years`/`months` accept
+  lists or `"all"`, and per-model rows depend on persisted `model_id` values, not recomputation from prompts or
+  provider APIs.
 - Tool port configurations: component instances in graph payloads include `port_configurations` (setup modes: `ai_filled`, `user_set`, `deactivated`) and a computed `tool_description`. `tool_description_override` customizes the description shown to the AI. When changing tool port behavior, update `docs://graphs`, `docs://agent-config`, and `mcp_server/README.md`.
 - QA custom columns: entry `custom_columns` dicts are keyed by column UUID, not display name. Always use `list_custom_columns` to discover the mapping before writing. See `docs://qa` and `docs://known-quirks`.
 - CSV tools: `export_dataset_csv` / `import_dataset_csv` handle dataset round-trips. The export builds CSV from paginated `list_entries` internally (no `graph_runner_id` needed). The import uses multipart file upload to the backend's CSV import endpoint.

--- a/ada_backend/docs/api-reference.md
+++ b/ada_backend/docs/api-reference.md
@@ -173,6 +173,7 @@ Run input data is persisted in the `run_inputs` table (keyed by `retry_group_id`
 |---|---|---|---|
 | GET | `/monitor/org/{organization_id}/charts` | JWT(Member) | Org charts |
 | GET | `/monitor/org/{organization_id}/kpis` | JWT(Member) | Org KPIs |
+| GET | `/monitor/org/{organization_id}/token-usage` | JWT(Member) | Monthly org input/output token usage from stored trace spans. Query params: repeated `years`, repeated `months`, or `all`; `by_model` |
 | GET | `/projects/{project_id}/traces` | JWT(Member) | List traces. Filters: `duration` (days lookback), `start_time`/`end_time` (ISO 8601 date range), `search`, `environment`, `call_type`, `graph_runner_id`. Requires `duration` or at least one of `start_time`/`end_time`. **Precedence:** if `start_time` or `end_time` is provided, `duration` is ignored (explicit bounds override the lookback window). |
 | GET | `/traces/{trace_id}/tree` | JWT | Trace span tree |
 

--- a/ada_backend/docs/credits.md
+++ b/ada_backend/docs/credits.md
@@ -22,6 +22,9 @@ Cost varies by parameter value. FK to `component_parameter_definitions.id` + `pa
 
 - **`Usage`** (`credits.usages`): Monthly aggregate per `(project_id, year, month)` with `credits_used`. Unique on project+year+month.
 - **`SpanUsage`** (`credits.span_usages`): Per-span credit breakdown. FK to `traces.spans.span_id`. Fields: `credits_input_token`, `credits_output_token`, `credits_per_call`, `credits_per` (JSONB).
+- Monthly org token usage is queried by period from persisted `traces.spans.llm_token_count_prompt` and
+  `traces.spans.llm_token_count_completion`, joined through `projects.organization_id`. This is separate from
+  `credits.usages`, which stores only credit totals and does not preserve token or model breakdowns.
 
 ## Organization Limits
 
@@ -33,6 +36,7 @@ Cost varies by parameter value. FK to `component_parameter_definitions.id` + `pa
 | Endpoint | Auth | Purpose |
 |---|---|---|
 | `GET /organizations/{org_id}/credit-usage` | JWT(Member) | Credit usage chart |
+| `GET /monitor/org/{org_id}/token-usage` | JWT(Member) | Monthly input/output token usage from stored trace spans, filtered by `years`/`months` lists or `all` |
 | `GET /organizations-limits-and-usage` | JWT(SuperAdmin) | All org limits + usage |
 | `POST /organizations/{org_id}/organization-limits` | SuperAdmin\|AdminKey | Create org limit |
 | `PATCH /organizations/{org_id}/organization-limits` | JWT(SuperAdmin) | Update org limit |

--- a/ada_backend/routers/monitor_router.py
+++ b/ada_backend/routers/monitor_router.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 from typing import Annotated, List
 from uuid import UUID
 
@@ -8,13 +9,44 @@ from ada_backend.database.models import CallType
 from ada_backend.routers.auth_router import UserRights, user_has_access_to_organization_dependency
 from ada_backend.schemas.auth_schema import SupabaseUser
 from ada_backend.schemas.chart_schema import ChartsResponse
-from ada_backend.schemas.monitor_schema import KPISResponse
+from ada_backend.schemas.monitor_schema import KPISResponse, OrgTokenUsageResponse
 from ada_backend.services.charts_service import get_charts_by_projects
-from ada_backend.services.metrics.monitor_kpis_service import get_monitoring_kpis_by_projects
+from ada_backend.services.metrics.monitor_kpis_service import get_monitoring_kpis_by_projects, get_org_token_usage
 
 LOGGER = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/monitor")
+
+
+def _parse_token_usage_filter(
+    values: list[str] | None,
+    *,
+    field_name: str,
+    default_values: list[int],
+    minimum: int,
+    maximum: int | None = None,
+) -> list[int] | None:
+    if values is None:
+        return default_values
+
+    normalized_values = [value.strip().lower() for value in values]
+    if "all" in normalized_values:
+        if len(normalized_values) > 1:
+            raise HTTPException(status_code=400, detail=f"{field_name}=all cannot be combined with explicit values")
+        return None
+
+    parsed_values = []
+    for value in normalized_values:
+        try:
+            parsed_value = int(value)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"{field_name} must contain integers or 'all'") from exc
+        if parsed_value < minimum or (maximum is not None and parsed_value > maximum):
+            range_detail = f"between {minimum} and {maximum}" if maximum is not None else f">= {minimum}"
+            raise HTTPException(status_code=400, detail=f"{field_name} values must be {range_detail}")
+        parsed_values.append(parsed_value)
+
+    return sorted(set(parsed_values))
 
 
 @router.get("/org/{organization_id}/charts", response_model=ChartsResponse, tags=["Metrics"])
@@ -79,3 +111,48 @@ async def get_organization_kpis(
             exc_info=True,
         )
         raise HTTPException(status_code=400, detail="Bad request") from e
+
+
+@router.get("/org/{organization_id}/token-usage", response_model=OrgTokenUsageResponse, tags=["Metrics"])
+async def get_organization_token_usage(
+    organization_id: UUID,
+    user: Annotated[
+        SupabaseUser,
+        Depends(user_has_access_to_organization_dependency(allowed_roles=UserRights.MEMBER.value)),
+    ],
+    years: list[str] | None = Query(
+        None,
+        description="UTC years to include. Repeat for multiple values, or pass 'all'. Defaults to current year.",
+    ),
+    months: list[str] | None = Query(
+        None,
+        description=(
+            "UTC months (1-12) to include. Repeat for multiple values, or pass 'all'. "
+            "Defaults to current month."
+        ),
+    ),
+    by_model: bool = True,
+):
+    if not user.id:
+        raise HTTPException(status_code=400, detail="User ID not found")
+
+    now = datetime.now(tz=timezone.utc)
+    resolved_years = _parse_token_usage_filter(
+        years,
+        field_name="years",
+        default_values=[now.year],
+        minimum=1,
+    )
+    resolved_months = _parse_token_usage_filter(
+        months,
+        field_name="months",
+        default_values=[now.month],
+        minimum=1,
+        maximum=12,
+    )
+    return get_org_token_usage(
+        organization_id=organization_id,
+        years=resolved_years,
+        months=resolved_months,
+        by_model=by_model,
+    )

--- a/ada_backend/schemas/monitor_schema.py
+++ b/ada_backend/schemas/monitor_schema.py
@@ -1,4 +1,5 @@
 from typing import List, Optional, Union
+from uuid import UUID
 
 from pydantic import BaseModel
 
@@ -36,3 +37,34 @@ class OccurenceQuestion(BaseModel):
 
 class OccurenceQuestionsList(BaseModel):
     questions: list[OccurenceQuestion]
+
+
+class OrgTokenUsageByModel(BaseModel):
+    model_id: Optional[UUID] = None
+    provider: Optional[str] = None
+    model_name: Optional[str] = None
+    display_name: Optional[str] = None
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+
+class OrgTokenUsageTotals(BaseModel):
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+
+class OrgTokenUsagePeriod(BaseModel):
+    year: int
+    month: int
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    by_model: list[OrgTokenUsageByModel]
+
+
+class OrgTokenUsageResponse(BaseModel):
+    organization_id: UUID
+    periods: list[OrgTokenUsagePeriod]
+    totals: OrgTokenUsageTotals

--- a/ada_backend/services/metrics/monitor_kpis_service.py
+++ b/ada_backend/services/metrics/monitor_kpis_service.py
@@ -4,16 +4,126 @@ from typing import List, Optional
 from uuid import UUID
 
 import pandas as pd
+from sqlalchemy import text
 
 from ada_backend.database.models import CallType
 from ada_backend.mixpanel_analytics import track_monitoring_loaded
-from ada_backend.schemas.monitor_schema import KPI, CostKPI, KPISResponse, TraceKPIS
+from ada_backend.schemas.monitor_schema import (
+    KPI,
+    CostKPI,
+    KPISResponse,
+    OrgTokenUsageByModel,
+    OrgTokenUsagePeriod,
+    OrgTokenUsageResponse,
+    OrgTokenUsageTotals,
+    TraceKPIS,
+)
 from ada_backend.services.metrics.utils import QUERY_COSTS_BASIS, SQL_COST_KPIS_ROUNDED_TAIL
 from engine.trace.sql_exporter import get_session_trace
 
 LOGGER = logging.getLogger(__name__)
 
 SIGNIFICANT_FIGURES_CREDIT_FORMAT = 2
+
+
+def get_org_token_usage(
+    organization_id: UUID,
+    years: list[int] | None,
+    months: list[int] | None,
+    by_model: bool = True,
+) -> OrgTokenUsageResponse:
+    filters = ["p.organization_id = :organization_id"]
+    params: dict[str, object] = {"organization_id": organization_id}
+    if years is not None:
+        filters.append("EXTRACT(YEAR FROM s.start_time AT TIME ZONE 'UTC')::int = ANY(:years)")
+        params["years"] = years
+    if months is not None:
+        filters.append("EXTRACT(MONTH FROM s.start_time AT TIME ZONE 'UTC')::int = ANY(:months)")
+        params["months"] = months
+
+    query = text(
+        f"""
+        SELECT
+            EXTRACT(YEAR FROM s.start_time AT TIME ZONE 'UTC')::int AS year,
+            EXTRACT(MONTH FROM s.start_time AT TIME ZONE 'UTC')::int AS month,
+            s.model_id,
+            lm.provider,
+            lm.model_name,
+            lm.display_name,
+            COALESCE(SUM(COALESCE(s.llm_token_count_prompt, 0)), 0)::bigint AS input_tokens,
+            COALESCE(SUM(COALESCE(s.llm_token_count_completion, 0)), 0)::bigint AS output_tokens
+        FROM traces.spans s
+        JOIN projects p ON s.project_id = p.id::text
+        LEFT JOIN llm_models lm ON s.model_id = lm.id
+        WHERE {" AND ".join(filters)}
+          AND (s.llm_token_count_prompt IS NOT NULL OR s.llm_token_count_completion IS NOT NULL)
+        GROUP BY year, month, s.model_id, lm.provider, lm.model_name, lm.display_name
+        ORDER BY
+            year DESC,
+            month DESC,
+            COALESCE(SUM(COALESCE(s.llm_token_count_prompt, 0)), 0) +
+            COALESCE(SUM(COALESCE(s.llm_token_count_completion, 0)), 0) DESC
+        """
+    )
+    session = get_session_trace()
+    try:
+        rows = session.execute(query, params).fetchall()
+    finally:
+        session.close()
+
+    periods_by_key: dict[tuple[int, int], OrgTokenUsagePeriod] = {}
+    total_input_tokens = 0
+    total_output_tokens = 0
+    for row in rows:
+        row_year = int(row.year)
+        row_month = int(row.month)
+        row_input_tokens = int(row.input_tokens or 0)
+        row_output_tokens = int(row.output_tokens or 0)
+        total_input_tokens += row_input_tokens
+        total_output_tokens += row_output_tokens
+        period_key = (row_year, row_month)
+        period = periods_by_key.get(period_key)
+        if period is None:
+            period = OrgTokenUsagePeriod(
+                year=row_year,
+                month=row_month,
+                input_tokens=0,
+                output_tokens=0,
+                total_tokens=0,
+                by_model=[],
+            )
+            periods_by_key[period_key] = period
+
+        period.input_tokens += row_input_tokens
+        period.output_tokens += row_output_tokens
+        period.total_tokens += row_input_tokens + row_output_tokens
+        if by_model:
+            period.by_model.append(
+                OrgTokenUsageByModel(
+                    model_id=row.model_id,
+                    provider=row.provider,
+                    model_name=row.model_name,
+                    display_name=row.display_name,
+                    input_tokens=row_input_tokens,
+                    output_tokens=row_output_tokens,
+                    total_tokens=row_input_tokens + row_output_tokens,
+                )
+            )
+
+    periods = sorted(
+        periods_by_key.values(),
+        key=lambda period: (period.year, period.month),
+        reverse=True,
+    )
+    return OrgTokenUsageResponse(
+        organization_id=organization_id,
+        periods=periods,
+        totals=OrgTokenUsageTotals(
+            input_tokens=total_input_tokens,
+            output_tokens=total_output_tokens,
+            total_tokens=total_input_tokens + total_output_tokens,
+        ),
+    )
 
 
 def _run_trace_kpis_query(

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -90,7 +90,7 @@ All domain content lives in `docs.py` (single source of truth).
 | Variables | 9 | Admin only — definitions, sets, secrets |
 | Knowledge | 9 | `create_source` (website/database), sources, documents, chunks |
 | QA | 20 | Datasets, entries, custom columns, CSV export/import, judges, evaluations |
-| Monitoring | 5 | Traces, charts, KPIs, credits |
+| Monitoring | 6 | Traces, charts, KPIs, credits, monthly token usage |
 | Crons | 9 | Create, pause/resume, manual trigger, execution history |
 | OAuth | 3 | List, check status, revoke |
 | Alert Emails | 3 | `list_alert_emails`, `create_alert_email`, `delete_alert_email` — per-project run failure recipients (developer+) |
@@ -135,7 +135,7 @@ Custom tools (validation, multi-step, client-side logic) are still defined as `@
 | Release stage | Component catalog auto-filtered by org tier. Cannot be overridden by the AI. |
 | Agent name | `create_agent` rejects empty/whitespace names. |
 | Pagination | `list_runs` caps page_size at 100. Org-scoped with optional filters: `project_id` (single, mapped to `project_ids`), `status` (single, mapped to `statuses`), `trigger`, `date_from`, `date_to`. |
-| Monitoring | Duration clamped 1–90 days. `list_traces` also accepts `start_time`/`end_time` (ISO 8601) for date range filtering. |
+| Monitoring | Duration clamped 1–90 days. `list_traces` also accepts `start_time`/`end_time` (ISO 8601) for date range filtering. `get_org_token_usage` reads stored trace spans by monthly period; pass `years`/`months` as lists or `"all"`, with optional per-model rows. |
 | Response size | Responses > 50KB are trimmed by default. `ToolSpec.trim=False` disables trimming per tool (e.g. `get_graph`, `list_components` for round-trip safety). |
 | Session diagnostics | `get_current_context` includes `session.session_id` and `session.storage_backend` ("redis" or "memory"). |
 | Agent tools | `add_tool_to_agent` rejects non-`function_callable`, duplicate, or integration-backed tools that it cannot wire safely. Use the display name from `search_components()`, not hard-coded names. The AI Agent's `skip_tools_with_missing_oauth` parameter (default `True`) silently drops any tool whose OAuth connection is missing at agent startup. Neverdrop-branded Google tools use the `google-mail-neverdrop` and `google-calendar-neverdrop` provider filters. |

--- a/mcp_server/docs.py
+++ b/mcp_server/docs.py
@@ -117,6 +117,9 @@ and supports optional filters: `project_id`, `status` (mapped to `statuses`), `t
 - `get_org_charts`, `get_org_kpis`, and `list_traces` clamp `duration` to 1–90 days. \
 `list_traces` also accepts `start_time`/`end_time` (ISO 8601) for precise date range \
 filtering; when provided, `duration` is ignored
+- `get_org_token_usage` reads monthly input/output tokens from stored trace spans; it does \
+not call providers or infer tokens from prompts. Use `years`/`months` lists or `"all"`; \
+model breakdowns depend on stored `model_id`
 - Batch deletions: `delete_datasets`, `delete_entries`, `delete_judges` accept lists of IDs
 - Graph updates send the full graph structure — always `get_graph` first, modify, then `update_graph`
 - Secrets values are write-only; `list_secrets` returns masked values
@@ -1740,6 +1743,9 @@ when provided, `duration` is ignored
 - `get_org_charts(duration_days)` → usage charts (1–90 days)
 - `get_org_kpis(duration_days)` → key metrics
 - `get_credit_usage` → credit consumption
+- `get_org_token_usage(years?, months?, by_model=true)` → input/output token usage by \
+monthly period from stored trace spans. `years` and `months` accept lists or `"all"`; \
+per-model rows are included when stored `model_id` is available
 """
 
 DOMAINS: dict[str, str] = {

--- a/mcp_server/tools/monitoring.py
+++ b/mcp_server/tools/monitoring.py
@@ -37,6 +37,31 @@ PROXY_SPECS: list[ToolSpec] = [
         path="/organizations/{org_id}/credit-usage",
         scope="org",
     ),
+    ToolSpec(
+        name="get_org_token_usage",
+        description=(
+            "Get input/output token usage for the active organization by month from stored trace spans, "
+            "filtered by year/month lists or 'all', optionally broken down by model."
+        ),
+        method="get",
+        path="/monitor/org/{org_id}/token-usage",
+        scope="org",
+        query_params=(
+            Param(
+                "years",
+                Optional[list[int] | str],
+                default=None,
+                description="UTC years to include as a list, or 'all'. Defaults to current year.",
+            ),
+            Param(
+                "months",
+                Optional[list[int] | str],
+                default=None,
+                description="UTC months (1-12) to include as a list, or 'all'. Defaults to current month.",
+            ),
+            Param("by_model", bool, default=True, description="Include per-model token usage rows."),
+        ),
+    ),
 ]
 
 

--- a/tests/ada_backend/services/metrics/test_org_token_usage.py
+++ b/tests/ada_backend/services/metrics/test_org_token_usage.py
@@ -1,0 +1,189 @@
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+from openinference.semconv.trace import OpenInferenceSpanKindValues
+from opentelemetry.trace.status import StatusCode
+
+from ada_backend.database.models import EnvType, Project, WorkflowProject
+from ada_backend.database.setup_db import get_db_session
+from ada_backend.database.trace_models import Span
+from ada_backend.repositories.llm_models_repository import create_llm_model, delete_llm_model
+from ada_backend.services.metrics.monitor_kpis_service import get_org_token_usage
+
+
+def _span(
+    *,
+    span_id: UUID,
+    trace_rowid: UUID,
+    project_id: UUID,
+    start_time: datetime,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    model_id: UUID | None,
+) -> Span:
+    return Span(
+        trace_rowid=str(trace_rowid),
+        span_id=str(span_id),
+        parent_id=None,
+        graph_runner_id=None,
+        name="LLM",
+        span_kind=OpenInferenceSpanKindValues.LLM,
+        start_time=start_time,
+        end_time=start_time + timedelta(seconds=1),
+        attributes={},
+        events="[]",
+        status_code=StatusCode.OK,
+        status_message="",
+        cumulative_error_count=0,
+        cumulative_llm_token_count_prompt=input_tokens or 0,
+        cumulative_llm_token_count_completion=output_tokens or 0,
+        llm_token_count_prompt=input_tokens,
+        llm_token_count_completion=output_tokens,
+        environment=EnvType.DRAFT,
+        call_type=None,
+        project_id=str(project_id),
+        tag_name=None,
+        component_instance_id=None,
+        model_id=model_id,
+    )
+
+
+def test_get_org_token_usage_aggregates_monthly_tokens_by_model():
+    organization_id = uuid4()
+    other_organization_id = uuid4()
+    project_id = uuid4()
+    project_id_2 = uuid4()
+    other_org_project_id = uuid4()
+    month_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    previous_month = datetime(2026, 6, 30, 23, 59, tzinfo=timezone.utc)
+
+    with get_db_session() as session:
+        llm_model = create_llm_model(
+            session,
+            display_name="Test Model",
+            model_description="Fake LLM model for org token usage tests",
+            model_capacity=None,
+            model_provider="test-provider",
+            model_name="test-model",
+        )
+        model_id = llm_model.id
+        projects = [
+            WorkflowProject(id=project_id, name=f"token-usage-{project_id}", organization_id=organization_id),
+            WorkflowProject(id=project_id_2, name=f"token-usage-{project_id_2}", organization_id=organization_id),
+            WorkflowProject(
+                id=other_org_project_id,
+                name=f"token-usage-{other_org_project_id}",
+                organization_id=other_organization_id,
+            ),
+        ]
+        session.add_all(projects)
+        spans = [
+            _span(
+                span_id=uuid4(),
+                trace_rowid=uuid4(),
+                project_id=project_id,
+                start_time=month_start + timedelta(days=1),
+                input_tokens=10,
+                output_tokens=3,
+                model_id=model_id,
+            ),
+            _span(
+                span_id=uuid4(),
+                trace_rowid=uuid4(),
+                project_id=project_id_2,
+                start_time=month_start + timedelta(days=2),
+                input_tokens=5,
+                output_tokens=7,
+                model_id=model_id,
+            ),
+            _span(
+                span_id=uuid4(),
+                trace_rowid=uuid4(),
+                project_id=project_id,
+                start_time=month_start + timedelta(days=3),
+                input_tokens=2,
+                output_tokens=4,
+                model_id=None,
+            ),
+            _span(
+                span_id=uuid4(),
+                trace_rowid=uuid4(),
+                project_id=project_id,
+                start_time=previous_month,
+                input_tokens=100,
+                output_tokens=100,
+                model_id=model_id,
+            ),
+            _span(
+                span_id=uuid4(),
+                trace_rowid=uuid4(),
+                project_id=other_org_project_id,
+                start_time=month_start + timedelta(days=1),
+                input_tokens=100,
+                output_tokens=100,
+                model_id=model_id,
+            ),
+        ]
+        session.add_all(spans)
+        session.commit()
+
+        try:
+            result = get_org_token_usage(organization_id=organization_id, years=[2026], months=[7])
+
+            assert result.totals.input_tokens == 17
+            assert result.totals.output_tokens == 14
+            assert result.totals.total_tokens == 31
+            assert len(result.periods) == 1
+
+            july_period = result.periods[0]
+            assert july_period.year == 2026
+            assert july_period.month == 7
+            assert july_period.input_tokens == 17
+            assert july_period.output_tokens == 14
+            assert july_period.total_tokens == 31
+            assert len(july_period.by_model) == 2
+
+            model_row = next(row for row in july_period.by_model if row.model_id == model_id)
+            assert model_row.provider == "test-provider"
+            assert model_row.model_name == "test-model"
+            assert model_row.display_name == "Test Model"
+            assert model_row.input_tokens == 15
+            assert model_row.output_tokens == 10
+            assert model_row.total_tokens == 25
+
+            null_model_row = next(row for row in july_period.by_model if row.model_id is None)
+            assert null_model_row.input_tokens == 2
+            assert null_model_row.output_tokens == 4
+            assert null_model_row.total_tokens == 6
+
+            without_model_breakdown = get_org_token_usage(
+                organization_id=organization_id,
+                years=[2026],
+                months=[7],
+                by_model=False,
+            )
+            assert without_model_breakdown.totals.input_tokens == 17
+            assert without_model_breakdown.totals.output_tokens == 14
+            assert without_model_breakdown.periods[0].by_model == []
+
+            all_2026_months = get_org_token_usage(organization_id=organization_id, years=[2026], months=None)
+            assert [(period.year, period.month) for period in all_2026_months.periods] == [(2026, 7), (2026, 6)]
+            assert all_2026_months.totals.input_tokens == 117
+            assert all_2026_months.totals.output_tokens == 114
+            assert all_2026_months.totals.total_tokens == 231
+
+            empty_month = get_org_token_usage(organization_id=organization_id, years=[2026], months=[8])
+            assert empty_month.periods == []
+            assert empty_month.totals.input_tokens == 0
+            assert empty_month.totals.output_tokens == 0
+            assert empty_month.totals.total_tokens == 0
+        finally:
+            span_ids = [span.span_id for span in spans]
+            project_ids = [project.id for project in projects]
+            session.query(Span).filter(Span.span_id.in_(span_ids)).delete(synchronize_session=False)
+            session.query(WorkflowProject).filter(WorkflowProject.id.in_([project.id for project in projects])).delete(
+                synchronize_session=False
+            )
+            session.query(Project).filter(Project.id.in_(project_ids)).delete(synchronize_session=False)
+            delete_llm_model(session, model_id)
+            session.commit()

--- a/tests/mcp_server/test_monitoring.py
+++ b/tests/mcp_server/test_monitoring.py
@@ -6,7 +6,7 @@ import pytest
 
 from mcp_server.tools import _factory, monitoring
 from mcp_server.tools.monitoring import _normalize_duration
-from tests.mcp_server.conftest import FAKE_OTEL_TRACE_ID, FAKE_PROJECT_ID
+from tests.mcp_server.conftest import FAKE_ORG_ID, FAKE_OTEL_TRACE_ID, FAKE_PROJECT_ID
 
 
 class TestNormalizeDuration:
@@ -42,6 +42,18 @@ class TestMonitoringSpecs:
     def test_get_credit_usage_is_org_scoped(self):
         spec = next(s for s in monitoring.PROXY_SPECS if s.name == "get_credit_usage")
         assert spec.scope == "org"
+
+    def test_get_org_token_usage_is_org_scoped(self):
+        spec = next(s for s in monitoring.PROXY_SPECS if s.name == "get_org_token_usage")
+        assert spec.scope == "org"
+        assert spec.method == "get"
+
+    def test_get_org_token_usage_accepts_period_params(self):
+        spec = next(s for s in monitoring.PROXY_SPECS if s.name == "get_org_token_usage")
+        query_params = {p.name: p for p in spec.query_params}
+        assert query_params["years"].default is None
+        assert query_params["months"].default is None
+        assert query_params["by_model"].default is True
 
 
 @pytest.mark.asyncio
@@ -100,3 +112,24 @@ async def test_list_traces_rejects_zero_page(fake_mcp, monkeypatch):
 
     with pytest.raises(ValueError, match="page must be >= 1"):
         await fake_mcp.tools["list_traces"](project_id=FAKE_PROJECT_ID, page=0)
+
+
+@pytest.mark.asyncio
+async def test_get_org_token_usage_forwards_query_params(fake_mcp, monkeypatch):
+    get_mock = AsyncMock(return_value={"input_tokens": 1})
+    org_mock = AsyncMock(return_value={"org_id": FAKE_ORG_ID})
+    monkeypatch.setattr(_factory, "_get_auth", lambda: ("jwt", "user-1"))
+    monkeypatch.setattr(_factory, "require_org_context", org_mock)
+    monkeypatch.setattr(_factory.api, "get", get_mock)
+
+    monitoring.register(fake_mcp)
+    await fake_mcp.tools["get_org_token_usage"](years=[2025, 2026], months="all", by_model=False)
+
+    get_mock.assert_awaited_once_with(
+        f"/monitor/org/{FAKE_ORG_ID}/token-usage",
+        "jwt",
+        trim=True,
+        years=[2025, 2026],
+        months="all",
+        by_model=False,
+    )


### PR DESCRIPTION
## Summary
- Add `get_org_token_usage` MCP tool and backend endpoint for org token usage from stored trace spans only.
- Support month-by-month reporting with years / months filters as lists or "all", defaulting to the current UTC month.
- Return aggregate totals plus periods, with optional per-model breakdown via stored `model_id`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds monthly org token usage reporting from stored trace spans, with a new API endpoint and MCP tool. Implements DRA-1331 with year/month filters and optional per-model breakdown, returning totals and period rows.

- **New Features**
  - GET `/monitor/org/{organization_id}/token-usage` → monthly input/output tokens from `traces.spans` (no provider calls). Query: repeated `years`, repeated `months` (1–12), or `"all"`; `by_model` to include per-model rows. Defaults to current UTC year/month.
  - Validation prevents mixing `"all"` with explicit values; months must be 1–12.
  - Response schema (`OrgTokenUsageResponse`) returns `totals` and `periods` with optional per-model entries using stored `model_id`.
  - MCP tool `get_org_token_usage` proxies the endpoint with the same params; docs in `mcp_server/README.md` and `docs.py` updated. API reference and credits docs updated to clarify token-vs-credit data paths.

<sup>Written for commit 5b665473833e49e3f4eb5d75b133b30843f976f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

