### PR TITLE
feat(components): add extra field to hubspot owner tool dra-1333

### DIFF
--- a/engine/components/tools/hubspot_owner_tool.py
+++ b/engine/components/tools/hubspot_owner_tool.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Optional, Type
 
-import requests
+import httpx
 from openinference.semconv.trace import OpenInferenceSpanKindValues
 from pydantic import BaseModel, Field
 
@@ -12,6 +12,7 @@ from engine.components.utils import load_str_to_json
 from engine.trace.trace_manager import TraceManager
 
 HUBSPOT_OWNER_ENDPOINT = "https://api.hubapi.com/crm/v3/owners/{owner_id}"
+HUBSPOT_CONTACTS_SEARCH_ENDPOINT = "https://api.hubapi.com/crm/v3/objects/contacts/search"
 
 HUBSPOT_OWNER_TOOL_DESCRIPTION = ToolDescription(
     name="hubspot_owner",
@@ -118,7 +119,7 @@ class HubSpotOwnerTool(APICallTool):
             timeout=timeout,
         )
 
-    def _get_additional_properties(
+    async def _get_additional_properties(
         self, api_data: dict[str, Any], additional_properties: dict[str, Any], headers: dict[str, str]
     ) -> dict[str, Any]:
         property_names = list(additional_properties)
@@ -130,30 +131,31 @@ class HubSpotOwnerTool(APICallTool):
             return api_data
 
         try:
-            response = requests.request(
-                method="POST",
-                url="https://api.hubapi.com/crm/v3/objects/contacts/search",
-                headers=headers,
-                timeout=15,
-                json={
-                    "filterGroups": [
-                        {
-                            "filters": [
-                                {
-                                    "propertyName": "email",
-                                    "operator": "EQ",
-                                    "value": owner_email,
-                                }
-                            ]
-                        }
-                    ],
-                    "properties": property_names,
-                    "limit": 1,
-                },
-            )
-            response.raise_for_status()
-            payload = response.json()
-        except requests.RequestException as exc:
+            async with httpx.AsyncClient() as client:
+                response = await client.request(
+                    method="POST",
+                    url=HUBSPOT_CONTACTS_SEARCH_ENDPOINT,
+                    headers=headers,
+                    timeout=self.timeout,
+                    json={
+                        "filterGroups": [
+                            {
+                                "filters": [
+                                    {
+                                        "propertyName": "email",
+                                        "operator": "EQ",
+                                        "value": owner_email,
+                                    }
+                                ]
+                            }
+                        ],
+                        "properties": property_names,
+                        "limit": 1,
+                    },
+                )
+                response.raise_for_status()
+                payload = response.json()
+        except (httpx.HTTPError, json.JSONDecodeError) as exc:
             raise ValueError(f"HubSpot request failed: {exc}") from exc
         contacts = payload.get("results", [])
         if not contacts:
@@ -181,7 +183,7 @@ class HubSpotOwnerTool(APICallTool):
         if api_response.get("success", False):
             data: dict[str, Any] = api_response.get("data", {})
             if inputs.additional_properties:
-                data = self._get_additional_properties(data, inputs.additional_properties, headers)
+                data = await self._get_additional_properties(data, inputs.additional_properties, headers)
             output = json.dumps(data, indent=2)
         else:
             data = {}

--- a/engine/components/tools/hubspot_owner_tool.py
+++ b/engine/components/tools/hubspot_owner_tool.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Optional, Type
 
+import requests
 from openinference.semconv.trace import OpenInferenceSpanKindValues
 from pydantic import BaseModel, Field
 
@@ -50,9 +51,23 @@ class HubSpotOwnerInputs(BaseModel):
             ).model_dump(exclude_unset=True, exclude_none=True),
         },
     )
+    additional_properties: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Additional properties to include in the HubSpot owner API response.",
+        json_schema_extra={
+            "ui_component": UIComponent.JSON_TEXTAREA,
+            "drives_output_schema": True,
+            "ui_component_properties": UIComponentProperties(
+                label="Additional Properties",
+                placeholder='{"key": "value"}',
+            ).model_dump(exclude_unset=True, exclude_none=True),
+        },
+    )
 
 
 class HubSpotOwnerOutputs(BaseModel):
+    model_config = {"extra": "allow"}
+
     output: str = Field(description="The raw owner response formatted as JSON.")
     status_code: int = Field(description="The status code of the HubSpot owner API response.")
     success: bool = Field(description="Whether the HubSpot owner lookup succeeded.")
@@ -103,6 +118,54 @@ class HubSpotOwnerTool(APICallTool):
             timeout=timeout,
         )
 
+    def _get_additional_properties(
+        self, api_data: dict[str, Any], additional_properties: dict[str, Any], headers: dict[str, str]
+    ) -> dict[str, Any]:
+        property_names = list(additional_properties)
+        default_values = dict.fromkeys(property_names)
+        owner_email = api_data.get("email")
+
+        if not owner_email:
+            api_data.update(default_values)
+            return api_data
+
+        try:
+            response = requests.request(
+                method="POST",
+                url="https://api.hubapi.com/crm/v3/objects/contacts/search",
+                headers=headers,
+                timeout=15,
+                json={
+                    "filterGroups": [
+                        {
+                            "filters": [
+                                {
+                                    "propertyName": "email",
+                                    "operator": "EQ",
+                                    "value": owner_email,
+                                }
+                            ]
+                        }
+                    ],
+                    "properties": property_names,
+                    "limit": 1,
+                },
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException as exc:
+            raise ValueError(f"HubSpot request failed: {exc}") from exc
+        contacts = payload.get("results", [])
+        if not contacts:
+            api_data.update(default_values)
+            return api_data
+
+        contact_properties = contacts[0].get("properties", {})
+
+        api_data.update({property_name: contact_properties.get(property_name) for property_name in property_names})
+
+        return api_data
+
     async def _run_without_io_trace(
         self,
         inputs: HubSpotOwnerInputs,
@@ -117,6 +180,8 @@ class HubSpotOwnerTool(APICallTool):
         )
         if api_response.get("success", False):
             data: dict[str, Any] = api_response.get("data", {})
+            if inputs.additional_properties:
+                data = self._get_additional_properties(data, inputs.additional_properties, headers)
             output = json.dumps(data, indent=2)
         else:
             data = {}

--- a/tests/components/test_hubspot_owner_tool.py
+++ b/tests/components/test_hubspot_owner_tool.py
@@ -2,7 +2,11 @@ import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+import pytest
+
 from engine.components.tools.hubspot_owner_tool import (
+    HUBSPOT_CONTACTS_SEARCH_ENDPOINT,
     HUBSPOT_OWNER_TOOL_DESCRIPTION,
     HubSpotOwnerInputs,
     HubSpotOwnerOutputs,
@@ -99,3 +103,140 @@ def test_hubspot_owner_tool_flattens_owner_data_to_root_outputs():
     assert result.firstName == "Benjamin"
     assert result.lastName == "ATTAL"
     assert result.archived is False
+
+
+@patch("httpx.AsyncClient")
+def test_hubspot_owner_tool_fetches_additional_properties_via_async_httpx(mock_client_class):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "results": [
+            {
+                "properties": {
+                    "phone": "+33123456789",
+                    "company": "Novair",
+                }
+            }
+        ]
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.request.return_value = mock_response
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    tool = _hubspot_owner_tool()
+    inputs = HubSpotOwnerInputs(
+        headers={"Authorization": "Bearer hubspot_token"},
+        owner_id="1361098942",
+        additional_properties={"phone": None, "company": None},
+    )
+
+    with patch.object(tool, "make_api_call", new_callable=AsyncMock) as mock_make_api_call:
+        mock_make_api_call.return_value = {
+            "status_code": 200,
+            "data": OWNER_RESPONSE.copy(),
+            "headers": {"Content-Type": "application/json"},
+            "success": True,
+        }
+        result = asyncio.run(tool._run_without_io_trace(inputs))
+
+    mock_client.request.assert_called_once_with(
+        method="POST",
+        url=HUBSPOT_CONTACTS_SEARCH_ENDPOINT,
+        headers={"Authorization": "Bearer hubspot_token"},
+        timeout=30,
+        json={
+            "filterGroups": [
+                {
+                    "filters": [
+                        {
+                            "propertyName": "email",
+                            "operator": "EQ",
+                            "value": "benjamin.attal@novair.fr",
+                        }
+                    ]
+                }
+            ],
+            "properties": ["phone", "company"],
+            "limit": 1,
+        },
+    )
+    assert result.phone == "+33123456789"
+    assert result.company == "Novair"
+
+
+def test_hubspot_owner_tool_additional_properties_defaults_when_owner_has_no_email():
+    tool = _hubspot_owner_tool()
+    owner_without_email = {**OWNER_RESPONSE, "email": None}
+    inputs = HubSpotOwnerInputs(
+        headers={"Authorization": "Bearer hubspot_token"},
+        owner_id="1361098942",
+        additional_properties={"phone": None},
+    )
+
+    with patch.object(tool, "make_api_call", new_callable=AsyncMock) as mock_make_api_call:
+        mock_make_api_call.return_value = {
+            "status_code": 200,
+            "data": owner_without_email,
+            "headers": {"Content-Type": "application/json"},
+            "success": True,
+        }
+        with patch("httpx.AsyncClient") as mock_client_class:
+            result = asyncio.run(tool._run_without_io_trace(inputs))
+
+    mock_client_class.assert_not_called()
+    assert result.phone is None
+
+
+@patch("httpx.AsyncClient")
+def test_hubspot_owner_tool_additional_properties_raises_on_invalid_json_response(mock_client_class):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.request.return_value = mock_response
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    tool = _hubspot_owner_tool()
+    inputs = HubSpotOwnerInputs(
+        headers={"Authorization": "Bearer hubspot_token"},
+        owner_id="1361098942",
+        additional_properties={"phone": None},
+    )
+
+    with patch.object(tool, "make_api_call", new_callable=AsyncMock) as mock_make_api_call:
+        mock_make_api_call.return_value = {
+            "status_code": 200,
+            "data": OWNER_RESPONSE.copy(),
+            "headers": {"Content-Type": "application/json"},
+            "success": True,
+        }
+        with pytest.raises(ValueError, match="HubSpot request failed"):
+            asyncio.run(tool._run_without_io_trace(inputs))
+
+
+@patch("httpx.AsyncClient")
+def test_hubspot_owner_tool_additional_properties_raises_on_http_error(mock_client_class):
+    mock_client = AsyncMock()
+    mock_client.request.side_effect = httpx.ConnectError("connection failed")
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    tool = _hubspot_owner_tool()
+    inputs = HubSpotOwnerInputs(
+        headers={"Authorization": "Bearer hubspot_token"},
+        owner_id="1361098942",
+        additional_properties={"phone": None},
+    )
+
+    with patch.object(tool, "make_api_call", new_callable=AsyncMock) as mock_make_api_call:
+        mock_make_api_call.return_value = {
+            "status_code": 200,
+            "data": OWNER_RESPONSE.copy(),
+            "headers": {"Content-Type": "application/json"},
+            "success": True,
+        }
+        with pytest.raises(ValueError, match="HubSpot request failed"):
+            asyncio.run(tool._run_without_io_trace(inputs))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an optional `additional_properties` input to `hubspot_owner_tool` to fetch and merge custom HubSpot contact properties into the owner response. Supports Linear DRA-1333 by exposing custom owner properties and allowing extra fields in outputs.

- **New Features**
  - Accepts an `additional_properties` dict; searches HubSpot contacts by owner email and merges the requested fields into the owner data.
  - If email/contact is missing, returns requested keys as null; raises a clear error on HTTP/JSON failures; uses a 30s timeout.
  - Output model now allows extra fields so merged properties are included in the result.

<sup>Written for commit ecd08ad9195098f89f14e5bfadabf790bc582d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Scopeo/draftnrun/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

